### PR TITLE
Add pkg-config files to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if (WIN32)
 	set (DATAROOTDIR share)
 	set (MANDIR man)
 	set (SHAREDEST .)
+	set (PKGCONFIGDIR "${LIBDIR}/pkgconfig")
 	add_definitions("-D_CRT_SECURE_NO_WARNINGS")
 	add_definitions("-D_CRT_NONSTDC_NO_DEPRECATE")
 else (WIN32)
@@ -49,6 +50,7 @@ else (WIN32)
 	set (DATAROOTDIR share)
 	set (MANDIR "${DATAROOTDIR}/man")
 	set (SHAREDIR "${DATAROOTDIR}/mosquitto")
+	set (PKGCONFIGDIR "${LIBDIR}/pkgconfig")
 endif (WIN32)
 
 option(WITH_TLS
@@ -97,6 +99,16 @@ endif (${DOCUMENTATION} STREQUAL ON)
 # ========================================
 
 install(FILES mosquitto.conf aclfile.example pskfile.example pwfile.example DESTINATION "${SYSCONFDIR}")
+
+
+# ========================================
+# Install pkg-config files
+# ========================================
+
+configure_file(libmosquitto.pc.in libmosquitto.pc @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libmosquitto.pc" DESTINATION "${PKGCONFIGDIR}")
+configure_file(libmosquittopp.pc.in libmosquittopp.pc @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libmosquittopp.pc" DESTINATION "${PKGCONFIGDIR}")
 
 # ========================================
 # Testing

--- a/libmosquitto.pc.in
+++ b/libmosquitto.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: mosquitto
+Description: mosquitto MQTT library (C bindings)
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmosquitto

--- a/libmosquittopp.pc.in
+++ b/libmosquittopp.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: mosquittopp
+Description: mosquitto MQTT library (C++ bindings)
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmosquittopp


### PR DESCRIPTION
This patch adds pkg-config files for libmosquitto and libmosquittopp,
and installs them through CMake.

Refs #107