### PR TITLE
Add TLS server name indication (SNI) support

### DIFF
--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -65,6 +65,7 @@ void client_config_cleanup(struct mosq_config *cfg)
 	free(cfg->certfile);
 	free(cfg->keyfile);
 	free(cfg->ciphers);
+	free(cfg->server_name);
 	free(cfg->tls_version);
 #  ifdef WITH_TLS_PSK
 	free(cfg->psk);
@@ -337,6 +338,14 @@ int client_config_line_proc(struct mosq_config *cfg, int pub_or_sub, int argc, c
 				return 1;
 			}else{
 				cfg->ciphers = strdup(argv[i+1]);
+			}
+			i++;
+		}else if(!strcmp(argv[i], "--server-name")){
+			if(i==argc-1){
+				fprintf(stderr, "Error: --server-name argument given but no server name specified.\n\n");
+				return 1;
+			}else{
+				cfg->server_name = strdup(argv[i+1]);
 			}
 			i++;
 #endif
@@ -788,6 +797,11 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 			&& mosquitto_tls_set(mosq, cfg->cafile, cfg->capath, cfg->certfile, cfg->keyfile, NULL)){
 
 		if(!cfg->quiet) fprintf(stderr, "Error: Problem setting TLS options.\n");
+		mosquitto_lib_cleanup();
+		return 1;
+	}
+	if((cfg->server_name) && mosquitto_tls_server_name_set(mosq, cfg->server_name)){
+		if(!cfg->quiet) fprintf(stderr, "Error: Problem setting TLS server name.\n");
 		mosquitto_lib_cleanup();
 		return 1;
 	}

--- a/client/client_shared.h
+++ b/client/client_shared.h
@@ -64,6 +64,7 @@ struct mosq_config {
 	char *certfile;
 	char *keyfile;
 	char *ciphers;
+	char *server_name;
 	bool insecure;
 	char *tls_version;
 #  ifdef WITH_TLS_PSK

--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -220,7 +220,7 @@ void print_usage(void)
 	printf("                     [--will-topic [--will-payload payload] [--will-qos qos] [--will-retain]]\n");
 #ifdef WITH_TLS
 	printf("                     [{--cafile file | --capath dir} [--cert file] [--key file]\n");
-	printf("                      [--ciphers ciphers] [--insecure]]\n");
+	printf("                      [--ciphers ciphers] [--server-name server name] [--insecure]]\n");
 #ifdef WITH_TLS_PSK
 	printf("                     [--psk hex-key --psk-identity identity [--ciphers ciphers]]\n");
 #endif
@@ -272,6 +272,7 @@ void print_usage(void)
 	printf(" --cert : client certificate for authentication, if required by server.\n");
 	printf(" --key : client private key for authentication, if required by server.\n");
 	printf(" --ciphers : openssl compatible list of TLS ciphers to support.\n");
+	printf(" --server-name : server name indication (SNI).\n");
 	printf(" --tls-version : TLS protocol version, can be one of tlsv1.2 tlsv1.1 or tlsv1.\n");
 	printf("                 Defaults to tlsv1.2 if available.\n");
 	printf(" --insecure : do not check that the server certificate hostname matches the remote\n");

--- a/client/sub_client.c
+++ b/client/sub_client.c
@@ -164,7 +164,7 @@ void print_usage(void)
 	printf("                     [--will-topic [--will-payload payload] [--will-qos qos] [--will-retain]]\n");
 #ifdef WITH_TLS
 	printf("                     [{--cafile file | --capath dir} [--cert file] [--key file]\n");
-	printf("                      [--ciphers ciphers] [--insecure]]\n");
+	printf("                      [--ciphers ciphers] [--server-name server name] [--insecure]]\n");
 #ifdef WITH_TLS_PSK
 	printf("                     [--psk hex-key --psk-identity identity [--ciphers ciphers]]\n");
 #endif
@@ -219,6 +219,7 @@ void print_usage(void)
 	printf(" --cert : client certificate for authentication, if required by server.\n");
 	printf(" --key : client private key for authentication, if required by server.\n");
 	printf(" --ciphers : openssl compatible list of TLS ciphers to support.\n");
+	printf(" --server-name : server name indication (SNI).\n");
 	printf(" --tls-version : TLS protocol version, can be one of tlsv1.2 tlsv1.1 or tlsv1.\n");
 	printf("                 Defaults to tlsv1.2 if available.\n");
 	printf(" --insecure : do not check that the server certificate hostname matches the remote\n");

--- a/lib/cpp/mosquittopp.cpp
+++ b/lib/cpp/mosquittopp.cpp
@@ -352,6 +352,11 @@ int mosquittopp::tls_opts_set(int cert_reqs, const char *tls_version, const char
 	return mosquitto_tls_opts_set(m_mosq, cert_reqs, tls_version, ciphers);
 }
 
+int mosquittopp::tls_server_name_set(const char *server_name)
+{
+	return mosquitto_tls_server_name_set(m_mosq, server_name);
+}
+
 int mosquittopp::tls_insecure_set(bool value)
 {
 	return mosquitto_tls_insecure_set(m_mosq, value);

--- a/lib/cpp/mosquittopp.h
+++ b/lib/cpp/mosquittopp.h
@@ -108,6 +108,7 @@ class mosqpp_EXPORT mosquittopp {
 		void user_data_set(void *userdata);
 		int tls_set(const char *cafile, const char *capath=NULL, const char *certfile=NULL, const char *keyfile=NULL, int (*pw_callback)(char *buf, int size, int rwflag, void *userdata)=NULL);
 		int tls_opts_set(int cert_reqs, const char *tls_version=NULL, const char *ciphers=NULL);
+		int tls_server_name_set(const char *server_name);
 		int tls_insecure_set(bool value);
 		int tls_psk_set(const char *psk, const char *identity, const char *ciphers=NULL);
 		int opts_set(enum mosq_opt_t option, void *value);

--- a/lib/linker.version
+++ b/lib/linker.version
@@ -85,4 +85,5 @@ MOSQ_1.5 {
 		mosquitto_subscribe_callback;
 		mosquitto_message_free_contents;
 		mosquitto_validate_utf8;
+		mosquitto_tls_server_name_set;
 } MOSQ_1.4;

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -198,6 +198,7 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_se
 #ifdef WITH_TLS
 	mosq->ssl = NULL;
 	mosq->tls_cert_reqs = SSL_VERIFY_PEER;
+	mosq->tls_server_name = NULL;
 	mosq->tls_insecure = false;
 	mosq->want_write = false;
 #endif
@@ -309,6 +310,7 @@ void mosquitto__destroy(struct mosquitto *mosq)
 	mosquitto__free(mosq->tls_capath);
 	mosquitto__free(mosq->tls_certfile);
 	mosquitto__free(mosq->tls_keyfile);
+	mosquitto__free(mosq->tls_server_name);
 	if(mosq->tls_pw_callback) mosq->tls_pw_callback = NULL;
 	mosquitto__free(mosq->tls_version);
 	mosquitto__free(mosq->tls_ciphers);
@@ -761,6 +763,19 @@ int mosquitto_tls_opts_set(struct mosquitto *mosq, int cert_reqs, const char *tl
 #else
 	return MOSQ_ERR_NOT_SUPPORTED;
 
+#endif
+}
+
+
+int mosquitto_tls_server_name_set(struct mosquitto *mosq, const char *server_name)
+{
+#ifdef WITH_TLS
+	if(!mosq) return MOSQ_ERR_INVAL;
+	if(mosq->tls_server_name) mosquitto__free(mosq->tls_server_name);
+	mosq->tls_server_name = mosquitto__strdup(server_name);
+	return MOSQ_ERR_SUCCESS;
+#else
+	return MOSQ_ERR_NOT_SUPPORTED;
 #endif
 }
 

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -1018,6 +1018,25 @@ libmosq_EXPORT int mosquitto_tls_set(struct mosquitto *mosq,
 		int (*pw_callback)(char *buf, int size, int rwflag, void *userdata));
 
 /*
+ * Function: mosquitto_tls_server_name_set
+ *
+ * Configure the client to use SNI (server name indication). Must be called
+ * before <mosquitto_connect>.
+ *
+ * Parameters:
+ *  mosq -        a valid mosquitto instance.
+ *  server_name - the server name indication (SNI) to use during TLS handshake
+ *
+ * Returns:
+ *	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ *
+ * See Also:
+ *	<mosquitto_tls_set>
+ */
+libmosq_EXPORT int mosquitto_tls_server_name_set(struct mosquitto *mosq, const char *server_name);
+
+/*
  * Function: mosquitto_tls_insecure_set
  *
  * Configure verification of the server hostname in the server certificate. If

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -175,6 +175,7 @@ struct mosquitto {
 	char *tls_certfile;
 	char *tls_keyfile;
 	int (*tls_pw_callback)(char *buf, int size, int rwflag, void *userdata);
+	char *tls_server_name;
 	char *tls_version;
 	char *tls_ciphers;
 	char *tls_psk;

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -498,6 +498,18 @@ int net__socket_connect(struct mosquitto *mosq, const char *host, uint16_t port,
 			net__print_ssl_error(mosq);
 			return MOSQ_ERR_TLS;
 		}
+		if(mosq->tls_server_name){
+			ret = SSL_set_tlsext_host_name(mosq->ssl, mosq->tls_server_name);
+			if(ret != 1){
+#ifdef WITH_BROKER
+				log__printf(mosq, MOSQ_LOG_ERR, "Error: Unable to set server name, check bridge_server_name \"%s\".", mosq->tls_server_name);
+#else
+				log__printf(mosq, MOSQ_LOG_ERR, "Error: Unable to set server name \"%s\".", mosq->tls_server_name);
+#endif
+				COMPAT_CLOSE(sock);
+				return MOSQ_ERR_TLS;
+			}
+		}
 		SSL_set_ex_data(mosq->ssl, tls_ex_index_mosq, mosq);
 		bio = BIO_new_socket(sock, BIO_NOCLOSE);
 		if(!bio){

--- a/man/libmosquitto.3.xml
+++ b/man/libmosquitto.3.xml
@@ -113,6 +113,11 @@
 					<paramdef>const char *<parameter>ciphers</parameter></paramdef>
 			</funcprototype></funcsynopsis>
 
+			<funcsynopsis><funcprototype><funcdef>int <function>mosquitto_tls_server_name_set</function></funcdef>
+					<paramdef>struct mosquitto *<parameter>mosq</parameter></paramdef>
+					<paramdef>const char *<parameter>server_name</parameter></paramdef>
+			</funcprototype></funcsynopsis>
+
 			<funcsynopsis><funcprototype><funcdef>int <function>mosquitto_tls_insecure_set</function></funcdef>
 					<paramdef>struct mosquitto *<parameter>mosq</parameter></paramdef>
 					<paramdef>bool <parameter>value</parameter></paramdef>

--- a/man/mosquitto_pub.1.xml
+++ b/man/mosquitto_pub.1.xml
@@ -60,6 +60,7 @@
 					<arg><option>--cert</option> <replaceable>file</replaceable></arg>
 					<arg><option>--key</option> <replaceable>file</replaceable></arg>
 					<arg><option>--ciphers</option> <replaceable>ciphers</replaceable></arg>
+					<arg><option>--server-name</option> <replaceable>server name</replaceable></arg>
 					<arg><option>--tls-version</option> <replaceable>version</replaceable></arg>
 					<arg><option>--insecure</option></arg>
 				</arg>
@@ -151,6 +152,12 @@
 						in the client. See
 						<citerefentry><refentrytitle>ciphers</refentrytitle><manvolnum>1</manvolnum></citerefentry>
 						for more information.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><option>--server-name</option></term>
+				<listitem>
+					<para>Server name indication (SNI).</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>

--- a/man/mosquitto_sub.1.xml
+++ b/man/mosquitto_sub.1.xml
@@ -177,6 +177,12 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
+				<term><option>--server-name</option></term>
+				<listitem>
+					<para>Server name indication (SNI).</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
 				<term><option>-C</option></term>
 				<listitem>
 					<para>Disconnect and exit the program immediately after

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -81,6 +81,7 @@ int bridge__new(struct mosquitto_db *db, struct mosquitto__bridge *bridge)
 	new_context->tls_keyfile = new_context->bridge->tls_keyfile;
 	new_context->tls_cert_reqs = SSL_VERIFY_PEER;
 	new_context->tls_version = new_context->bridge->tls_version;
+	new_context->tls_server_name = new_context->bridge->tls_server_name;
 	new_context->tls_insecure = new_context->bridge->tls_insecure;
 #ifdef REAL_WITH_TLS_PSK
 	new_context->tls_psk_identity = new_context->bridge->tls_psk_identity;

--- a/src/conf.c
+++ b/src/conf.c
@@ -830,6 +830,17 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 #else
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge and/or TLS support not available.");
 #endif
+				}else if(!strcmp(token, "bridge_server_name")){
+#if defined(WITH_BRIDGE) && defined(WITH_TLS)
+					if(reload) continue; // FIXME
+					if(!cur_bridge){
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge configuration.");
+						return MOSQ_ERR_INVAL;
+					}
+					if(conf__parse_string(&token, "bridge_server_name", &cur_bridge->tls_server_name, saveptr)) return MOSQ_ERR_INVAL;
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge and/or TLS support not available.");
+#endif
 				}else if(!strcmp(token, "bridge_protocol_version")){
 #ifdef WITH_BRIDGE
 					if(reload) continue; // FIXME

--- a/src/mosquitto_broker.h
+++ b/src/mosquitto_broker.h
@@ -413,6 +413,7 @@ struct mosquitto__bridge{
 	char *tls_capath;
 	char *tls_certfile;
 	char *tls_keyfile;
+	char *tls_server_name;
 	bool tls_insecure;
 	char *tls_version;
 #  ifdef REAL_WITH_TLS_PSK


### PR DESCRIPTION
Introduce mosquitto_tls_server_name_set API to allow clients to specify
TLS server name indication (SNI) when connecting to brokers and provide
"--server-name" option in mosquitto_sub/mosquitto_pub to support usage.

Signed-off-by: Brian Ericson brianericson@exosite.com
