### PR TITLE
Fix missing context->listener for websocket client

### DIFF
--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -346,7 +346,7 @@ int main(int argc, char *argv[])
 			}
 		}else if(config.listeners[i].protocol == mp_websockets){
 #ifdef WITH_WEBSOCKETS
-			config.listeners[i].ws_context = mosq_websockets_init(&config.listeners[i], config.websockets_log_level);
+			config.listeners[i].ws_context = mosq_websockets_init(&int_db, &config.listeners[i], config.websockets_log_level);
 			if(!config.listeners[i].ws_context){
 				_mosquitto_log_printf(NULL, MOSQ_LOG_ERR, "Error: Unable to create websockets listener on port %d.", config.listeners[i].port);
 				return 1;

--- a/src/mosquitto_broker.h
+++ b/src/mosquitto_broker.h
@@ -31,6 +31,7 @@ Contributors:
 #    define libwebsocket_write(A, B, C, D) lws_write((A), (B), (C), (D))
 #    define libwebsocket_get_socket_fd(A) lws_get_socket_fd((A))
 #    define libwebsockets_return_http_status(A, B, C, D) lws_return_http_status((B), (C), (D))
+#    define libwebsocket_get_protocol(A) lws_get_protocol((A))
 
 #    define libwebsocket_context lws_context
 #    define libwebsocket_protocols lws_protocols
@@ -344,6 +345,7 @@ struct _mqtt3_bridge{
 #ifdef WITH_WEBSOCKETS
 struct libws_mqtt_hack {
 	char *http_dir;
+	struct mosquitto_db *db;
 };
 
 struct libws_mqtt_data {
@@ -502,9 +504,9 @@ void service_run(void);
  * ============================================================ */
 #ifdef WITH_WEBSOCKETS
 #  if defined(LWS_LIBRARY_VERSION_NUMBER)
-struct lws_context *mosq_websockets_init(struct _mqtt3_listener *listener, int log_level);
+struct lws_context *mosq_websockets_init(struct mosquitto_db *db, struct _mqtt3_listener *listener, int log_level);
 #  else
-struct libwebsocket_context *mosq_websockets_init(struct _mqtt3_listener *listener, int log_level);
+struct libwebsocket_context *mosq_websockets_init(struct mosquitto_db *db, struct _mqtt3_listener *listener, int log_level);
 #  endif
 #endif
 void do_disconnect(struct mosquitto_db *db, struct mosquitto *context);


### PR DESCRIPTION
The context associated with websocket client didn't had listener filled, which caused use_username_as_clientid to be ignored.

I've tested with the following config:
```
listener 1883
use_username_as_clientid true

listener 1880
protocol websockets
use_username_as_clientid true
```

When connecting to websocket as myuser:
```
#!/usr/bin/python
import paho.mqtt.client
c=paho.mqtt.client.Client(transport='websockets')
c.username_pw_set('myuser', 'secret')
c.connect('localhost', port=1880)
```

The clientid is NOT myuser:
```
1470235969: New client connected from 127.0.0.1 as paho/6CD3326A41CD4D51D9 (c1, k60, u'myuser').
```