### PR TITLE
Openssl engine support

### DIFF
--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -66,6 +66,8 @@ void client_config_cleanup(struct mosq_config *cfg)
 	free(cfg->keyfile);
 	free(cfg->ciphers);
 	free(cfg->tls_version);
+	free(cfg->tls_engine);
+	free(cfg->keyform);
 #  ifdef WITH_TLS_PSK
 	free(cfg->psk);
 	free(cfg->psk_identity);
@@ -223,6 +225,10 @@ int client_config_load(struct mosq_config *cfg, int pub_or_sub, int argc, char *
 		fprintf(stderr, "Error: Both certfile and keyfile must be provided if one of them is.\n");
 		return 1;
 	}
+	if((cfg->keyform && !cfg->keyfile)){
+		fprintf(stderr, "Error: keyfile must be specified if keyform is.\n");
+		return 1;
+	}
 #endif
 #ifdef WITH_TLS_PSK
 	if((cfg->cafile || cfg->capath) && cfg->psk){
@@ -339,6 +345,14 @@ int client_config_line_proc(struct mosq_config *cfg, int pub_or_sub, int argc, c
 				cfg->ciphers = strdup(argv[i+1]);
 			}
 			i++;
+		}else if(!strcmp(argv[i], "--tls-engine")){
+			if(i==argc-1){
+				fprintf(stderr, "Error: --tls-engine argument given but no engine_id specified.\n\n");
+				return 1;
+			}else{
+				cfg->tls_engine = strdup(argv[i+1]);
+			}
+			i++;
 #endif
 		}else if(!strcmp(argv[i], "-C")){
 			if(pub_or_sub == CLIENT_PUB){
@@ -430,6 +444,14 @@ int client_config_line_proc(struct mosq_config *cfg, int pub_or_sub, int argc, c
 				return 1;
 			}else{
 				cfg->keyfile = strdup(argv[i+1]);
+			}
+			i++;
+		}else if(!strcmp(argv[i], "--keyform")){
+			if(i==argc-1){
+				fprintf(stderr, "Error: --keyform argument given but no keyform specified.\n\n");
+				return 1;
+			}else{
+				cfg->keyform = strdup(argv[i+1]);
 			}
 			i++;
 #endif
@@ -793,6 +815,16 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 	}
 	if(cfg->insecure && mosquitto_tls_insecure_set(mosq, true)){
 		if(!cfg->quiet) fprintf(stderr, "Error: Problem setting TLS insecure option.\n");
+		mosquitto_lib_cleanup();
+		return 1;
+	}
+	if(cfg->tls_engine && mosquitto_tls_engine_set(mosq, cfg->tls_engine)){
+		if(!cfg->quiet) fprintf(stderr, "Error: Problem setting TLS engine.\n");
+		mosquitto_lib_cleanup();
+		return 1;
+	}
+	if(cfg->keyform && mosquitto_tls_keyform_set(mosq, cfg->keyform)){
+		if(!cfg->quiet) fprintf(stderr, "Error: Problem setting keyform.\n");
 		mosquitto_lib_cleanup();
 		return 1;
 	}

--- a/client/client_shared.h
+++ b/client/client_shared.h
@@ -66,6 +66,8 @@ struct mosq_config {
 	char *ciphers;
 	bool insecure;
 	char *tls_version;
+	char *tls_engine;
+	char *keyform;
 #  ifdef WITH_TLS_PSK
 	char *psk;
 	char *psk_identity;

--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -220,7 +220,8 @@ void print_usage(void)
 	printf("                     [--will-topic [--will-payload payload] [--will-qos qos] [--will-retain]]\n");
 #ifdef WITH_TLS
 	printf("                     [{--cafile file | --capath dir} [--cert file] [--key file]\n");
-	printf("                      [--ciphers ciphers] [--insecure]]\n");
+	printf("                      [--ciphers ciphers] [--insecure] [--tls-engine engine]\n");
+	printf("                      [--keyform keyform]]\n");
 #ifdef WITH_TLS_PSK
 	printf("                     [--psk hex-key --psk-identity identity [--ciphers ciphers]]\n");
 #endif
@@ -271,6 +272,7 @@ void print_usage(void)
 	printf("            communication.\n");
 	printf(" --cert : client certificate for authentication, if required by server.\n");
 	printf(" --key : client private key for authentication, if required by server.\n");
+	printf(" --keyform : keyfile type, can be one of pem or engine.\n");
 	printf(" --ciphers : openssl compatible list of TLS ciphers to support.\n");
 	printf(" --tls-version : TLS protocol version, can be one of tlsv1.2 tlsv1.1 or tlsv1.\n");
 	printf("                 Defaults to tlsv1.2 if available.\n");
@@ -278,6 +280,7 @@ void print_usage(void)
 	printf("              hostname. Using this option means that you cannot be sure that the\n");
 	printf("              remote host is the server you wish to connect to and so is insecure.\n");
 	printf("              Do not use this option in a production environment.\n");
+	printf(" --tls-engine : toggles the usage of a SSL engine device.\n");
 #  ifdef WITH_TLS_PSK
 	printf(" --psk : pre-shared-key in hexadecimal (no leading 0x) to enable TLS-PSK mode.\n");
 	printf(" --psk-identity : client identity string for TLS-PSK mode.\n");

--- a/client/sub_client.c
+++ b/client/sub_client.c
@@ -164,7 +164,8 @@ void print_usage(void)
 	printf("                     [--will-topic [--will-payload payload] [--will-qos qos] [--will-retain]]\n");
 #ifdef WITH_TLS
 	printf("                     [{--cafile file | --capath dir} [--cert file] [--key file]\n");
-	printf("                      [--ciphers ciphers] [--insecure]]\n");
+	printf("                      [--ciphers ciphers] [--insecure] [--tls-engine engine]\n");
+	printf("                      [--keyform keyform]]\n");
 #ifdef WITH_TLS_PSK
 	printf("                     [--psk hex-key --psk-identity identity [--ciphers ciphers]]\n");
 #endif
@@ -218,6 +219,7 @@ void print_usage(void)
 	printf("            communication.\n");
 	printf(" --cert : client certificate for authentication, if required by server.\n");
 	printf(" --key : client private key for authentication, if required by server.\n");
+	printf(" --keyform : keyfile type, can be one of pem or engine.\n");
 	printf(" --ciphers : openssl compatible list of TLS ciphers to support.\n");
 	printf(" --tls-version : TLS protocol version, can be one of tlsv1.2 tlsv1.1 or tlsv1.\n");
 	printf("                 Defaults to tlsv1.2 if available.\n");
@@ -225,6 +227,7 @@ void print_usage(void)
 	printf("              hostname. Using this option means that you cannot be sure that the\n");
 	printf("              remote host is the server you wish to connect to and so is insecure.\n");
 	printf("              Do not use this option in a production environment.\n");
+	printf(" --tls-engine : toggles the usage of a SSL engine device.\n");
 #ifdef WITH_TLS_PSK
 	printf(" --psk : pre-shared-key in hexadecimal (no leading 0x) to enable TLS-PSK mode.\n");
 	printf(" --psk-identity : client identity string for TLS-PSK mode.\n");

--- a/lib/cpp/mosquittopp.cpp
+++ b/lib/cpp/mosquittopp.cpp
@@ -362,4 +362,14 @@ int mosquittopp::tls_psk_set(const char *psk, const char *identity, const char *
 	return mosquitto_tls_psk_set(m_mosq, psk, identity, ciphers);
 }
 
+int mosquittopp::tls_engine_set(const char *engine_id)
+{
+   return mosquitto_tls_engine_set(m_mosq, engine_id);
+}
+
+int mosquittopp::tls_keyform_set(const char *keyform)
+{
+   return mosquitto_tls_keyform_set(m_mosq, keyform);
+}
+
 }

--- a/lib/cpp/mosquittopp.h
+++ b/lib/cpp/mosquittopp.h
@@ -110,6 +110,8 @@ class mosqpp_EXPORT mosquittopp {
 		int tls_opts_set(int cert_reqs, const char *tls_version=NULL, const char *ciphers=NULL);
 		int tls_insecure_set(bool value);
 		int tls_psk_set(const char *psk, const char *identity, const char *ciphers=NULL);
+		int tls_engine_set(const char *engine_id);
+		int tls_keyform_set(const char *keyform);
 		int opts_set(enum mosq_opt_t option, void *value);
 
 		int loop(int timeout=-1, int max_packets=1);

--- a/lib/linker.version
+++ b/lib/linker.version
@@ -44,6 +44,8 @@ MOSQ_1.0 {
 		mosquitto_tls_set;
 		mosquitto_tls_opts_set;
 		mosquitto_tls_psk_set;
+		mosquitto_tls_engine_set;
+		mosquitto_tls_keyform_set;
 		mosquitto_sub_topic_tokenise;
 		mosquitto_sub_topic_tokens_free;
 		mosquitto_topic_matches_sub;

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -777,6 +777,45 @@ int mosquitto_tls_insecure_set(struct mosquitto *mosq, bool value)
 }
 
 
+int mosquitto_tls_engine_set(struct mosquitto *mosq, const char *engine_id)
+{
+#ifdef WITH_TLS
+	if(!mosq) return MOSQ_ERR_INVAL;
+	ENGINE *e = ENGINE_by_id(engine_id);
+	if (!e)
+		return MOSQ_ERR_INVAL;
+	/* Release the structural reference from ENGINE_by_id() */
+	ENGINE_free(e);
+	mosq->tls_engine = mosquitto__strdup(engine_id);
+	return MOSQ_ERR_SUCCESS;
+#else
+	return MOSQ_ERR_NOT_SUPPORTED;
+#endif
+}
+
+
+int mosquitto_tls_keyform_set(struct mosquitto *mosq, const char *keyform)
+{
+#ifdef WITH_TLS
+	if(!mosq) return MOSQ_ERR_INVAL;
+
+	if (keyform){
+		if(!strcasecmp(keyform, "pem"))
+			mosq->tls_keyform = mosq_k_pem;
+		else if (!strcasecmp(keyform, "engine"))
+			mosq->tls_keyform = mosq_k_engine;
+		else
+			return MOSQ_ERR_INVAL;
+	}else{
+		mosq->tls_keyform = mosq_k_pem;
+	}
+	return MOSQ_ERR_SUCCESS;
+#else
+	return MOSQ_ERR_NOT_SUPPORTED;
+#endif
+}
+
+
 int mosquitto_tls_psk_set(struct mosquitto *mosq, const char *psk, const char *identity, const char *ciphers)
 {
 #ifdef REAL_WITH_TLS_PSK

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -1105,6 +1105,44 @@ libmosq_EXPORT int mosquitto_tls_opts_set(struct mosquitto *mosq, int cert_reqs,
  */
 libmosq_EXPORT int mosquitto_tls_psk_set(struct mosquitto *mosq, const char *psk, const char *identity, const char *ciphers);
 
+/*
+ * Function: mosquitto_tls_engine_set
+ *
+ * Configure the client for TLS engine support. Must be called
+ * before <mosquitto_connect>.
+ *
+ * Parameters:
+ *  mosq -       a valid mosquitto instance.
+ *  engine_id - the engine ID that wants to be used.
+ *
+ * Returns:
+ *  MOSQ_ERR_SUCCESS - on success.
+ *  MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ *
+ * See Also:
+ * <mosquitto_tls_set>
+ */
+libmosq_EXPORT int mosquitto_tls_engine_set(struct mosquitto *mosq, const char *engine_id);
+
+/*
+ * Function: mosquitto_tls_keyform_set
+ *
+ * Configure the client to treat the keyfile differently depending on its type.
+ * Must be called before <mosquitto_connect>.
+ *
+ * Parameters:
+ *  mosq -    a valid mosquitto instance.
+ *  keyform - the key type. Currently only "pem" or "engine" are supported.
+ *
+ * Returns:
+ *  MOSQ_ERR_SUCCESS - on success.
+ *  MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ *
+ * See Also:
+ * <mosquitto_tls_set>
+ */
+libmosq_EXPORT int mosquitto_tls_keyform_set(struct mosquitto *mosq, const char *keyform);
+
 /* 
  * Function: mosquitto_connect_callback_set
  *

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -147,6 +147,13 @@ struct mosquitto_message_all{
 	struct mosquitto_message msg;
 };
 
+#ifdef WITH_TLS
+enum _mosquitto_keyform {
+	mosq_k_pem = 0,
+	mosq_k_engine = 1,
+};
+#endif
+
 struct mosquitto {
 	mosq_sock_t sock;
 #ifndef WITH_BROKER
@@ -181,6 +188,8 @@ struct mosquitto {
 	char *tls_psk_identity;
 	int tls_cert_reqs;
 	bool tls_insecure;
+	char *tls_engine;
+	enum _mosquitto_keyform tls_keyform;
 #endif
 	bool want_write;
 	bool want_connect;

--- a/lib/net_mosq.h
+++ b/lib/net_mosq.h
@@ -68,6 +68,8 @@ ssize_t net__write(struct mosquitto *mosq, void *buf, size_t count);
 #ifdef WITH_TLS
 int net__socket_apply_tls(struct mosquitto *mosq);
 int net__socket_connect_tls(struct mosquitto *mosq);
+UI_METHOD *net__get_ui_method(void);
+#define ENGINE_REF_FREE(e) if(e) ENGINE_free(e)
 #endif
 
 #endif

--- a/lib/tls_mosq.h
+++ b/lib/tls_mosq.h
@@ -26,6 +26,7 @@ Contributors:
 #ifdef WITH_TLS
 
 #include <openssl/ssl.h>
+#include <openssl/engine.h>
 #ifdef WITH_TLS_PSK
 #  if OPENSSL_VERSION_NUMBER >= 0x10000000
 #    define REAL_WITH_TLS_PSK

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -783,6 +783,22 @@
 					</listitem>
 				</varlistentry>
 				<varlistentry>
+					<term><option>tls_engine</option> <replaceable>engine</replaceable></term>
+					<listitem>
+						<para>A valid openssl engine id. These can be listed with
+						openssl engine command.</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term><option>tls_keyform</option> [ pem |	engine ]</term>
+					<listitem>
+						<para>Specifies the type of key in use. This could be pem or
+						engine. This parameter is useful for example when a TPM
+						module is being used and the key has been created with
+						it. If not specified, pem keys are assumed</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
 					<term><option>crlfile</option> <replaceable>file path</replaceable></term>
 					<listitem>
 						<para>If you have <option>require_certificate</option>

--- a/man/mosquitto_pub.1.xml
+++ b/man/mosquitto_pub.1.xml
@@ -61,6 +61,12 @@
 					<arg><option>--key</option> <replaceable>file</replaceable></arg>
 					<arg><option>--ciphers</option> <replaceable>ciphers</replaceable></arg>
 					<arg><option>--tls-version</option> <replaceable>version</replaceable></arg>
+					<arg><option>--tls-engine</option> <replaceable>engine</replaceable></arg>
+					<arg><option>--keyform</option>
+					<group choice='req'>
+						<arg choice='plain'><replaceable>pem</replaceable></arg>
+						<arg choice='plain'><replaceable>engine</replaceable></arg>
+					</group></arg>
 					<arg><option>--insecure</option></arg>
 				</arg>
 				<arg>
@@ -151,6 +157,24 @@
 						in the client. See
 						<citerefentry><refentrytitle>ciphers</refentrytitle><manvolnum>1</manvolnum></citerefentry>
 						for more information.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><option>--tls-engine</option></term>
+				<listitem>
+					<para>A valid openssl engine id. These can be listed with
+						openssl engine command.</para>
+					<para>See also <option>--keyform</option>.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><option>--keyform</option></term>
+				<listitem>
+					<para>Specifies the type of key in use. This could be pem or
+						engine. This parameter is useful for example when a TPM
+						module is being used and the key has been created with
+						it. If not specified, pem keys are assumed</para>
+					<para>See also <option>--tls-engine</option>.</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>

--- a/man/mosquitto_sub.1.xml
+++ b/man/mosquitto_sub.1.xml
@@ -64,6 +64,12 @@
 					<arg><option>--cert</option> <replaceable>file</replaceable></arg>
 					<arg><option>--key</option> <replaceable>file</replaceable></arg>
 					<arg><option>--tls-version</option> <replaceable>version</replaceable></arg>
+					<arg><option>--tls-engine</option> <replaceable>engine</replaceable></arg>
+					<arg><option>--keyform</option>
+					<group choice='req'>
+						<arg choice='plain'><replaceable>pem</replaceable></arg>
+						<arg choice='plain'><replaceable>engine</replaceable></arg>
+					</group></arg>
 					<arg><option>--insecure</option></arg>
 				</arg>
 				<arg>
@@ -174,6 +180,24 @@
 						in the client. See
 						<citerefentry><refentrytitle>ciphers</refentrytitle><manvolnum>1</manvolnum></citerefentry>
 						for more information.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><option>--tls-engine</option></term>
+				<listitem>
+					<para>A valid openssl engine id. These can be listed with
+						openssl engine command.</para>
+					<para>See also <option>--keyform</option>.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><option>--keyform</option></term>
+				<listitem>
+					<para>Specifies the type of key in use. This could be pem or
+						engine. This parameter is useful for example when a TPM
+						module is being used and the key has been created with
+						it. If not specified, pem keys are assumed</para>
+					<para>See also <option>--tls-engine</option>.</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>

--- a/src/mosquitto_broker.h
+++ b/src/mosquitto_broker.h
@@ -157,6 +157,8 @@ struct mosquitto__listener {
 	char *capath;
 	char *certfile;
 	char *keyfile;
+	char *tls_engine;
+	enum _mosquitto_keyform tls_keyform;
 	char *ciphers;
 	char *psk_hint;
 	bool require_certificate;


### PR DESCRIPTION
These two commits enable OpenSSL engine support on both libmosquitto and broker code paths. 

An OpenSSL engine can be used to offload CPU intensive cryptographic operations to a dedicated hardware. The main goal behind these patches though is to being able to access to a TPM module (Trusted Platform Module) from mosquitto clients. 

Taken from the Wikipedia

> Trusted Platform Module (TPM) is an international standard for a secure cryptoprocessor, which is a dedicated microcontroller designed to secure hardware by integrating cryptographic keys into devices. TPM's technical specification was written by a computer industry consortium called Trusted Computing Group (TCG). International Organization for Standardization (ISO) and International Electrotechnical Commission (IEC) standardized the specification as ISO/IEC 11889 in 2009

The patches add two new options to libmosquitto and mosquitto.conf.
- **tls-engine**: specifies the ID of the OpenSSL engine to be used. These can be listed by running `openssl engine -t`
- **keyform**: specifies the key format. It can be pem (default) or engine.

All existent tests are still passing but no new ones have been added. The setup I've used to test the patches is quite complex and didn't think it would be a good idea to incorporate it as an automated test. It involves using a [TPM emulator](https://github.com/PeterHuewe/tpm-emulator), [TrouSerS](http://trousers.sourceforge.net/) and an [OpenSSL TPM engine](https://sourceforge.net/projects/trousers/files/OpenSSL%20TPM%20Engine). I have a detailed guide of how to set it up and the results I got in case you are wondering. 

Nico.
