### PR TITLE
Add (missing) plugin.c into build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set (MOSQ_SRCS
 	../lib/net_mosq.c ../lib/net_mosq.h
 	../lib/packet_mosq.c ../lib/packet_mosq.h
 	persist.c persist.h
+	plugin.c
 	read_handle.c
 	../lib/read_handle.h
 	subs.c


### PR DESCRIPTION
Fix the following error:

[ 98%] Linking C executable mosquitto
CMakeFiles/mosquitto.dir/security.c.o: In function `mosquitto_acl_check':
security.c:(.text+0x159d): undefined reference to `mosquitto_client_username'
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/mosquitto.dir/build.make:1215: src/mosquitto] Chyba 1
make[1]: *** [CMakeFiles/Makefile2:483: src/CMakeFiles/mosquitto.dir/all] Chyba 2
make: *** [Makefile:128: all] Chyba 2
