### PR TITLE
Update Dockerfiles to not save apk cache

### DIFF
--- a/docker/1.4.4/Dockerfile
+++ b/docker/1.4.4/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER David Audet <david.audet@ca.com>
 
 LABEL Description="Eclipse Mosquitto MQTT Broker"
 
-RUN apk --no-cache --update add mosquitto=1.4.4-r0 && \
+RUN apk --no-cache add mosquitto=1.4.4-r0 && \
     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
     cp /etc/mosquitto/mosquitto.conf /mosquitto/config && \
     chown -R mosquitto:mosquitto /mosquitto

--- a/docker/1.4.8/Dockerfile
+++ b/docker/1.4.8/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER David Audet <david.audet@ca.com>
 
 LABEL Description="Eclipse Mosquitto MQTT Broker"
 
-RUN apk --no-cache --update add mosquitto=1.4.8-r2 && \
+RUN apk --no-cache add mosquitto=1.4.8-r2 && \
     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
     cp /etc/mosquitto/mosquitto.conf /mosquitto/config && \
     chown -R mosquitto:mosquitto /mosquitto


### PR DESCRIPTION
When installing the Mosquitto package from Alpine Linux, we don't need
to save the latest package index to the cache. We are specifically requesting
the latest package index each time we install Mosquitto and not using the local
cache at all (--no-cache).