### PR TITLE
Added support for asynchronous DNS-query.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -80,6 +80,9 @@ WITH_DOCS:=yes
 # Build with client support for SOCK5 proxy.
 WITH_SOCKS:=yes
 
+# Build with asynchronous DNS queries (use getaddrinfo_a() instead of getaddrinfo()).
+WITH_ASYNC_DNS:=no
+
 # Strip executables and shared libraries on install.
 WITH_STRIP:=no
 
@@ -194,6 +197,13 @@ endif
 ifeq ($(WITH_SOCKS),yes)
 	LIB_CFLAGS:=$(LIB_CFLAGS) -DWITH_SOCKS
 	CLIENT_CFLAGS:=$(CLIENT_CFLAGS) -DWITH_SOCKS
+endif
+
+ifeq ($(WITH_ASYNC_DNS),yes)
+	ifeq ($(UNAME),Linux)
+		BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_ASYNC_DNS -D_GNU_SOURCE
+		BROKER_LIBS:=$(BROKER_LIBS) -lanl
+	endif
 endif
 
 ifeq ($(WITH_UUID),yes)

--- a/src/loop.c
+++ b/src/loop.c
@@ -14,7 +14,9 @@ Contributors:
    Roger Light - initial implementation and documentation.
 */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <config.h>
 
@@ -121,6 +123,9 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 	sigaddset(&sigblock, SIGTERM);
 	sigaddset(&sigblock, SIGUSR1);
 	sigaddset(&sigblock, SIGUSR2);
+#ifdef WITH_ASYNC_DNS
+	sigaddset(&sigblock, SIGALRM);
+#endif
 #endif
 
 	if(db->config->persistent_client_expiration > 0){


### PR DESCRIPTION
This update adds an option to use asynchronous DNS-query on Linux-environment.
It runs async-query on background and gives time for mosquitto to serve local clients.

Fixes #41

Signed-off-by: Kari Keinanen <kari.keinanen@kone.com>