### PR TITLE
Fix use-after-free (DOS) and small memory leak

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -224,6 +224,7 @@ void mqtt3_config_cleanup(struct mqtt3_config *config)
 	if(config->persistence_file) _mosquitto_free(config->persistence_file);
 	if(config->persistence_filepath) _mosquitto_free(config->persistence_filepath);
 	if(config->psk_file) _mosquitto_free(config->psk_file);
+	if(config->pid_file) _mosquitto_free(config->pid_file);
 	if(config->listeners){
 		for(i=0; i<config->listener_count; i++){
 			if(config->listeners[i].host) _mosquitto_free(config->listeners[i].host);

--- a/src/read_handle_server.c
+++ b/src/read_handle_server.c
@@ -549,6 +549,9 @@ int mqtt3_handle_connect(struct mosquitto_db *db, struct mosquitto *context)
 					msg_tail = msg_prev->next;
 				}else{
 					context->msgs = context->msgs->next;
+					if(context->last_msg == msg_tail){
+						context->last_msg = NULL;
+					}
 					_mosquitto_free(msg_tail);
 					msg_tail = context->msgs;
 				}


### PR DESCRIPTION
The use-after-free allows an unauthorized attacker to crash the broker.