### PR TITLE
Add support for local only bridge notifications

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -1089,6 +1089,15 @@
 						<replaceable>true</replaceable>.</para>
 				</listitem>
 			</varlistentry>
+			 <varlistentry>
+				<term><option>notifications_local_only</option> [ true | false ]</term>
+				<listitem>
+					<para>If set to <replaceable>true</replaceable>, only publish
+						notification messages to the local broker giving 
+						information about the state of the bridge connection.
+						Defaults to <replaceable>false</replaceable>.</para>
+				</listitem>
+			</varlistentry>
 			<varlistentry>
 				<term><option>notification_topic</option> <replaceable>topic</replaceable></term>
 				<listitem>

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -149,10 +149,13 @@ int bridge__connect(struct mosquitto_db *db, struct mosquitto *context)
 				db__messages_easy_queue(db, context, context->bridge->notification_topic, 1, 1, &notification_payload, 1);
 				context->bridge->initial_notification_done = true;
 			}
-			notification_payload = '0';
-			rc = will__set(context, context->bridge->notification_topic, 1, &notification_payload, 1, true);
-			if(rc != MOSQ_ERR_SUCCESS){
-				return rc;
+
+			if (!context->bridge->notifications_local_only) {
+				notification_payload = '0';
+				rc = will__set(context, context->bridge->notification_topic, 1, &notification_payload, 1, true);
+				if(rc != MOSQ_ERR_SUCCESS){
+					return rc;
+				}
 			}
 		}else{
 			notification_topic_len = strlen(context->bridge->remote_clientid)+strlen("$SYS/broker/connection//state");
@@ -167,11 +170,13 @@ int bridge__connect(struct mosquitto_db *db, struct mosquitto *context)
 				context->bridge->initial_notification_done = true;
 			}
 
-			notification_payload = '0';
-			rc = will__set(context, notification_topic, 1, &notification_payload, 1, true);
-			mosquitto__free(notification_topic);
-			if(rc != MOSQ_ERR_SUCCESS){
-				return rc;
+			if (!context->bridge->notifications_local_only) {
+				notification_payload = '0';
+				rc = will__set(context, notification_topic, 1, &notification_payload, 1, true);
+				mosquitto__free(notification_topic);
+				if(rc != MOSQ_ERR_SUCCESS){
+					return rc;
+				}
 			}
 		}
 	}

--- a/src/conf.c
+++ b/src/conf.c
@@ -968,6 +968,7 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 						}
 						cur_bridge->keepalive = 60;
 						cur_bridge->notifications = true;
+						cur_bridge->notifications_local_only = false;
 						cur_bridge->start_type = bst_automatic;
 						cur_bridge->idle_timeout = 60;
 						cur_bridge->restart_timeout = 30;
@@ -1354,6 +1355,17 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 					}
 					if(conf__parse_bool(&token, "notifications", &cur_bridge->notifications, saveptr)) return MOSQ_ERR_INVAL;
 #else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge support not available.");
+#endif
+				}else if(!strcmp(token, "notifications_local_only")){
+#ifdef WITH_BRIDGE
+					if(reload) continue; // FIXME
+					if(!cur_bridge){
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge configuration");
+						return MOSQ_ERR_INVAL;
+					}
+					if(conf__parse_bool(&token, "notifications_local_only", &cur_bridge->notifications_local_only, saveptr)) return MOSQ_ERR_INVAL;
+#else					
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge support not available.");
 #endif
 				}else if(!strcmp(token, "notification_topic")){

--- a/src/handle_connack.c
+++ b/src/handle_connack.c
@@ -46,10 +46,12 @@ int handle__connack(struct mosquitto_db *db, struct mosquitto *context)
 				if(context->bridge->notifications){
 					notification_payload = '1';
 					if(context->bridge->notification_topic){
-						if(send__real_publish(context, mosquitto__mid_generate(context),
-								context->bridge->notification_topic, 1, &notification_payload, 1, true, 0)){
+						if(!context->bridge->notifications_local_only){
+							if(send__real_publish(context, mosquitto__mid_generate(context),
+									context->bridge->notification_topic, 1, &notification_payload, 1, true, 0)){
 
-							return 1;
+								return 1;
+							}
 						}
 						db__messages_easy_queue(db, context, context->bridge->notification_topic, 1, 1, &notification_payload, 1);
 					}else{
@@ -59,11 +61,13 @@ int handle__connack(struct mosquitto_db *db, struct mosquitto *context)
 
 						snprintf(notification_topic, notification_topic_len+1, "$SYS/broker/connection/%s/state", context->bridge->remote_clientid);
 						notification_payload = '1';
-						if(send__real_publish(context, mosquitto__mid_generate(context),
-								notification_topic, 1, &notification_payload, 1, true, 0)){
+						if(!context->bridge->notifications_local_only){
+							if(send__real_publish(context, mosquitto__mid_generate(context),
+									notification_topic, 1, &notification_payload, 1, true, 0)){
 
-							mosquitto__free(notification_topic);
-							return 1;
+								mosquitto__free(notification_topic);
+								return 1;
+							}
 						}
 						db__messages_easy_queue(db, context, notification_topic, 1, 1, &notification_payload, 1);
 						mosquitto__free(notification_topic);

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -422,6 +422,7 @@ struct mosquitto__bridge{
 	char *local_username;
 	char *local_password;
 	bool notifications;
+	bool notifications_local_only;
 	char *notification_topic;
 	enum mosquitto_bridge_start_type start_type;
 	int idle_timeout;


### PR DESCRIPTION
This update adds an option to only publishes bridge
notification messages to the local side of the bridge.

It adds a config file option called notifications_local_only
that accepts a boolean value, defaults to false to be
consistent with existing behaviour.

Fixes #233

Signed-off-by: Ben Hardill <hardillb@uk.ibm.com>