### PR TITLE
Change pod name to Mosquitto

### DIFF
--- a/Mosquitto.podspec
+++ b/Mosquitto.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = "Eclipse Mosquitto"
+  s.name             = "Mosquitto"
   s.version          = "1.4.8"
   s.summary          = "Eclipse Mosquitto is an open source implementation of a server for version 3.1 and 3.1.1 of the MQTT protocol."
   s.description      = "Eclipse Mosquitto is an open source implementation of a server for version 3.1 and 3.1.1 of the MQTT protocol."


### PR DESCRIPTION
This version is now pushed to CocoaPods:
https://raw.githubusercontent.com/CocoaPods/Specs/beee5c5026a9b374b8ab99066044a55525b1720c/Specs/Mosquitto/1.4.8/Mosquitto.podspec.json
