### PR TITLE
Implement byte limits for message queues

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -33,6 +33,7 @@ Broker:
 - new $SYS/broker/store/messages/bytes
 - max_queued_bytes feature to limit queues by real size rather than
   than just message count. Closes Eclipse #452919 or Github #100
+- queue_qos0_messages was not observing max_queued_** limits
 
 Client library:
 - Outgoing messages with QoS>1 are no longer retried after a timeout period.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -29,6 +29,8 @@ Broker:
 - mosquitto_db_dump tool can now output some stats on clients.
 - perform utf-8 validation on incoming will, subscription and unsubscription
   topics.
+- new $SYS/broker/store/messages/count (deprecates $SYS/broker/messages/stored)
+- new $SYS/broker/store/messages/bytes
 
 Client library:
 - Outgoing messages with QoS>1 are no longer retried after a timeout period.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -31,6 +31,8 @@ Broker:
   topics.
 - new $SYS/broker/store/messages/count (deprecates $SYS/broker/messages/stored)
 - new $SYS/broker/store/messages/bytes
+- max_queued_bytes feature to limit queues by real size rather than
+  than just message count. Closes Eclipse #452919 or Github #100
 
 Client library:
 - Outgoing messages with QoS>1 are no longer retried after a timeout period.

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -205,6 +205,8 @@ struct mosquitto {
 	struct mosquitto_client_msg *last_inflight_msg;
 	struct mosquitto_client_msg *queued_msgs;
 	struct mosquitto_client_msg *last_queued_msg;
+	unsigned long msg_bytes;
+	unsigned long msg_bytes12;
 	int msg_count;
 	int msg_count12;
 	struct mosquitto__acl_user *acl_list;

--- a/man/mosquitto.8.xml
+++ b/man/mosquitto.8.xml
@@ -292,14 +292,6 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
-				<term><option>$SYS/broker/messages/stored</option></term>
-				<listitem>
-					<para>The number of messages currently held in the message
-						store. This includes retained messages and messages
-						queued for durable clients.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
 				<term><option>$SYS/broker/publish/messages/dropped</option></term>
 				<listitem>
 					<para>The total number of publish messages that have been
@@ -326,6 +318,23 @@
 				<term><option>$SYS/broker/retained messages/count</option></term>
 				<listitem>
 					<para>The total number of retained messages active on the broker.</para>
+				</listitem>
+			</varlistentry>
+                        <varlistentry>
+                            <term><option>$SYS/broker/store/messages/count</option></term>
+                            <term><option>$SYS/broker/messages/stored</option> (deprecated)</term>
+				<listitem>
+					<para>The number of messages currently held in the message
+						store. This includes retained messages and messages
+						queued for durable clients.</para>
+				</listitem>
+			</varlistentry>
+                        <varlistentry>
+                            <term><option>$SYS/broker/store/messages/bytes</option></term>
+				<listitem>
+					<para>The number of bytes currently held by message payloads
+                                            in the message store. This includes retained messages
+                                            and messages queued for durable clients.</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -359,6 +359,16 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
+				<term><option>max_inflight_bytes</option> <replaceable>count</replaceable></term>
+				<listitem>
+					<para>QoS 1 and 2 messages will be allowed in flight until this byte
+                                            limit is reached.  Defaults to 0. (No limit)
+                                            See also the <option>max_inflight_messages</option> option.
+                                        </para>
+					<para>Reloaded on reload signal.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
 				<term><option>max_inflight_messages</option> <replaceable>count</replaceable></term>
 				<listitem>
 					<para>The maximum number of QoS 1 or 2 messages that can be
@@ -372,13 +382,28 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
+				<term><option>max_queued_bytes</option> <replaceable>count</replaceable></term>
+				<listitem>
+					<para>QoS 1 and 2 messages above those currently in-flight will be
+						queued (per client) until this limit is exceeded.
+						Defaults to 0. (No maximum) See also the
+						<option>max_queued_messages</option> option.
+						If both max_queued_messages and max_queued_bytes are specified,
+						packets will  be queued until the first limit is reached.
+					</para>
+					<para>Reloaded on reload signal.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
 				<term><option>max_queued_messages</option> <replaceable>count</replaceable></term>
 				<listitem>
 					<para>The maximum number of QoS 1 or 2 messages to hold in the
 						queue (per client) above those messages that are currently
 						in flight. Defaults to 100. Set to 0 for no maximum (not
 						recommended). See also the
-						<option>queue_qos0_messages</option> option.</para>
+						<option>queue_qos0_messages</option> and
+						<option>max_queued_bytes</option> options.
+                                        </para>
 					<para>Reloaded on reload signal.</para>
 				</listitem>
 			</varlistentry>

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -374,9 +374,9 @@
 			<varlistentry>
 				<term><option>max_queued_messages</option> <replaceable>count</replaceable></term>
 				<listitem>
-					<para>The maximum number of QoS 1 or 2 messages to hold in
-						the queue above those messages that are currently in
-						flight. Defaults to 100. Set to 0 for no maximum (not
+					<para>The maximum number of QoS 1 or 2 messages to hold in the
+						queue (per client) above those messages that are currently
+						in flight. Defaults to 100. Set to 0 for no maximum (not
 						recommended). See also the
 						<option>queue_qos0_messages</option> option.</para>
 					<para>Reloaded on reload signal.</para>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -46,15 +46,28 @@
 # and 2 messages.
 #max_inflight_messages 20
 
+# QoS 1 and 2 messages will be allowed inflight per client until this limit
+# is exceeded.  Defaults to 0. (No maximum)
+# See also max_inflight_messages
+#max_inflight_bytes 0
+
 # The maximum number of QoS 1 and 2 messages to hold in a queue per client
 # above those that are currently in-flight.  Defaults to 100. Set 
 # to 0 for no maximum (not recommended).
 # See also queue_qos0_messages.
+# See also max_queued_bytes.
 #max_queued_messages 100
+
+# QoS 1 and 2 messages above those currently in-flight will be queued per
+# client until this limit is exceeded.  Defaults to 0. (No maximum)
+# See also max_queued_messages.
+# If both max_queued_messages and max_queued_bytes are specified, packets will
+# be queued until the first limit is reached.
+#max_queued_bytes 0
 
 # Set to true to queue messages with QoS 0 when a persistent client is
 # disconnected. These messages are included in the limit imposed by
-# max_queued_messages.
+# max_queued_messages and max_queued_bytes
 # Defaults to false.
 # This is a non-standard option for the MQTT v3.1 spec but is allowed in
 # v3.1.1.

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -46,7 +46,7 @@
 # and 2 messages.
 #max_inflight_messages 20
 
-# The maximum number of QoS 1 and 2 messages to hold in a queue 
+# The maximum number of QoS 1 and 2 messages to hold in a queue per client
 # above those that are currently in-flight.  Defaults to 100. Set 
 # to 0 for no maximum (not recommended).
 # See also queue_qos0_messages.

--- a/src/conf.c
+++ b/src/conf.c
@@ -475,7 +475,7 @@ int config__read(struct mosquitto__config *config, bool reload)
 {
 	int rc = MOSQ_ERR_SUCCESS;
 	struct config_recurse cr;
-	int lineno;
+	int lineno = 0;
 	int len;
 #ifdef WITH_BRIDGE
 	int i;

--- a/src/context.c
+++ b/src/context.c
@@ -74,6 +74,8 @@ struct mosquitto *context__init(struct mosquitto_db *db, mosq_sock_t sock)
 	context->last_inflight_msg = NULL;
 	context->queued_msgs = NULL;
 	context->last_queued_msg = NULL;
+	context->msg_bytes = 0;
+	context->msg_bytes12 = 0;
 	context->msg_count = 0;
 	context->msg_count12 = 0;
 #ifdef WITH_TLS

--- a/src/database.c
+++ b/src/database.c
@@ -125,6 +125,7 @@ void db__msg_store_remove(struct mosquitto_db *db, struct mosquitto_msg_store *s
 		}
 	}
 	db->msg_store_count--;
+	db->msg_store_bytes -= store->payloadlen;
 
 	mosquitto__free(store->source_id);
 	if(store->dest_ids){
@@ -556,6 +557,7 @@ int db__message_store(struct mosquitto_db *db, const char *source, uint16_t sour
 	temp->dest_ids = NULL;
 	temp->dest_id_count = 0;
 	db->msg_store_count++;
+	db->msg_store_bytes += payloadlen;
 	(*stored) = temp;
 
 	if(!store_id){

--- a/src/database.c
+++ b/src/database.c
@@ -26,7 +26,68 @@ Contributors:
 #include "time_mosq.h"
 
 static int max_inflight = 20;
+static unsigned long max_inflight_bytes = 0;
 static int max_queued = 100;
+static unsigned long max_queued_bytes = 0;
+
+/**
+ * Is this context ready to take more in flight messages right now?
+ * @param context the client context of interest
+ * @param qos qos for the packet of interest
+ * @return true if more in flight are allowed.
+ */
+static bool db__ready_for_flight(struct mosquitto *context, int qos)
+{
+	if(qos == 0 || (max_inflight == 0 && max_inflight_bytes == 0)){
+		return true;
+	}
+
+	bool valid_bytes = context->msg_bytes12 < max_inflight_bytes;
+	bool valid_count = context->msg_count12 < max_inflight;
+
+	if(max_inflight == 0){
+		return valid_bytes;
+	}
+	if(max_inflight_bytes == 0){
+		return valid_count;
+	}
+
+	return valid_bytes && valid_count;
+}
+
+
+/**
+ * For a given client context, are more messages allowed to be queued?
+ * @param context client of interest
+ * @return true if queuing is allowed, false if should be dropped
+ */
+static bool db__ready_for_queue(struct mosquitto *context)
+{
+	if(max_queued == 0 && max_queued_bytes == 0){
+		return true;
+	}
+
+	unsigned long adjust_bytes = max_inflight_bytes;
+	int adjust_count = max_inflight;
+	/* nothing in flight for offline clients */
+	if(context->sock == INVALID_SOCKET){
+		adjust_bytes = 0;
+		adjust_count = 0;
+	}
+
+	bool valid_bytes = context->msg_bytes12 - adjust_bytes < max_queued_bytes;
+	bool valid_count = context->msg_count12 - adjust_count < max_queued;
+
+	if(max_queued_bytes == 0){
+		return valid_count;
+	}
+	if(max_queued == 0){
+		return valid_bytes;
+	}
+
+	return valid_bytes && valid_count;
+}
+
 
 int db__open(struct mosquitto__config *config, struct mosquitto_db *db)
 {
@@ -169,6 +230,12 @@ static void db__message_remove(struct mosquitto_db *db, struct mosquitto *contex
 	}
 
 	if((*msg)->store){
+		context->msg_count--;
+		context->msg_bytes -= (*msg)->store->payloadlen;
+		if((*msg)->qos > 0){
+			context->msg_count12--;
+			context->msg_bytes12 -= (*msg)->store->payloadlen;
+		}
 		db__msg_store_deref(db, &(*msg)->store);
 	}
 	if(last){
@@ -181,10 +248,6 @@ static void db__message_remove(struct mosquitto_db *db, struct mosquitto *contex
 		if(!context->inflight_msgs){
 			context->last_inflight_msg = NULL;
 		}
-	}
-	context->msg_count--;
-	if((*msg)->qos > 0){
-		context->msg_count12--;
 	}
 	mosquitto__free(*msg);
 	if(last){
@@ -305,7 +368,7 @@ int db__message_insert(struct mosquitto_db *db, struct mosquitto *context, uint1
 	}
 
 	if(context->sock != INVALID_SOCKET){
-		if(qos == 0 || max_inflight == 0 || context->msg_count12 < max_inflight){
+		if(db__ready_for_flight(context, qos)){
 			if(dir == mosq_md_out){
 				switch(qos){
 					case 0:
@@ -325,7 +388,7 @@ int db__message_insert(struct mosquitto_db *db, struct mosquitto *context, uint1
 					return 1;
 				}
 			}
-		}else if(max_queued == 0 || context->msg_count12-max_inflight < max_queued){
+		}else if(db__ready_for_queue(context)){
 			state = mosq_ms_queued;
 			rc = 2;
 		}else{
@@ -340,7 +403,9 @@ int db__message_insert(struct mosquitto_db *db, struct mosquitto *context, uint1
 			return 2;
 		}
 	}else{
-		if(max_queued > 0 && context->msg_count12 >= max_queued){
+		if (db__ready_for_queue(context, qos)){
+			state = mosq_ms_queued;
+		}else{
 			G_MSGS_DROPPED_INC();
 			if(context->is_dropping == false){
 				context->is_dropping = true;
@@ -349,8 +414,6 @@ int db__message_insert(struct mosquitto_db *db, struct mosquitto *context, uint1
 						context->id);
 			}
 			return 2;
-		}else{
-			state = mosq_ms_queued;
 		}
 	}
 	assert(state != mosq_ms_invalid);
@@ -389,8 +452,10 @@ int db__message_insert(struct mosquitto_db *db, struct mosquitto *context, uint1
 		*last_msg = msg;
 	}
 	context->msg_count++;
+	context->msg_bytes += msg->store->payloadlen;
 	if(qos > 0){
 		context->msg_count12++;
+		context->msg_bytes12 += msg->store->payloadlen;
 	}
 
 	if(db->config->allow_duplicate_messages == false && dir == mosq_md_out && retain == false){
@@ -474,6 +539,8 @@ int db__messages_delete(struct mosquitto_db *db, struct mosquitto *context)
 	}
 	context->queued_msgs = NULL;
 	context->last_queued_msg = NULL;
+	context->msg_bytes = 0;
+	context->msg_bytes12 = 0;
 	context->msg_count = 0;
 	context->msg_count12 = 0;
 
@@ -606,14 +673,18 @@ int db__message_reconnect_reset(struct mosquitto_db *db, struct mosquitto *conte
 	struct mosquitto_client_msg *prev = NULL;
 
 	msg = context->inflight_msgs;
+	context->msg_bytes = 0;
+	context->msg_bytes12 = 0;
 	context->msg_count = 0;
 	context->msg_count12 = 0;
 	while(msg){
 		context->last_inflight_msg = msg;
 
 		context->msg_count++;
+		context->msg_bytes += msg->store->payloadlen;
 		if(msg->qos > 0){
 			context->msg_count12++;
+			context->msg_bytes12 += msg->store->payloadlen;
 		}
 
 		if(msg->direction == mosq_md_out){
@@ -657,10 +728,12 @@ int db__message_reconnect_reset(struct mosquitto_db *db, struct mosquitto *conte
 			context->last_queued_msg = msg;
 
 			context->msg_count++;
+			context->msg_bytes += msg->store->payloadlen;
 			if(msg->qos > 0){
 				context->msg_count12++;
+				context->msg_bytes12 += msg->store->payloadlen;
 			}
-			if (max_inflight == 0 || context->msg_count <= max_inflight){
+			if (db__ready_for_flight(context, msg->qos)) {
 				switch(msg->qos){
 					case 0:
 						msg->state = mosq_ms_publish_qos0;
@@ -895,10 +968,12 @@ int db__message_write(struct mosquitto_db *db, struct mosquitto *context)
 	return MOSQ_ERR_SUCCESS;
 }
 
-void db__limits_set(int inflight, int queued)
+void db__limits_set(int inflight, unsigned long inflight_bytes, int queued, unsigned long queued_bytes)
 {
 	max_inflight = inflight;
+	max_inflight_bytes = inflight_bytes;
 	max_queued = queued;
+	max_queued_bytes = queued_bytes;
 }
 
 void db__vacuum(void)

--- a/src/database.c
+++ b/src/database.c
@@ -604,7 +604,6 @@ int db__message_reconnect_reset(struct mosquitto_db *db, struct mosquitto *conte
 {
 	struct mosquitto_client_msg *msg;
 	struct mosquitto_client_msg *prev = NULL;
-	int count;
 
 	msg = context->inflight_msgs;
 	context->msg_count = 0;
@@ -653,17 +652,15 @@ int db__message_reconnect_reset(struct mosquitto_db *db, struct mosquitto *conte
 	 * will be sent out of order.
 	 */
 	if(context->queued_msgs){
-		count = context->msg_count;
 		msg = context->queued_msgs;
 		while(msg){
 			context->last_queued_msg = msg;
 
-			count++;
 			context->msg_count++;
 			if(msg->qos > 0){
 				context->msg_count12++;
 			}
-			if (max_inflight == 0 || count <= max_inflight){
+			if (max_inflight == 0 || context->msg_count <= max_inflight){
 				switch(msg->qos){
 					case 0:
 						msg->state = mosq_ms_publish_qos0;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -358,6 +358,7 @@ struct mosquitto_db{
 #ifdef WITH_BRIDGE
 	int bridge_count;
 #endif
+	unsigned long msg_store_bytes;
 	int msg_store_count;
 	struct mosquitto__config *config;
 	int persistence_changes;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -513,7 +513,7 @@ int db__close(struct mosquitto_db *db);
 int persist__backup(struct mosquitto_db *db, bool shutdown);
 int persist__restore(struct mosquitto_db *db);
 #endif
-void db__limits_set(int inflight, int queued);
+void db__limits_set(int inflight, unsigned long inflight_bytes, int queued, unsigned long queued_bytes);
 /* Return the number of in-flight messages in count. */
 int db__message_count(int *count);
 int db__message_delete(struct mosquitto_db *db, struct mosquitto *context, uint16_t mid, enum mosquitto_msg_direction dir);

--- a/src/sys_tree.c
+++ b/src/sys_tree.c
@@ -149,6 +149,7 @@ void sys_tree__update(struct mosquitto_db *db, int interval, time_t start_time)
 	char buf[BUFLEN];
 
 	static int msg_store_count = -1;
+	static unsigned long msg_store_bytes = -1;
 	static unsigned long msgs_received = -1;
 	static unsigned long msgs_sent = -1;
 	static unsigned long publish_dropped = -1;
@@ -271,6 +272,13 @@ void sys_tree__update(struct mosquitto_db *db, int interval, time_t start_time)
 			msg_store_count = db->msg_store_count;
 			snprintf(buf, BUFLEN, "%d", msg_store_count);
 			db__messages_easy_queue(db, NULL, "$SYS/broker/messages/stored", SYS_TREE_QOS, strlen(buf), buf, 1);
+			db__messages_easy_queue(db, NULL, "$SYS/broker/store/messages/count", SYS_TREE_QOS, strlen(buf), buf, 1);
+		}
+
+		if (db->msg_store_bytes != msg_store_bytes){
+			msg_store_bytes = db->msg_store_bytes;
+			snprintf(buf, BUFLEN, "%lu", msg_store_bytes);
+			db__messages_easy_queue(db, NULL, "$SYS/broker/store/messages/bytes", SYS_TREE_QOS, strlen(buf), buf, 1);
 		}
 
 		if(db->subscription_count != subscription_count){

--- a/src/sys_tree.c
+++ b/src/sys_tree.c
@@ -123,14 +123,20 @@ static void sys_tree__update_memory(struct mosquitto_db *db, char *buf)
 }
 #endif
 
-static void calc_load(struct mosquitto_db *db, char *buf, const char *topic, double exponent, double interval, double *current)
+static void calc_load(struct mosquitto_db *db, char *buf, const char *topic, bool initial, double exponent, double interval, double *current)
 {
 	double new_value;
 
-	new_value = interval + exponent*((*current) - interval);
-	if(fabs(new_value - (*current)) >= 0.01){
+	if (initial) {
+		new_value = *current;
 		snprintf(buf, BUFLEN, "%.2f", new_value);
 		db__messages_easy_queue(db, NULL, topic, SYS_TREE_QOS, strlen(buf), buf, 1);
+	} else {
+		new_value = interval + exponent*((*current) - interval);
+		if(fabs(new_value - (*current)) >= 0.01){
+			snprintf(buf, BUFLEN, "%.2f", new_value);
+			db__messages_easy_queue(db, NULL, topic, SYS_TREE_QOS, strlen(buf), buf, 1);
+		}
 	}
 	(*current) = new_value;
 }
@@ -210,6 +216,11 @@ void sys_tree__update(struct mosquitto_db *db, int interval, time_t start_time)
 		db__messages_easy_queue(db, NULL, "$SYS/broker/uptime", SYS_TREE_QOS, strlen(buf), buf, 1);
 
 		sys_tree__update_clients(db, buf);
+		bool initial_publish = false;
+		if(last_update == 0){
+			initial_publish = true;
+			last_update = 1;
+		}
 		if(last_update > 0){
 			i_mult = 60.0/(double)(now-last_update);
 
@@ -231,41 +242,41 @@ void sys_tree__update(struct mosquitto_db *db, int interval, time_t start_time)
 			/* 1 minute load */
 			exponent = exp(-1.0*(now-last_update)/60.0);
 
-			calc_load(db, buf, "$SYS/broker/load/messages/received/1min", exponent, msgs_received_interval, &msgs_received_load1);
-			calc_load(db, buf, "$SYS/broker/load/messages/sent/1min", exponent, msgs_sent_interval, &msgs_sent_load1);
-			calc_load(db, buf, "$SYS/broker/load/publish/dropped/1min", exponent, publish_dropped_interval, &publish_dropped_load1);
-			calc_load(db, buf, "$SYS/broker/load/publish/received/1min", exponent, publish_received_interval, &publish_received_load1);
-			calc_load(db, buf, "$SYS/broker/load/publish/sent/1min", exponent, publish_sent_interval, &publish_sent_load1);
-			calc_load(db, buf, "$SYS/broker/load/bytes/received/1min", exponent, bytes_received_interval, &bytes_received_load1);
-			calc_load(db, buf, "$SYS/broker/load/bytes/sent/1min", exponent, bytes_sent_interval, &bytes_sent_load1);
-			calc_load(db, buf, "$SYS/broker/load/sockets/1min", exponent, socket_interval, &socket_load1);
-			calc_load(db, buf, "$SYS/broker/load/connections/1min", exponent, connection_interval, &connection_load1);
+			calc_load(db, buf, "$SYS/broker/load/messages/received/1min", initial_publish, exponent, msgs_received_interval, &msgs_received_load1);
+			calc_load(db, buf, "$SYS/broker/load/messages/sent/1min", initial_publish, exponent, msgs_sent_interval, &msgs_sent_load1);
+			calc_load(db, buf, "$SYS/broker/load/publish/dropped/1min", initial_publish, exponent, publish_dropped_interval, &publish_dropped_load1);
+			calc_load(db, buf, "$SYS/broker/load/publish/received/1min", initial_publish, exponent, publish_received_interval, &publish_received_load1);
+			calc_load(db, buf, "$SYS/broker/load/publish/sent/1min", initial_publish, exponent, publish_sent_interval, &publish_sent_load1);
+			calc_load(db, buf, "$SYS/broker/load/bytes/received/1min", initial_publish, exponent, bytes_received_interval, &bytes_received_load1);
+			calc_load(db, buf, "$SYS/broker/load/bytes/sent/1min", initial_publish, exponent, bytes_sent_interval, &bytes_sent_load1);
+			calc_load(db, buf, "$SYS/broker/load/sockets/1min", initial_publish, exponent, socket_interval, &socket_load1);
+			calc_load(db, buf, "$SYS/broker/load/connections/1min", initial_publish, exponent, connection_interval, &connection_load1);
 
 			/* 5 minute load */
 			exponent = exp(-1.0*(now-last_update)/300.0);
 
-			calc_load(db, buf, "$SYS/broker/load/messages/received/5min", exponent, msgs_received_interval, &msgs_received_load5);
-			calc_load(db, buf, "$SYS/broker/load/messages/sent/5min", exponent, msgs_sent_interval, &msgs_sent_load5);
-			calc_load(db, buf, "$SYS/broker/load/publish/dropped/5min", exponent, publish_dropped_interval, &publish_dropped_load5);
-			calc_load(db, buf, "$SYS/broker/load/publish/received/5min", exponent, publish_received_interval, &publish_received_load5);
-			calc_load(db, buf, "$SYS/broker/load/publish/sent/5min", exponent, publish_sent_interval, &publish_sent_load5);
-			calc_load(db, buf, "$SYS/broker/load/bytes/received/5min", exponent, bytes_received_interval, &bytes_received_load5);
-			calc_load(db, buf, "$SYS/broker/load/bytes/sent/5min", exponent, bytes_sent_interval, &bytes_sent_load5);
-			calc_load(db, buf, "$SYS/broker/load/sockets/5min", exponent, socket_interval, &socket_load5);
-			calc_load(db, buf, "$SYS/broker/load/connections/5min", exponent, connection_interval, &connection_load5);
+			calc_load(db, buf, "$SYS/broker/load/messages/received/5min", initial_publish, exponent, msgs_received_interval, &msgs_received_load5);
+			calc_load(db, buf, "$SYS/broker/load/messages/sent/5min", initial_publish, exponent, msgs_sent_interval, &msgs_sent_load5);
+			calc_load(db, buf, "$SYS/broker/load/publish/dropped/5min", initial_publish, exponent, publish_dropped_interval, &publish_dropped_load5);
+			calc_load(db, buf, "$SYS/broker/load/publish/received/5min", initial_publish, exponent, publish_received_interval, &publish_received_load5);
+			calc_load(db, buf, "$SYS/broker/load/publish/sent/5min", initial_publish, exponent, publish_sent_interval, &publish_sent_load5);
+			calc_load(db, buf, "$SYS/broker/load/bytes/received/5min", initial_publish, exponent, bytes_received_interval, &bytes_received_load5);
+			calc_load(db, buf, "$SYS/broker/load/bytes/sent/5min", initial_publish, exponent, bytes_sent_interval, &bytes_sent_load5);
+			calc_load(db, buf, "$SYS/broker/load/sockets/5min", initial_publish, exponent, socket_interval, &socket_load5);
+			calc_load(db, buf, "$SYS/broker/load/connections/5min", initial_publish, exponent, connection_interval, &connection_load5);
 
 			/* 15 minute load */
 			exponent = exp(-1.0*(now-last_update)/900.0);
 
-			calc_load(db, buf, "$SYS/broker/load/messages/received/15min", exponent, msgs_received_interval, &msgs_received_load15);
-			calc_load(db, buf, "$SYS/broker/load/messages/sent/15min", exponent, msgs_sent_interval, &msgs_sent_load15);
-			calc_load(db, buf, "$SYS/broker/load/publish/dropped/15min", exponent, publish_dropped_interval, &publish_dropped_load15);
-			calc_load(db, buf, "$SYS/broker/load/publish/received/15min", exponent, publish_received_interval, &publish_received_load15);
-			calc_load(db, buf, "$SYS/broker/load/publish/sent/15min", exponent, publish_sent_interval, &publish_sent_load15);
-			calc_load(db, buf, "$SYS/broker/load/bytes/received/15min", exponent, bytes_received_interval, &bytes_received_load15);
-			calc_load(db, buf, "$SYS/broker/load/bytes/sent/15min", exponent, bytes_sent_interval, &bytes_sent_load15);
-			calc_load(db, buf, "$SYS/broker/load/sockets/15min", exponent, socket_interval, &socket_load15);
-			calc_load(db, buf, "$SYS/broker/load/connections/15min", exponent, connection_interval, &connection_load15);
+			calc_load(db, buf, "$SYS/broker/load/messages/received/15min", initial_publish, exponent, msgs_received_interval, &msgs_received_load15);
+			calc_load(db, buf, "$SYS/broker/load/messages/sent/15min", initial_publish, exponent, msgs_sent_interval, &msgs_sent_load15);
+			calc_load(db, buf, "$SYS/broker/load/publish/dropped/15min", initial_publish, exponent, publish_dropped_interval, &publish_dropped_load15);
+			calc_load(db, buf, "$SYS/broker/load/publish/received/15min", initial_publish, exponent, publish_received_interval, &publish_received_load15);
+			calc_load(db, buf, "$SYS/broker/load/publish/sent/15min", initial_publish, exponent, publish_sent_interval, &publish_sent_load15);
+			calc_load(db, buf, "$SYS/broker/load/bytes/received/15min", initial_publish, exponent, bytes_received_interval, &bytes_received_load15);
+			calc_load(db, buf, "$SYS/broker/load/bytes/sent/15min", initial_publish, exponent, bytes_sent_interval, &bytes_sent_load15);
+			calc_load(db, buf, "$SYS/broker/load/sockets/15min", initial_publish, exponent, socket_interval, &socket_load15);
+			calc_load(db, buf, "$SYS/broker/load/connections/15min", initial_publish, exponent, connection_interval, &connection_load15);
 		}
 
 		if(db->msg_store_count != msg_store_count){

--- a/test/broker/03-publish-qos1-queued-bytes.conf
+++ b/test/broker/03-publish-qos1-queued-bytes.conf
@@ -1,0 +1,4 @@
+sys_interval 1
+max_queued_messages 0
+max_queued_bytes 400
+port 1888

--- a/test/broker/03-publish-qos1-queued-bytes.py
+++ b/test/broker/03-publish-qos1-queued-bytes.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+# Test whether a PUBLISH to a topic with an offline subscriber results in a queued message
+import Queue
+import random
+import string
+import subprocess
+import socket
+import threading
+import time
+
+import paho.mqtt.client
+import paho.mqtt.publish
+
+
+import inspect, os, sys
+# From http://stackoverflow.com/questions/279237/python-import-a-module-from-a-folder
+cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"..")))
+if cmd_subfolder not in sys.path:
+    sys.path.insert(0, cmd_subfolder)
+
+import mosq_test
+
+rc = 1
+
+def registerOfflineSubscriber():
+    """Just a durable client to trigger queuing"""
+    client = paho.mqtt.client.Client("sub-qos1-offline", clean_session=False)
+    client.connect("localhost", port=1888)
+    client.subscribe("test/publish/queueing/#", 1)
+    client.loop()
+    client.disconnect()
+
+
+broker = mosq_test.start_broker(filename=os.path.basename(__file__))
+
+class BrokerMonitor(threading.Thread):
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None, verbose=None):
+        threading.Thread.__init__(self, group=group, target=target, name=name, verbose=verbose)
+        self.rq, self.cq = args
+        self.stored = -1
+        self.stored_bytes = -1
+        self.dropped = -1
+
+    def store_count(self, client, userdata, message):
+        self.stored = int(message.payload)
+
+    def store_bytes(self, client, userdata, message):
+        self.stored_bytes = int(message.payload)
+
+    def publish_dropped(self, client, userdata, message):
+        self.dropped = int(message.payload)
+
+    def run(self):
+        client = paho.mqtt.client.Client("broker-monitor")
+        client.connect("localhost", port=1888)
+        client.message_callback_add("$SYS/broker/store/messages/count", self.store_count)
+        client.message_callback_add("$SYS/broker/store/messages/bytes", self.store_bytes)
+        client.message_callback_add("$SYS/broker/publish/messages/dropped", self.publish_dropped)
+        client.subscribe("$SYS/broker/store/messages/#")
+        client.subscribe("$SYS/broker/publish/messages/dropped")
+
+        while True:
+            expect_drops = cq.get()
+            self.cq.task_done()
+            if expect_drops == "quit":
+                break
+            first = time.time()
+            while self.stored < 0 or self.stored_bytes < 0 or (expect_drops and self.dropped < 0):
+                client.loop(timeout=0.5)
+                if time.time() - 10 > first:
+                    print("ABORT TIMEOUT")
+                    break
+
+            if expect_drops:
+                self.rq.put((self.stored, self.stored_bytes, self.dropped))
+            else:
+                self.rq.put((self.stored, self.stored_bytes, 0))
+            self.stored = -1
+            self.stored_bytes = -1
+            self.dropped = -1
+
+        client.disconnect()
+
+rq = Queue.Queue()
+cq = Queue.Queue()
+brokerMonitor = BrokerMonitor(args=(rq,cq))
+
+class StoreCounts():
+    def __init__(self):
+        self.stored = 0
+        self.bstored = 0
+        self.drops = 0
+        self.diff_stored = 0
+        self.diff_bstored = 0
+        self.diff_drops = 0
+
+    def update(self, tup):
+        self.diff_stored = tup[0] - self.stored
+        self.stored = tup[0]
+        self.diff_bstored = tup[1] - self.bstored
+        self.bstored = tup[1]
+        self.diff_drops = tup[2] - self.drops
+        self.drops = tup[2]
+
+    def __repr__(self):
+        return "s: %d (%d) b: %d (%d) d: %d (%d)" % (self.stored, self.diff_stored, self.bstored, self.diff_bstored, self.drops, self.diff_drops)
+
+try:
+    registerOfflineSubscriber()
+    time.sleep(2.5)  # Wait for first proper dump of stats
+    brokerMonitor.start()
+    counts = StoreCounts()
+    cq.put(True)  # Expect a dropped count (of 0, initial)
+    counts.update(rq.get())  # Initial start
+    print("rq.get (INITIAL) gave us: ", counts)
+    rq.task_done()
+
+    # publish 10 short messages, should be no drops
+    print("publishing 10 short")
+    cq.put(False)  # expect no updated drop count
+    msgs_short10 = [("test/publish/queueing/%d" % x,
+             ''.join(random.choice(string.hexdigits) for _ in range(10)),
+             1, False) for x in range(1, 10 + 1)]
+    paho.mqtt.publish.multiple(msgs_short10, port=1888)
+    counts.update(rq.get())  # Initial start
+    print("rq.get (short) gave us: ", counts)
+    rq.task_done()
+    if counts.diff_stored != 10 or counts.diff_bstored < 100:
+        raise ValueError
+    if counts.diff_drops != 0:
+        raise ValueError
+
+    # publish 10 mediums (40bytes). should fail after 8, when it finally crosses 400
+    print("publishing 10 medium")
+    cq.put(True)  # expect a drop count
+    msgs_medium10 = [("test/publish/queueing/%d" % x,
+             ''.join(random.choice(string.hexdigits) for _ in range(40)),
+             1, False) for x in range(1, 10 + 1)]
+    paho.mqtt.publish.multiple(msgs_medium10, port=1888)
+    counts.update(rq.get())  # Initial start
+    print("rq.get (medium) gave us: ", counts)
+    rq.task_done()
+    if counts.diff_stored != 8 or counts.diff_bstored < 320:
+        raise ValueError
+    if counts.diff_drops != 2:
+        raise ValueError
+    rc = 0
+
+finally:
+    cq.put("quit")
+    brokerMonitor.join()
+    rq.join()
+    cq.join()
+    broker.terminate()
+    (stdo, stde) = broker.communicate()
+    if rc:
+        print(stde)
+
+exit(rc)
+

--- a/test/broker/Makefile
+++ b/test/broker/Makefile
@@ -48,6 +48,7 @@ endif
 	./03-publish-c2b-disconnect-qos2.py
 	./03-publish-b2c-disconnect-qos2.py
 	./03-pattern-matching.py
+	./03-publish-qos1-queued-bytes.py
 
 04 :
 	./04-retain-qos0.py

--- a/test/mosq_test.py
+++ b/test/mosq_test.py
@@ -306,7 +306,7 @@ def gen_connack(resv=0, rc=0):
 
 def gen_publish(topic, qos, payload=None, retain=False, dup=False, mid=0):
     rl = 2+len(topic)
-    pack_format = "!BBH"+str(len(topic))+"s"
+    pack_format = "H"+str(len(topic))+"s"
     if qos > 0:
         rl = rl + 2
         pack_format = pack_format + "H"
@@ -317,6 +317,7 @@ def gen_publish(topic, qos, payload=None, retain=False, dup=False, mid=0):
         payload = ""
         pack_format = pack_format + "0s"
 
+    rlpacked = pack_remaining_length(rl)
     cmd = 48 | (qos<<1)
     if retain:
         cmd = cmd + 1
@@ -324,9 +325,9 @@ def gen_publish(topic, qos, payload=None, retain=False, dup=False, mid=0):
         cmd = cmd + 8
 
     if qos > 0:
-        return struct.pack(pack_format, cmd, rl, len(topic), topic, mid, payload)
+        return struct.pack("!B" + str(len(rlpacked))+"s" + pack_format, cmd, rlpacked, len(topic), topic, mid, payload)
     else:
-        return struct.pack(pack_format, cmd, rl, len(topic), topic, payload)
+        return struct.pack("!B" + str(len(rlpacked))+"s" + pack_format, cmd, rlpacked, len(topic), topic, payload)
 
 def gen_puback(mid):
     return struct.pack('!BBH', 64, 2, mid)

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -10,3 +10,5 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 	brew update
 	brew install c-ares openssl libwebsockets
 fi
+
+sudo pip install paho-mqtt


### PR DESCRIPTION
First round draft for discussion:  Some of these pieces are independent, such as the test remaining_length fix, and the db_dump tweaks and can clearly be put into separate pull requests.  Three mains changes:
* broker stats on bytes stored, not just counts
* max_queued_bytes setting now (substantially easier to limit the memory consumed by each client)
* queue_qos0_messages fixed to not infinitely queue.

Questions:  

* Should max_inflight_bytes be documented out and user tunable?  Probably for consistency?
* I had to publish initial load average stats to make it sane for parsing the $SYS tree for testing.  It's still very hard to automatically test some of this, without access to the client level queue stats from the tests.  The broker bytes store is influenced not just by messages to clients, but by the specific sizes of $SYS messages as well!
* likewise, to make a test for sending multiple messages to offline subscribers, using the raw packet interface in mosq_test proved extremely unwieldy.  However, my new test adds a dependency on the paho.mqtt client packages as a downside.