### PR TITLE
Add default config path to systemd services.

### DIFF
--- a/service/systemd/README
+++ b/service/systemd/README
@@ -1,7 +1,8 @@
 Select appropriate systemd service based on your compile settings. If you
 enabled WITH_SYSTEMD, use mosquitto.service.notify, otherwise use
 mosquitto.service.simple. The service must be renamed to mosquitto.service
-before usage.
+before usage. Don't forget to change default paths in service file if you
+changed the default build settings.
 
 With WITH_SYSTEMD mosquitto will notify a complete startup after
 initialization. This means that follow-up units can be started after full

--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -4,7 +4,7 @@ Description=Mosquitto MQTT v3.1/v3.1.1 Broker
 [Service]
 Type=notify
 NotifyAccess=main
-ExecStart=/usr/sbin/mosquitto
+ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 Restart=on-failure
 
 [Install]

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -2,7 +2,7 @@
 Description=Mosquitto MQTT v3.1/v3.1.1 Broker
 
 [Service]
-ExecStart=/usr/sbin/mosquitto
+ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Config file is installed by default, so I would expect that it will be used by
the systemd service. Add argument for the configuration to the services.

Signed-off-by: Tomas Novotny <novotny@rehivetech.com>