### PR TITLE
Fixes a bug where C++ wrapper would always claim SOCKS was not supported

### DIFF
--- a/lib/cpp/mosquittopp.cpp
+++ b/lib/cpp/mosquittopp.cpp
@@ -281,11 +281,7 @@ void mosquittopp::user_data_set(void *userdata)
 
 int mosquittopp::socks5_set(const char *host, int port, const char *username, const char *password)
 {
-#ifdef WITH_SOCKS
 	return mosquitto_socks5_set(m_mosq, host, port, username, password);
-#else
-	return MOSQ_ERR_NOT_SUPPORTED;
-#endif
 }
 
 


### PR DESCRIPTION
The WITH_* flags are not handed over to the C++ wrapper, instead it relies on
the actual library to check status.

Signed-off-by: Johan de Vries (Ubuntu VM) <devries@wivion.nl>