### PR TITLE
[280] Fix build with libressl

### DIFF
--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -25,6 +25,9 @@ Contributors:
 
 #ifdef WITH_TLS
 #  include <openssl/ssl.h>
+#  if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#    define HAVE_OPENSSL_OPAQUE_STRUCTS
+#  endif
 #else
 #  include <time.h>
 #endif

--- a/src/mosquitto_passwd.c
+++ b/src/mosquitto_passwd.c
@@ -90,7 +90,7 @@ int output_new_password(FILE *fptr, const char *username, const char *password)
 	unsigned char hash[EVP_MAX_MD_SIZE];
 	unsigned int hash_len;
 	const EVP_MD *digest;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPENSSL_OPAQUE_STRUCTS
 	EVP_MD_CTX context;
 #else
 	EVP_MD_CTX *context;
@@ -117,7 +117,7 @@ int output_new_password(FILE *fptr, const char *username, const char *password)
 		return 1;
 	}
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPENSSL_OPAQUE_STRUCTS
 	EVP_MD_CTX_init(&context);
 	EVP_DigestInit_ex(&context, digest, NULL);
 	EVP_DigestUpdate(&context, password, strlen(password));

--- a/src/security_default.c
+++ b/src/security_default.c
@@ -770,7 +770,7 @@ int mosquitto_psk_key_get_default(struct mosquitto_db *db, const char *hint, con
 int _pw_digest(const char *password, const unsigned char *salt, unsigned int salt_len, unsigned char *hash, unsigned int *hash_len)
 {
 	const EVP_MD *digest;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef HAVE_OPENSSL_OPAQUE_STRUCTS
 	EVP_MD_CTX context;
 
 	digest = EVP_get_digestbyname("sha512");


### PR DESCRIPTION
Closes #280

Fix building with libressl which broke in commit fff741613 (Support for
openssl 1.1.0).

Bug: #280

Signed-off-by: Natanael Copa ncopa@alpinelinux.org
