### PR TITLE
CMake changes : static library target, no /sbin/ldconfig on Mac, and Documentation option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ endif (${WITH_SOCKS} STREQUAL ON)
 
 option(WITH_SRV "Include SRV lookup support?" ON)
 
+option(DOCUMENTATION "Build documentation?" ON)
+
 # ========================================
 # Include projects
 # ========================================
@@ -86,7 +88,9 @@ option(WITH_SRV "Include SRV lookup support?" ON)
 add_subdirectory(lib)
 add_subdirectory(client)
 add_subdirectory(src)
-add_subdirectory(man)
+if (${DOCUMENTATION} STREQUAL ON)
+	add_subdirectory(man)
+endif (${DOCUMENTATION} STREQUAL ON)
 
 # ========================================
 # Install config file

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,8 +20,7 @@ include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/lib
 			${OPENSSL_INCLUDE_DIR} ${PTHREAD_INCLUDE_DIR})
 link_directories(${mosquitto_SOURCE_DIR}/lib)
 
-add_library(libmosquitto SHARED
-	logging_mosq.c logging_mosq.h
+set(C_SRC logging_mosq.c logging_mosq.h
 	memory_mosq.c memory_mosq.h
 	messages_mosq.c messages_mosq.h
 	mosquitto.c mosquitto.h
@@ -41,27 +40,10 @@ add_library(libmosquitto SHARED
 	util_mosq.c util_mosq.h
 	will_mosq.c will_mosq.h)
 
+add_library(libmosquitto SHARED ${C_SRC} )
+
 #target for building static version of library
-add_library(libmosquitto_static STATIC
-	logging_mosq.c logging_mosq.h
-	memory_mosq.c memory_mosq.h
-	messages_mosq.c messages_mosq.h
-	mosquitto.c mosquitto.h
-	mosquitto_internal.h
-	mqtt3_protocol.h
-	net_mosq.c net_mosq.h
-	read_handle.c read_handle.h
-	read_handle_client.c
-	read_handle_shared.c
-	send_client_mosq.c
-	send_mosq.c send_mosq.h
-	socks_mosq.c
-	srv_mosq.c
-	thread_mosq.c
-	time_mosq.c
-	tls_mosq.c
-	util_mosq.c util_mosq.h
-	will_mosq.c will_mosq.h)
+add_library(libmosquitto_static STATIC ${C_SRC})
 
 set (LIBRARIES ${OPENSSL_LIBRARIES} ${PTHREAD_LIBRARIES})
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -73,6 +73,7 @@ set_target_properties(libmosquitto PROPERTIES
 install(TARGETS libmosquitto RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 install(FILES mosquitto.h DESTINATION ${INCLUDEDIR})
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	install(CODE "EXEC_PROGRAM(/sbin/ldconfig)")
-endif (UNIX)
+endif (UNIX AND NOT APPLE)
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,6 +41,28 @@ add_library(libmosquitto SHARED
 	util_mosq.c util_mosq.h
 	will_mosq.c will_mosq.h)
 
+#target for building static version of library
+add_library(libmosquitto_static STATIC
+	logging_mosq.c logging_mosq.h
+	memory_mosq.c memory_mosq.h
+	messages_mosq.c messages_mosq.h
+	mosquitto.c mosquitto.h
+	mosquitto_internal.h
+	mqtt3_protocol.h
+	net_mosq.c net_mosq.h
+	read_handle.c read_handle.h
+	read_handle_client.c
+	read_handle_shared.c
+	send_client_mosq.c
+	send_mosq.c send_mosq.h
+	socks_mosq.c
+	srv_mosq.c
+	thread_mosq.c
+	time_mosq.c
+	tls_mosq.c
+	util_mosq.c util_mosq.h
+	will_mosq.c will_mosq.h)
+
 set (LIBRARIES ${OPENSSL_LIBRARIES} ${PTHREAD_LIBRARIES})
 
 if (UNIX AND NOT APPLE)
@@ -64,13 +86,22 @@ endif (${WITH_SRV} STREQUAL ON)
 
 target_link_libraries(libmosquitto ${LIBRARIES})
 
+target_link_libraries(libmosquitto_static ${LIBRARIES})
+
 set_target_properties(libmosquitto PROPERTIES
 	OUTPUT_NAME mosquitto
 	VERSION ${VERSION}
 	SOVERSION 1
 )
 
-install(TARGETS libmosquitto RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
+set_target_properties(libmosquitto_static PROPERTIES
+	OUTPUT_NAME mosquitto
+	VERSION ${VERSION}
+)
+
+target_compile_definitions(libmosquitto_static PUBLIC "STATIC_LIB")
+
+install(TARGETS libmosquitto libmosquitto_static RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
 install(FILES mosquitto.h DESTINATION ${INCLUDEDIR})
 
 if (UNIX AND NOT APPLE)

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(mosquittopp PROPERTIES
 install(TARGETS mosquittopp RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 install(FILES mosquittopp.h DESTINATION ${INCLUDEDIR})
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	install(CODE "EXEC_PROGRAM(/sbin/ldconfig)")
-endif (UNIX)
+endif (UNIX AND NOT APPLE)
+

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -21,7 +21,7 @@ Contributors:
 extern "C" {
 #endif
 
-#if defined(WIN32) && !defined(WITH_BROKER)
+#if defined(WIN32) && !defined(WITH_BROKER) && !defined(STATIC_LIB)
 #	ifdef libmosquitto_EXPORTS
 #		define libmosq_EXPORT  __declspec(dllexport)
 #	else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,11 +109,13 @@ endif(NOT APPLE)
 
 target_link_libraries(mosquitto ${MOSQ_LIBS})
 
-if (UNIX AND APPLE)
+if (UNIX)
+	if (APPLE)
 		set_target_properties(mosquitto PROPERTIES LINK_FLAGS "-Wl,-exported_symbols_list -Wl,${mosquitto_SOURCE_DIR}/src/linker-macosx.syms")
-else (UNIX AND APPLE)
+	else (APPLE)
 		set_target_properties(mosquitto PROPERTIES LINK_FLAGS "-Wl,-dynamic-list=${mosquitto_SOURCE_DIR}/src/linker.syms")
-endif (UNIX AND APPLE)
+	endif (APPLE)
+endif (UNIX)
 
 install(TARGETS mosquitto RUNTIME DESTINATION ${SBINDIR} LIBRARY DESTINATION ${LIBDIR})
 install(FILES mosquitto_plugin.h DESTINATION ${INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,7 +126,8 @@ if (${WITH_TLS} STREQUAL ON)
 	install(TARGETS mosquitto_passwd RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 endif (${WITH_TLS} STREQUAL ON)
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	install(CODE "EXEC_PROGRAM(/sbin/ldconfig)")
-endif (UNIX)
+endif (UNIX AND NOT APPLE)
+
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,13 +109,11 @@ endif(NOT APPLE)
 
 target_link_libraries(mosquitto ${MOSQ_LIBS})
 
-if (UNIX)
-	if (APPLE)
+if (UNIX AND APPLE)
 		set_target_properties(mosquitto PROPERTIES LINK_FLAGS "-Wl,-exported_symbols_list -Wl,${mosquitto_SOURCE_DIR}/src/linker-macosx.syms")
-	else (APPLE)
+else (UNIX AND APPLE)
 		set_target_properties(mosquitto PROPERTIES LINK_FLAGS "-Wl,-dynamic-list=${mosquitto_SOURCE_DIR}/src/linker.syms")
-	endif (APPLE)
-endif (UNIX)
+endif (UNIX AND APPLE)
 
 install(TARGETS mosquitto RUNTIME DESTINATION ${SBINDIR} LIBRARY DESTINATION ${LIBDIR})
 install(FILES mosquitto_plugin.h DESTINATION ${INCLUDEDIR})


### PR DESCRIPTION
This pull request has a couple of changes to the CMake build system.

* Now has an additional target `libmosquitto_static` which compiles the same files as libmosquitto into a static archive
* When building the new `libmosquitto_static` the declaration define `libmosq_EXPORT` also gets null defined as all of the functions are contained in the static library
* No longer runs `/sbin/ldconfig` on Mac OS X (specifically is now run when `UNIX` is true, and `APPLE` is false)
* Adding a `DOCUMENTATION` option that enables/disables copying the man files during `install` target