### PR TITLE
Improve performance with lots of queued message

### DIFF
--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -199,6 +199,8 @@ struct mosquitto {
 	struct mosquitto_client_msg *last_msg;
 	int msg_count;
 	int msg_count12;
+	int msg_count_ready_send;
+	int msg_count_queued2_in;
 	struct _mosquitto_acl_user *acl_list;
 	struct _mqtt3_listener *listener;
 	time_t disconnect_t;

--- a/src/context.c
+++ b/src/context.c
@@ -73,6 +73,8 @@ struct mosquitto *mqtt3_context_init(struct mosquitto_db *db, mosq_sock_t sock)
 	context->last_msg = NULL;
 	context->msg_count = 0;
 	context->msg_count12 = 0;
+	context->msg_count_ready_send = 0;
+	context->msg_count_queued2_in = 0;
 #ifdef WITH_TLS
 	context->ssl = NULL;
 #endif


### PR DESCRIPTION
In our use case, we could have large number of queued message for one consumer. In such case we had very poor performance.
After few investigation, I found that the issue was [mqtt3_db_message_write](https://github.com/eclipse/mosquitto/blob/d20355c8ac64746876bdfd0c47f9ac6096bee9dc/src/database.c#L810): each time a message could be sent to client, it iterate over whole list of message for this client.
With thousands of messages Mosquitto starts to use a lots of CPU and message consumption is way slower

This PR add counters to avoid iterating over all queued messages and stop as soon
as counters tell us that no more actions are required for now.


With a test client that:
* create a consumer with clean_session=False, subscribe to "topic" and disconnect
* create a producer that send N message to "topic" and disconnection
* re-connect the initial consumer and consume all N messages

I have the following result:

number of messages | message/s without PR | message/s with PR
------------ | ------------- | -------------
2500 | 16700 message/s | 18100 message/s
7500 | 15400 message/s | 18400 message/s
10000 | 13100 message/s | 19200 message/s
25000 | 3800 message/s | 19100 message/s


