### PR TITLE
websockets: fix compatibility with older lws versions

### DIFF
--- a/src/mosquitto_broker.h
+++ b/src/mosquitto_broker.h
@@ -31,7 +31,7 @@ Contributors:
 #    define libwebsocket_write(A, B, C, D) lws_write((A), (B), (C), (D))
 #    define libwebsocket_get_socket_fd(A) lws_get_socket_fd((A))
 #    define libwebsockets_return_http_status(A, B, C, D) lws_return_http_status((B), (C), (D))
-#    define libwebsocket_get_protocol(A) lws_get_protocol((A))
+#    define libwebsockets_get_protocol(A) lws_get_protocol((A))
 
 #    define libwebsocket_context lws_context
 #    define libwebsocket_protocols lws_protocols

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -182,7 +182,7 @@ static int callback_mqtt(struct libwebsocket_context *context,
 		case LWS_CALLBACK_ESTABLISHED:
 			mosq = mqtt3_context_init(db, WEBSOCKET_CLIENT);
 			if(mosq){
-				p = libwebsocket_get_protocol(wsi);
+				p = libwebsockets_get_protocol(wsi);
 				for (i=0; i<db->config->listener_count; i++){
 					if (db->config->listeners[i].protocol == mp_websockets) {
 						for (j=0; db->config->listeners[i].ws_protocol[j].name; j++){


### PR DESCRIPTION
patch is against the fixes branch, this was a regression from 1.4.9 to 1.4.10.
See also https://github.com/openwrt/packages/issues/3127

----
In 1.3, 1.4 and 1.5, the function was "libwebsockets_get_protocol" not
"libwebsocket_get_protocol"  While the #define name doesn't matter on
newer libwebsockets, where it redirects to lws_get_protocol, the naming
is critical for older versions.

Fixes: 477cd3e39911 (Fix missing context->listener for websocket client)

Signed-off-by: Karl Palsson <karlp@etactica.com>