### PR TITLE
Fix build configuration documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,9 +65,9 @@ already be built. Use `make binary` to skip building the man pages, or install
 
 ### Build Dependencies
 
-* c-ares (libc-ares2-dev on Debian based systems) - disable with `make WITH_DNS_SRV=no`
+* c-ares (libc-ares2-dev on Debian based systems) - disable with `make WITH_SRV=no`
 * libuuid (uuid-dev) - disable with `make WITH_UUID=no`
-* libwebsockets (libwebsockets-dev) - enable with `make WITH_LIBWEBSOCKETS=yes`
+* libwebsockets (libwebsockets-dev) - enable with `make WITH_WEBSOCKETS=yes`
 * openssl (libssl-dev on Debian based systems) - disable with `make WITH_TLS=no`
 
 ## Credits


### PR DESCRIPTION
The options `WITH_DNS_SRV` and `WITH_LIBWEBSOCKETS` do not exist.
They are named `WITH_SRV` and `WITH_WEBSOCKETS` instead.