### PR TITLE
Added docker support for version 1.4.10-r2 based on alpine 3.5

### DIFF
--- a/docker/1.4.10/Dockerfile
+++ b/docker/1.4.10/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.5
+MAINTAINER David Audet <david.audet@ca.com>
+
+LABEL Description="Eclipse Mosquitto MQTT Broker"
+
+RUN apk --no-cache --update add mosquitto=1.4.10-r2 && \
+    mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
+    cp /etc/mosquitto/mosquitto.conf /mosquitto/config && \
+    chown -R mosquitto:mosquitto /mosquitto
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]

--- a/docker/1.4.10/README.md
+++ b/docker/1.4.10/README.md
@@ -1,0 +1,49 @@
+#Eclipse Mosquitto v1.4.8 Docker Image
+
+##Mount Points
+
+Three mount points have been created in the image to be used for configuration, persistent storage and logs.
+```
+/mosquitto/config
+/mosquitto/data
+/mosquitto/log
+```
+
+
+##Configuration
+
+When running the image, the default configuration values are used. 
+To use a custom configuration file, mount a **local** configuration file to `/mosquitto/conf/mosquitto.conf`
+```
+docker run -it -p 1883:1883 -p 9001:9001 -v mosquitto.conf:/mosquitto/data/mosquitto.conf mosquitto:1.4.8
+```
+
+Configuration can be changed to:
+
+* persist data to `/mosquitto/data` 
+* log to `/mosquitto/log/mosquitto.log`
+
+i.e. add the following to `mosquitto.conf`:
+```
+persistence true
+persistence_location /mosquitto/data/
+
+log_dest file /mosquitto/log/mosquitto.log
+```
+
+**Note**: If a volume is used, the data will persist between containers.
+
+##Build
+Build the image:
+```
+docker build -t mosquitto:1.4.8 .
+```
+
+##Run
+Run a container using the new image:
+```
+docker run -it -p 1883:1883 -p 9001:9001 -v mosquitto.conf:/mosquitto/data/mosquitto.conf -v /mosquitto/data -v /mosquitto/log mosquitto:1.4.8
+```
+:boom: if the mosquitto configuration (mosquitto.conf) was modified
+to use non-default ports, the docker run command will need to be updated
+to expose the ports that have been configured.

--- a/docker/1.4.10/docker-entrypoint.sh
+++ b/docker/1.4.10/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/ash
+
+set -e
+exec "$@"
+


### PR DESCRIPTION
Basically the Dockerfile has been adapted to inherit from the alpine 3.5 image and to install the 1.4.10-r2 version of mosquitto.