### PR TITLE
Publish topic with client connection state when client connects/disconnects.

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -569,6 +569,15 @@ int handle__connect(struct mosquitto_db *db, struct mosquitto *context)
 			}else{
 				log__printf(NULL, MOSQ_LOG_NOTICE, "New client connected from %s as %s (c%d, k%d).", context->address, client_id, clean_session, context->keepalive);
 			}
+			int notification_topic_len = strlen(client_id)+strlen("$SYS/broker/clients/connection//state");
+			char* notification_topic = mosquitto__malloc(sizeof(char)*(notification_topic_len+1));
+			if(notification_topic) {
+				log__printf(NULL, MOSQ_LOG_DEBUG, "Publish %s connection.", client_id);
+				snprintf(notification_topic, notification_topic_len+1, "$SYS/broker/clients/connection/%s/state", client_id);
+				uint8_t notification_payload = '1';
+				db__messages_easy_queue(db, context, notification_topic, 1, 1, &notification_payload, 1);
+				mosquitto__free(notification_topic);
+			}
 		}
 	}
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -413,6 +413,19 @@ void do_disconnect(struct mosquitto_db *db, struct mosquitto *context)
 			}
 		}
 		context__disconnect(db, context);
+
+		if(context->id) {
+			int notification_topic_len = strlen(context->id)+strlen("$SYS/broker/clients/connection//state");
+			char* notification_topic = mosquitto__malloc(sizeof(char)*(notification_topic_len+1));
+			if(notification_topic) {
+				log__printf(NULL, MOSQ_LOG_DEBUG, "Publish %s disconnection.", context->id);
+				snprintf(notification_topic, notification_topic_len+1, "$SYS/broker/clients/connection/%s/state", context->id);
+				uint8_t notification_payload = '0';
+				db__messages_easy_queue(db, context, notification_topic, 1, 1, &notification_payload, 1);
+				mosquitto__free(notification_topic);
+			}
+		}
+
 #ifdef WITH_BRIDGE
 		if(context->clean_session && !context->bridge){
 #else


### PR DESCRIPTION
This change publishes a topic ($SYS/broker/clients/connection/_clientID_/state) with the client connection state whenever a client connects or disconnects. This is similar to the $SYS/broker/connection/_clientID_/state topic that is published for a bridge connection and allows for a simple way determine which clients are currently connected to the broker.
