### PR TITLE
Log more TLS error details

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -321,6 +321,9 @@ void net__print_ssl_error(struct mosquitto *mosq)
 int net__socket_connect_tls(struct mosquitto *mosq)
 {
 	int ret, err;
+	unsigned long e;
+	char ebuf[256];
+
 	ret = SSL_connect(mosq->ssl);
 	if(ret != 1) {
 		err = SSL_get_error(mosq->ssl, ret);
@@ -337,6 +340,11 @@ int net__socket_connect_tls(struct mosquitto *mosq)
 			mosq->want_write = true;
 			mosq->want_connect = true;
 		}else{
+			e = ERR_get_error();
+			while(e){
+				_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "OpenSSL Error: %s", ERR_error_string(e, ebuf));
+				e = ERR_get_error();
+			}
 			COMPAT_CLOSE(mosq->sock);
 			mosq->sock = INVALID_SOCKET;
 			net__print_ssl_error(mosq);


### PR DESCRIPTION
Signed-off-by: Jiří Pinkava <j-pi@seznam.cz>

This adds more verbose logging for case when TLS error occures during connection. This is especially aimed in case where CN in server certificate does not match server hostname and 'insecure_tls' option is disabled (default).

Without this error logging messages client (eg. mosquitto_pub) says nothing useful and server only says "Internal SSL error".

This happens when someone creates certificates as described in mosquitto-tls and uses mosquitto server with default example configuration. I suppose this might happens quite often. Debuging this is pretty hard and requires to dwelling deep in source code.
