### PR TITLE
Fixes -Wreserved-id-macro in mosquitto.h and mosquittopp.h.

### DIFF
--- a/lib/cpp/mosquittopp.h
+++ b/lib/cpp/mosquittopp.h
@@ -14,8 +14,8 @@ Contributors:
    Roger Light - initial implementation and documentation.
 */
 
-#ifndef _MOSQUITTOPP_H_
-#define _MOSQUITTOPP_H_
+#ifndef MOSQUITTOPP_H_
+#define MOSQUITTOPP_H_
 
 #ifdef _WIN32
 #	ifdef mosquittopp_EXPORTS

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -14,8 +14,8 @@ Contributors:
    Roger Light - initial implementation and documentation.
 */
 
-#ifndef _MOSQUITTO_H_
-#define _MOSQUITTO_H_
+#ifndef MOSQUITTO_H_
+#define MOSQUITTO_H_
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
In C and C++ identifiers starting with an underscore are reserved. This
commit fixes the warning for the files included by other projects.

Signed-off-by: Jens Breitbart <jbreitbart@gmail.com>