### PR TITLE
websockets: fix compile fail after refactoring

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -200,7 +200,7 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				return -1;
 			}
 
-			mqtt3_db_message_write(db, mosq);
+			db__message_write(db, mosq);
 
 			if(mosq->out_packet && !mosq->current_out_packet){
 				mosq->current_out_packet = mosq->out_packet;


### PR DESCRIPTION
A lot of function renaming was done in 663d50a0168bfdce98473265fdcece364600340f,
and this websockets patch was merged afterwards.  Autobuild testing
doesn't have websockets enabled, and missed this.

Fixes: d9142c3974be0ef6d4bc3a0aef762f8a7d8e1f32
Signed-off-by: Karl Palsson <karlp@etactica.com>