### PR TITLE
Enhance static library build

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,7 +24,17 @@ include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/lib
 			${OPENSSL_INCLUDE_DIR} ${PTHREAD_INCLUDE_DIR})
 link_directories(${mosquitto_SOURCE_DIR}/lib)
 
-set(C_SRC logging_mosq.c logging_mosq.h
+set(C_SRC
+	handle_connack.c
+	handle_ping.c
+	handle_pubackcomp.c
+	handle_publish.c
+	handle_pubrec.c
+	handle_pubrel.c
+	handle_suback.c
+	handle_unsuback.c
+	helpers.c
+	logging_mosq.c logging_mosq.h
 	memory_mosq.c memory_mosq.h
 	messages_mosq.c messages_mosq.h
 	mosquitto.c mosquitto.h

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
+option(BUILD_STATIC_LIBRARY "Build the static library?" ON)
 add_subdirectory(cpp)
 
 option(WITH_THREADING "Include client library threading support?" ON)
@@ -58,11 +59,6 @@ set(C_SRC
 	util_mosq.c util_mosq.h
 	will_mosq.c will_mosq.h)
 
-add_library(libmosquitto SHARED ${C_SRC} )
-
-#target for building static version of library
-add_library(libmosquitto_static STATIC ${C_SRC})
-
 set (LIBRARIES ${OPENSSL_LIBRARIES} ${PTHREAD_LIBRARIES})
 
 if (UNIX AND NOT APPLE)
@@ -84,9 +80,9 @@ if (${WITH_SRV} STREQUAL ON)
 	endif (ARES_HEADER)
 endif (${WITH_SRV} STREQUAL ON)
 
-target_link_libraries(libmosquitto ${LIBRARIES})
+add_library(libmosquitto SHARED ${C_SRC} )
 
-target_link_libraries(libmosquitto_static ${LIBRARIES})
+target_link_libraries(libmosquitto ${LIBRARIES})
 
 set_target_properties(libmosquitto PROPERTIES
 	OUTPUT_NAME mosquitto
@@ -94,14 +90,23 @@ set_target_properties(libmosquitto PROPERTIES
 	SOVERSION 1
 )
 
-set_target_properties(libmosquitto_static PROPERTIES
-	OUTPUT_NAME mosquitto
-	VERSION ${VERSION}
-)
+install(TARGETS libmosquitto RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 
-target_compile_definitions(libmosquitto_static PUBLIC "LIBMOSQUITTO_STATIC")
+if (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+	#target for building static version of library
+	add_library(libmosquitto_static STATIC ${C_SRC})
 
-install(TARGETS libmosquitto libmosquitto_static RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR} ARCHIVE DESTINATION ${LIBDIR})
+	target_link_libraries(libmosquitto_static ${LIBRARIES})
+
+	set_target_properties(libmosquitto_static PROPERTIES
+		OUTPUT_NAME mosquitto
+		VERSION ${VERSION}
+	)
+
+	target_compile_definitions(libmosquitto_static PUBLIC "LIBMOSQUITTO_STATIC")
+	install(TARGETS libmosquitto_static RUNTIME DESTINATION ${BINDIR} ARCHIVE DESTINATION ${LIBDIR})
+endif (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+
 install(FILES mosquitto.h DESTINATION ${INCLUDEDIR})
 
 if (UNIX AND NOT APPLE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(BUILD_STATIC_LIBRARY "Build the static library?" ON)
+option(WITH_STATIC_LIBRARIES "Build the static libraries?" ON)
 option(WITH_PIC "Build the static library with PIC(Position Independent Code) enabled archives?" OFF)
 add_subdirectory(cpp)
 
@@ -98,7 +98,7 @@ set_target_properties(libmosquitto PROPERTIES
 
 install(TARGETS libmosquitto RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 
-if (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+if (${WITH_STATIC_LIBRARIES} STREQUAL ON)
 	if (${WITH_PIC} STREQUAL OFF)
 		add_library(libmosquitto_static STATIC ${C_SRC})
 	else (${WITH_PIC} STREQUAL OFF)
@@ -114,7 +114,7 @@ if (${BUILD_STATIC_LIBRARY} STREQUAL ON)
 
 	target_compile_definitions(libmosquitto_static PUBLIC "LIBMOSQUITTO_STATIC")
 	install(TARGETS libmosquitto_static RUNTIME DESTINATION ${BINDIR} ARCHIVE DESTINATION ${LIBDIR})
-endif (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+endif (${WITH_STATIC_LIBRARIES} STREQUAL ON)
 
 install(FILES mosquitto.h DESTINATION ${INCLUDEDIR})
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(BUILD_STATIC_LIBRARY "Build the static library?" ON)
+option(WITH_PIC "Build the static library with PIC(Position Independent Code) enabled archives?" OFF)
 add_subdirectory(cpp)
 
 option(WITH_THREADING "Include client library threading support?" ON)
@@ -80,7 +81,12 @@ if (${WITH_SRV} STREQUAL ON)
 	endif (ARES_HEADER)
 endif (${WITH_SRV} STREQUAL ON)
 
-add_library(libmosquitto SHARED ${C_SRC} )
+add_library(libmosquitto_obj OBJECT ${C_SRC})
+set_target_properties(libmosquitto_obj PROPERTIES
+	POSITION_INDEPENDENT_CODE 1
+)
+
+add_library(libmosquitto SHARED $<TARGET_OBJECTS:libmosquitto_obj>)
 
 target_link_libraries(libmosquitto ${LIBRARIES})
 
@@ -93,8 +99,11 @@ set_target_properties(libmosquitto PROPERTIES
 install(TARGETS libmosquitto RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 
 if (${BUILD_STATIC_LIBRARY} STREQUAL ON)
-	#target for building static version of library
-	add_library(libmosquitto_static STATIC ${C_SRC})
+	if (${WITH_PIC} STREQUAL OFF)
+		add_library(libmosquitto_static STATIC ${C_SRC})
+	else (${WITH_PIC} STREQUAL OFF)
+		add_library(libmosquitto_static STATIC $<TARGET_OBJECTS:libmosquitto_obj>)
+	endif (${WITH_PIC} STREQUAL OFF)
 
 	target_link_libraries(libmosquitto_static ${LIBRARIES})
 

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ set_target_properties(mosquittopp PROPERTIES
 )
 install(TARGETS mosquittopp RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
 
-if (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+if (${WITH_STATIC_LIBRARIES} STREQUAL ON)
 	if (${WITH_PIC} STREQUAL OFF)
 		add_library(mosquittopp_static STATIC
 			$<TARGET_OBJECTS:libmosquitto_obj>
@@ -40,7 +40,7 @@ if (${BUILD_STATIC_LIBRARY} STREQUAL ON)
 
 	target_compile_definitions(mosquittopp_static PUBLIC "LIBMOSQUITTO_STATIC")
 	install(TARGETS mosquittopp_static RUNTIME DESTINATION ${BINDIR} ARCHIVE DESTINATION ${LIBDIR})
-endif (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+endif (${WITH_STATIC_LIBRARIES} STREQUAL ON)
 
 install(FILES mosquittopp.h DESTINATION ${INCLUDEDIR})
 

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -2,8 +2,14 @@ include_directories(${mosquitto_SOURCE_DIR}/lib ${mosquitto_SOURCE_DIR}/lib/cpp
 			${STDBOOL_H_PATH} ${STDINT_H_PATH})
 link_directories(${mosquitto_BINARY_DIR}/lib)
 
-add_library(mosquittopp SHARED
-	mosquittopp.cpp mosquittopp.h)
+set(C_SRC mosquittopp.cpp mosquittopp.h)
+
+add_library(mosquittopp_obj OBJECT ${C_SRC})
+set_target_properties(mosquittopp_obj PROPERTIES
+	POSITION_INDEPENDENT_CODE 1
+)
+
+add_library(mosquittopp SHARED $<TARGET_OBJECTS:mosquittopp_obj>)
 
 target_link_libraries(mosquittopp libmosquitto)
 set_target_properties(mosquittopp PROPERTIES
@@ -11,6 +17,31 @@ set_target_properties(mosquittopp PROPERTIES
 	SOVERSION 1
 )
 install(TARGETS mosquittopp RUNTIME DESTINATION ${BINDIR} LIBRARY DESTINATION ${LIBDIR})
+
+if (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+	if (${WITH_PIC} STREQUAL OFF)
+		add_library(mosquittopp_static STATIC
+			$<TARGET_OBJECTS:libmosquitto_obj>
+			${C_SRC}
+		)
+	else (${WITH_PIC} STREQUAL OFF)
+		add_library(mosquittopp_static STATIC
+			$<TARGET_OBJECTS:libmosquitto_obj>
+			$<TARGET_OBJECTS:mosquittopp_obj>
+		)
+	endif (${WITH_PIC} STREQUAL OFF)
+
+	target_link_libraries(mosquittopp_static ${LIBRARIES})
+
+	set_target_properties(mosquittopp_static PROPERTIES
+		OUTPUT_NAME mosquittopp
+		VERSION ${VERSION}
+	)
+
+	target_compile_definitions(mosquittopp_static PUBLIC "LIBMOSQUITTO_STATIC")
+	install(TARGETS mosquittopp_static RUNTIME DESTINATION ${BINDIR} ARCHIVE DESTINATION ${LIBDIR})
+endif (${BUILD_STATIC_LIBRARY} STREQUAL ON)
+
 install(FILES mosquittopp.h DESTINATION ${INCLUDEDIR})
 
 if (UNIX AND NOT APPLE)


### PR DESCRIPTION
1. Fix a build fail which is caused by a lack of source object in libmosquitto.
2. Add an CMake option BUILD_STATIC_LIBRARY to allow control over building static libraries or not.
3. Add an CMake option WITH_PIC to allow control over building static libraries with PIC or not.
4. Add build configuration to build CPP static library.

