### PR TITLE
Add 'mosquitto_log_vprintf' function for plugins

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -274,3 +274,7 @@ void mosquitto_log_printf(int level, const char *fmt, ...)
 	va_end(va);
 }
 
+void mosquitto_log_vprintf( int level, const char *fmt, va_list ap ) {
+    _mosquitto_log_vprintf(NULL, level, fmt, ap);
+}
+

--- a/src/mosquitto_plugin.h
+++ b/src/mosquitto_plugin.h
@@ -74,6 +74,30 @@ struct mosquitto_auth_opt {
 void mosquitto_log_printf(int level, const char *fmt, ...);
 
 
+/*
+ * Function: mosquitto_log_vprintf
+ *
+ * Write a log message using the broker configured logging.
+ *
+ * Parameters:
+ * 	level -    Log message priority. Can currently be one of:
+ *
+ *             MOSQ_LOG_INFO
+ *             MOSQ_LOG_NOTICE
+ *             MOSQ_LOG_WARNING
+ *             MOSQ_LOG_ERR
+ *             MOSQ_LOG_DEBUG
+ *             MOSQ_LOG_SUBSCRIBE (not recommended for use by plugins)
+ *             MOSQ_LOG_UNSUBSCRIBE (not recommended for use by plugins)
+ *
+ *             These values are defined in mosquitto.h.
+ *
+ *	fmt -      printf style format
+ *
+ *	ap -       stdarg va_list
+ */
+void mosquitto_log_vprintf(int level, const char *fmt, va_list ap );
+
 
 /* =========================================================================
  *


### PR DESCRIPTION
The existing logging interface doesn't support non variable (ie: va_list) arguments.
