### PR TITLE
Include <syslog.h> instead of <sys/syslog.h>

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -36,7 +36,7 @@ Contributors:
 #endif
 
 #if !defined(WIN32) && !defined(__CYGWIN__)
-#  include <sys/syslog.h>
+#  include <syslog.h>
 #endif
 
 #include <mosquitto_broker.h>


### PR DESCRIPTION
Using the standard <syslog.h> header instead of <sys/syslog.h> makes it consistent with other source files and fixes compilation on Android.

Signed-off-by: Fredrik Fornwall <fredrik@fornwall.net>