### PR TITLE
Remove -lanl when WITH_ADNS is unset

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -159,10 +159,6 @@ ifeq ($(UNAME),QNX)
 	LIB_LIBS:=$(LIB_LIBS) -lsocket
 endif
 
-ifeq ($(UNAME),Linux)
-	BROKER_LIBS:=$(BROKER_LIBS) -lanl
-endif
-
 ifeq ($(WITH_WRAP),yes)
 	BROKER_LIBS:=$(BROKER_LIBS) -lwrap
 	BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_WRAP


### PR DESCRIPTION
Do not add -lanl to BROKER_LIBS for all Linux builds.
Indeed, -lanl is only needed for getaddrinfo_a which is only used in
_mosquitto_try_connect_step1 when WITH_ADNS is set

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>