### PR TITLE
Fix failed to send CONNACK when auth failed with websocket

### DIFF
--- a/src/read_handle_server.c
+++ b/src/read_handle_server.c
@@ -384,7 +384,7 @@ int mqtt3_handle_connect(struct mosquitto_db *db, struct mosquitto *context)
 				case MOSQ_ERR_AUTH:
 					_mosquitto_send_connack(context, 0, CONNACK_REFUSED_NOT_AUTHORIZED);
 					mqtt3_context_disconnect(db, context);
-					rc = 1;
+					rc = 0; /* Avoid libwebsockets close the handle, thus CONNACK could not be sent. */
 					goto handle_connect_error;
 					break;
 				default:


### PR DESCRIPTION
CONNACK cannot be sent when MOSQ_ERR_AUTH returned by mosquitto_unpwd_check with websocket