### PR TITLE
Add extra-verbose option to mosquitto_sub

### DIFF
--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -749,6 +749,11 @@ int client_config_line_proc(struct mosq_config *cfg, int pub_or_sub, int argc, c
 				goto unknown_option;
 			}
 			cfg->verbose = 1;
+		}else if(!strcmp(argv[i], "-vv") || !strcmp(argv[i], "--extra-verbose")){
+			if(pub_or_sub == CLIENT_PUB){
+				goto unknown_option;
+			}
+			cfg->verbose = 2;
 		}else if(!strcmp(argv[i], "-x")){
 			if(pub_or_sub == CLIENT_PUB){
 				goto unknown_option;

--- a/client/client_shared.h
+++ b/client/client_shared.h
@@ -80,7 +80,7 @@ struct mosq_config {
 	int filter_out_count; /* sub */
 	char **unsub_topics; /* sub */
 	int unsub_topic_count; /* sub */
-	bool verbose; /* sub */
+	int verbose; /* sub */
 	bool eol; /* sub */
 	bool hex_output; /* sub */
 	int msg_count; /* sub */

--- a/client/sub_client.c
+++ b/client/sub_client.c
@@ -19,6 +19,8 @@ Contributors:
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
+#include <time.h>
 #ifndef WIN32
 #include <unistd.h>
 #else
@@ -49,6 +51,9 @@ static void write_payload(const unsigned char *payload, int payloadlen, bool hex
 void my_message_callback(struct mosquitto *mosq, void *obj, const struct mosquitto_message *message)
 {
 	struct mosq_config *cfg;
+	struct tm *tm;
+	char date[32];
+	struct timeval tv;
 	int i;
 	bool res;
 
@@ -72,6 +77,12 @@ void my_message_callback(struct mosquitto *mosq, void *obj, const struct mosquit
 	}
 
 	if(cfg->verbose){
+		if(cfg->verbose > 1){
+			gettimeofday(&tv, NULL);
+			tm = localtime(&tv.tv_sec);
+			strftime(date, sizeof(date), "%F %T", tm);
+			printf("[%s.%06lu] ", date, tv.tv_usec);
+		}
 		if(message->payloadlen){
 			printf("%s ", message->topic);
 			write_payload(message->payload, message->payloadlen, cfg->hex_output);
@@ -198,6 +209,7 @@ void print_usage(void)
 	printf(" -u : provide a username (requires MQTT 3.1 broker)\n");
 	printf(" -U : unsubscribe from a topic. May be repeated.\n");
 	printf(" -v : print published messages verbosely.\n");
+	printf(" -vv : same as -v but also prints a timestamp of when the message was received.\n");
 	printf(" -V : specify the version of the MQTT protocol to use when connecting.\n");
 	printf("      Can be mqttv31 or mqttv311. Defaults to mqttv31.\n");
 	printf(" -x : print published message payloads as hexadecimal data.\n");


### PR DESCRIPTION
This very simple patch adds an extra-verbose option to mosquitto_sub that prints out the timestamp of when a message was received.

I've dealt with this in the past by piping mosquitto_sub's output into a Perl script to append a timestamp to each line (message) and I thought it would be a good idea to have it in as part of the client.

Nico.