### PR TITLE
lib: fix OpenSSL 1.1 deprecation warning for ERR_remove_state

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -114,7 +114,9 @@ void _mosquitto_net_init(void)
 void _mosquitto_net_cleanup(void)
 {
 #ifdef WITH_TLS
-	ERR_remove_state(0);
+	#if OPENSSL_VERSION_NUMBER < 0x10100000L
+		ERR_remove_state(0);
+	#endif
 	ENGINE_cleanup();
 	CONF_modules_unload(1);
 	ERR_free_strings();


### PR DESCRIPTION
ERR_remove_state has been marked deprecated in OpenSSL 1.1.0 and do
nothing, as the OpenSSL libraries now normally do all thread
initialization and deinitialisation automatically.