### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ endif (${WITH_SOCKS} STREQUAL ON)
 
 option(WITH_SRV "Include SRV lookup support?" OFF)
 
+option(DOCUMENTATION "Build documentation?" ON)
+
 # ========================================
 # Include projects
 # ========================================
@@ -86,7 +88,9 @@ option(WITH_SRV "Include SRV lookup support?" OFF)
 add_subdirectory(lib)
 add_subdirectory(client)
 add_subdirectory(src)
-add_subdirectory(man)
+if (${DOCUMENTATION} STREQUAL ON)
+	add_subdirectory(man)
+endif (${DOCUMENTATION} STREQUAL ON)
 
 # ========================================
 # Install config file

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -89,7 +89,7 @@ set_target_properties(libmosquitto_static PROPERTIES
 	VERSION ${VERSION}
 )
 
-target_compile_definitions(libmosquitto_static PUBLIC "STATIC_LIB")
+target_compile_definitions(libmosquitto_static PUBLIC "LIBMOSQUITTO_STATIC")
 
 install(TARGETS libmosquitto libmosquitto_static RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
 install(FILES mosquitto.h DESTINATION ${INCLUDEDIR})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -90,6 +90,7 @@ set_target_properties(libmosquitto PROPERTIES
 install(TARGETS libmosquitto RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 install(FILES mosquitto.h DESTINATION ${INCLUDEDIR})
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	install(CODE "EXEC_PROGRAM(/sbin/ldconfig)")
-endif (UNIX)
+endif (UNIX AND NOT APPLE)
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -58,6 +58,28 @@ add_library(libmosquitto SHARED
 	util_mosq.c util_mosq.h
 	will_mosq.c will_mosq.h)
 
+#target for building static version of library
+add_library(libmosquitto_static STATIC
+	logging_mosq.c logging_mosq.h
+	memory_mosq.c memory_mosq.h
+	messages_mosq.c messages_mosq.h
+	mosquitto.c mosquitto.h
+	mosquitto_internal.h
+	mqtt3_protocol.h
+	net_mosq.c net_mosq.h
+	read_handle.c read_handle.h
+	read_handle_client.c
+	read_handle_shared.c
+	send_client_mosq.c
+	send_mosq.c send_mosq.h
+	socks_mosq.c
+	srv_mosq.c
+	thread_mosq.c
+	time_mosq.c
+	tls_mosq.c
+	util_mosq.c util_mosq.h
+	will_mosq.c will_mosq.h)
+
 set (LIBRARIES ${OPENSSL_LIBRARIES} ${PTHREAD_LIBRARIES})
 
 if (UNIX AND NOT APPLE)
@@ -81,13 +103,22 @@ endif (${WITH_SRV} STREQUAL ON)
 
 target_link_libraries(libmosquitto ${LIBRARIES})
 
+target_link_libraries(libmosquitto_static ${LIBRARIES})
+
 set_target_properties(libmosquitto PROPERTIES
 	OUTPUT_NAME mosquitto
 	VERSION ${VERSION}
 	SOVERSION 1
 )
 
-install(TARGETS libmosquitto RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
+set_target_properties(libmosquitto_static PROPERTIES
+	OUTPUT_NAME mosquitto
+	VERSION ${VERSION}
+)
+
+target_compile_definitions(libmosquitto_static PUBLIC "STATIC_LIB")
+
+install(TARGETS libmosquitto libmosquitto_static RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
 install(FILES mosquitto.h DESTINATION ${INCLUDEDIR})
 
 if (UNIX AND NOT APPLE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,17 +24,7 @@ include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/lib
 			${OPENSSL_INCLUDE_DIR} ${PTHREAD_INCLUDE_DIR})
 link_directories(${mosquitto_SOURCE_DIR}/lib)
 
-add_library(libmosquitto SHARED
-	handle_connack.c
-	handle_ping.c
-	handle_pubackcomp.c
-	handle_publish.c
-	handle_pubrec.c
-	handle_pubrel.c
-	handle_suback.c
-	handle_unsuback.c
-	helpers.c
-	logging_mosq.c logging_mosq.h
+set(C_SRC logging_mosq.c logging_mosq.h
 	memory_mosq.c memory_mosq.h
 	messages_mosq.c messages_mosq.h
 	mosquitto.c mosquitto.h
@@ -58,27 +48,10 @@ add_library(libmosquitto SHARED
 	util_mosq.c util_mosq.h
 	will_mosq.c will_mosq.h)
 
+add_library(libmosquitto SHARED ${C_SRC} )
+
 #target for building static version of library
-add_library(libmosquitto_static STATIC
-	logging_mosq.c logging_mosq.h
-	memory_mosq.c memory_mosq.h
-	messages_mosq.c messages_mosq.h
-	mosquitto.c mosquitto.h
-	mosquitto_internal.h
-	mqtt3_protocol.h
-	net_mosq.c net_mosq.h
-	read_handle.c read_handle.h
-	read_handle_client.c
-	read_handle_shared.c
-	send_client_mosq.c
-	send_mosq.c send_mosq.h
-	socks_mosq.c
-	srv_mosq.c
-	thread_mosq.c
-	time_mosq.c
-	tls_mosq.c
-	util_mosq.c util_mosq.h
-	will_mosq.c will_mosq.h)
+add_library(libmosquitto_static STATIC ${C_SRC})
 
 set (LIBRARIES ${OPENSSL_LIBRARIES} ${PTHREAD_LIBRARIES})
 

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(mosquittopp PROPERTIES
 install(TARGETS mosquittopp RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 install(FILES mosquittopp.h DESTINATION ${INCLUDEDIR})
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	install(CODE "EXEC_PROGRAM(/sbin/ldconfig)")
-endif (UNIX)
+endif (UNIX AND NOT APPLE)
+

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -21,7 +21,7 @@ Contributors:
 extern "C" {
 #endif
 
-#if defined(WIN32) && !defined(WITH_BROKER)
+#if defined(WIN32) && !defined(WITH_BROKER) && !defined(STATIC_LIB)
 #	ifdef libmosquitto_EXPORTS
 #		define libmosq_EXPORT  __declspec(dllexport)
 #	else

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -21,7 +21,7 @@ Contributors:
 extern "C" {
 #endif
 
-#if defined(WIN32) && !defined(WITH_BROKER) && !defined(STATIC_LIB)
+#if defined(WIN32) && !defined(WITH_BROKER) && !defined(LIBMOSQUITTO_STATIC)
 #	ifdef libmosquitto_EXPORTS
 #		define libmosq_EXPORT  __declspec(dllexport)
 #	else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -154,7 +154,8 @@ if (${WITH_TLS} STREQUAL ON)
 	install(TARGETS mosquitto_passwd RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 endif (${WITH_TLS} STREQUAL ON)
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	install(CODE "EXEC_PROGRAM(/sbin/ldconfig)")
-endif (UNIX)
+endif (UNIX AND NOT APPLE)
+
 


### PR DESCRIPTION
* Now has a `DOCUMENTATION` option for enabling/disabling documentation man pages
* Created a new static library target for libmosquitto, named `libmosquitto_static`
* Remove all function export declarations for the static library
* No longer calls `/sbin/ldconfig` on platforms other than Unix


(this is basically the same as [this PR](https://github.com/eclipse/mosquitto/pull/143))