### PR TITLE
Win ssl workaround

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -377,6 +377,7 @@ int mosquitto__socket_connect_tls(struct mosquitto *mosq)
 {
 	int ret, err;
 	ret = SSL_connect(mosq->ssl);
+
 	if(ret != 1) {
 		err = SSL_get_error(mosq->ssl, ret);
 #ifdef WIN32


### PR DESCRIPTION
In windows SSL sometimes returns SSL_ERROR_SYSCALL on non-blocked socket when connection in progress. This is workaround for this situation.