### PR TITLE
Fix compilation against musl libc.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -159,10 +159,6 @@ ifeq ($(UNAME),QNX)
 	LIB_LIBS:=$(LIB_LIBS) -lsocket
 endif
 
-ifeq ($(UNAME),Linux)
-	BROKER_LIBS:=$(BROKER_LIBS) -lanl
-endif
-
 ifeq ($(WITH_WRAP),yes)
 	BROKER_LIBS:=$(BROKER_LIBS) -lwrap
 	BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_WRAP


### PR DESCRIPTION
Commit e13af18ed9c527b8152697c9ede62f0e4e81bdd6 breaks mosquitto on
systems with musl libc, due to unconditional inclusion of -lanl on
Linux.

Commit 433ee5c4d6852b507b43eae9c9a2c9028c6b48e5 already added
conditional inclusion of -lanl, so just remove the unconditional
inclusion completely.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>