### PR TITLE
Add new feature: Apache Kafka bridge

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -35,7 +35,11 @@ WITH_THREADING:=yes
 # to connect to other brokers and subscribe/publish to topics. You probably
 # want to leave this included unless you want to save a very small amount of
 # memory size and CPU time.
-WITH_BRIDGE:=yes
+#WITH_BRIDGE:=yes
+
+# Comment out to remove Kafa support from the broker. This allows the broker
+# to connect to a Kafka cluster and publish messages to it.
+WITH_KAFKA_BRIDGE:=yes
 
 # Comment out to remove persistent database support from the broker. This
 # allows the broker to store retained messages and durable subscriptions to a
@@ -212,6 +216,11 @@ endif
 
 ifeq ($(WITH_BRIDGE),yes)
 	BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_BRIDGE
+endif
+
+ifeq ($(WITH_KAFKA_BRIDGE),yes)
+	BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_KAFKA_BRIDGE
+	BROKER_LIBS:=$(BROKER_LIBS) -lrdkafka
 endif
 
 ifeq ($(WITH_PERSISTENCE),yes)

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -207,6 +207,7 @@ struct mosquitto {
 	bool is_dropping;
 	bool is_bridge;
 	struct mosquitto__bridge *bridge;
+	struct kafka__bridge *kafka_bridge;
 	struct mosquitto_client_msg *inflight_msgs;
 	struct mosquitto_client_msg *last_inflight_msg;
 	struct mosquitto_client_msg *queued_msgs;

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -820,6 +820,32 @@
 #bridge_identity
 #bridge_psk
 
+# =================================================================
+# Kafka bridges
+# =================================================================
+
+# A Kafka bridge is a way to publish MQTT topics to an Apache Kafka broker.
+# Create a new Kafka bridge using the "kafka_connection" option as described below.
+# Set options for the bridges using the remaining parameters. You must specify the
+# address and at least one topic to subscribe to.
+# Each connection must have a unique name. It is prefixed with "kafka_bridge." and
+# then used as virtual consumer client ID.
+# The configuration of the Kafka connection is supplied using "kafka_config".
+# "kafka_config metadata.broker.list [broker]" is the minimum required configuration.
+# If a Kafka broker version >= 0.10.x.x is used, you have to set
+# "kafka_config api.version.request true" to ensure message timestamps are set
+# correctly.
+# The Kafka bridge currently only supports bridging MQTT published messages to Kafka.
+# Because Kafka has stricter limitations concerning the topic name, following
+# changes are made:
+#  - forward slashes (/) are replaced by periods (.)
+#  - [^a-zA-Z0-9/_\-] is replaced by minus (-)
+
+#kafka_connection <name>
+#kafka_config metadata.broker.list localhost:9092
+#kafka_config api.version.request true
+#topic <topic>
+
 
 # =================================================================
 # External config files

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,14 @@ if (${INC_BRIDGE_SUPPORT} STREQUAL ON)
 	add_definitions("-DWITH_BRIDGE")
 endif (${INC_BRIDGE_SUPPORT} STREQUAL ON)
 
+option(INC_KAFKA_BRIDGE_SUPPORT
+		"Include Kafka bridge support for connecting to Apache Kafka?" ON)
+if (${INC_KAFKA_BRIDGE_SUPPORT} STREQUAL ON)
+	set (MOSQ_SRCS ${MOSQ_SRCS} kafka_bridge.c)
+	set (MOSQ_LIBS ${MOSQ_LIBS} rdkafka)
+	add_definitions("-DWITH_KAFKA_BRIDGE")
+endif (${INC_KAFKA_BRIDGE_SUPPORT} STREQUAL ON)
+
 
 option(USE_LIBWRAP
 	"Include tcp-wrappers support?" OFF)

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,7 @@ OBJS=	mosquitto.o \
 		handle_subscribe.o \
 		handle_unsuback.o \
 		handle_unsubscribe.o \
+		kafka_bridge.o \
 		logging.o \
 		loop.o \
 		memory_mosq.o \
@@ -107,6 +108,9 @@ handle_unsuback.o : ../lib/handle_unsuback.c ../lib/read_handle.h
 	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_unsubscribe.o : handle_unsubscribe.c mosquitto_broker_internal.h
+	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+
+kafka_bridge.o : kafka_bridge.c mosquitto_broker_internal.h
 	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
 
 logging.o : logging.c mosquitto_broker_internal.h

--- a/src/conf.c
+++ b/src/conf.c
@@ -218,6 +218,10 @@ void config__init(struct mosquitto__config *config)
 	config->bridges = NULL;
 	config->bridge_count = 0;
 #endif
+#ifdef WITH_KAFKA_BRIDGE
+	config->kafka_bridges = NULL;
+	config->kafka_bridge_count = 0;
+#endif
 	config->auth_plugins = NULL;
 	config->verbose = false;
 	config->message_size_limit = 0;
@@ -298,6 +302,21 @@ void config__cleanup(struct mosquitto__config *config)
 #endif
 		}
 		mosquitto__free(config->bridges);
+	}
+#endif
+#ifdef WITH_KAFKA_BRIDGE
+	if(config->kafka_bridges){
+		for(i=0; i<config->kafka_bridge_count; i++){
+			mosquitto__free(config->kafka_bridges[i].name);
+			if(config->kafka_bridges[i].topics){
+				for(j=0; j<config->kafka_bridges[i].topic_count; j++){
+					mosquitto__free(config->kafka_bridges[i].topics[j]);
+				}
+				mosquitto__free(config->kafka_bridges[i].topics);
+			}
+			rd_kafka_conf_destroy(config->kafka_bridges[i].conf);
+		}
+		mosquitto__free(config->kafka_bridges);
 	}
 #endif
 	if(config->auth_plugins){
@@ -479,7 +498,7 @@ int config__read(struct mosquitto__config *config, bool reload)
 	struct config_recurse cr;
 	int lineno = 0;
 	int len;
-#ifdef WITH_BRIDGE
+#if defined(WITH_BRIDGE) || defined(WITH_KAFKA_BRIDGE)
 	int i;
 #endif
 
@@ -550,6 +569,15 @@ int config__read(struct mosquitto__config *config, bool reload)
 	}
 #endif
 
+#ifdef WITH_KAFKA_BRIDGE
+	for(i=0; i<config->kafka_bridge_count; i++) {
+		if (!config->kafka_bridges[i].name || !config->kafka_bridges[i].conf) {
+			log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid Kafka bridge configuration.");
+			return MOSQ_ERR_INVAL;
+		}
+	}
+#endif
+
 	if(cr.log_dest_set){
 		config->log_dest = cr.log_dest;
 	}
@@ -571,6 +599,11 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 #ifdef WITH_BRIDGE
 	struct mosquitto__bridge *cur_bridge = NULL;
 	struct mosquitto__bridge_topic *cur_topic;
+#endif
+#ifdef WITH_KAFKA_BRIDGE
+	struct kafka__bridge *cur_kafka_bridge = NULL;
+	char errstr[512];
+	char *token2;
 #endif
 	struct mosquitto__auth_plugin_config *cur_auth_plugin = NULL;
 
@@ -949,6 +982,9 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 					}
 					if(conf__parse_string(&token, "clientid_prefixes", &config->clientid_prefixes, saveptr)) return MOSQ_ERR_INVAL;
 				}else if(!strcmp(token, "connection")){
+#ifdef WITH_KAFKA_BRIDGE
+					cur_kafka_bridge = NULL;
+#endif
 #ifdef WITH_BRIDGE
 					if(reload) continue; // FIXME
 					token = strtok_r(NULL, " ", &saveptr);
@@ -1083,6 +1119,64 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 						closedir(dh);
 #endif
 					}
+				}else if(!strcmp(token, "kafka_config")) {
+#ifdef WITH_KAFKA_BRIDGE
+					if(reload) continue; // FIXME
+					if(!cur_kafka_bridge){
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid Kafka bridge configuration.");
+						return MOSQ_ERR_INVAL;
+					}
+					if(!cur_kafka_bridge->conf){
+						cur_kafka_bridge->conf = rd_kafka_conf_new();
+						if(!cur_kafka_bridge->conf){
+							return MOSQ_ERR_NOMEM;
+						}
+					}
+
+					token = strtok_r(NULL, " ", &saveptr);
+					token2 = strtok_r(NULL, " ", &saveptr);
+					if (token && token2){
+						if (rd_kafka_conf_set(cur_kafka_bridge->conf, token, token2,
+											  errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK){
+							log__printf(NULL, MOSQ_LOG_ERR, "Error: Wrong Kafka configuration: %s", errstr);
+							return MOSQ_ERR_INVAL;
+						}
+					}else{
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid kafka_config value in configuration.");
+						return MOSQ_ERR_INVAL;
+					}
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Kafka bridge support not available.");
+#endif
+				}else if(!strcmp(token, "kafka_connection")) {
+#ifdef WITH_BRIDGE
+					cur_bridge = NULL;
+#endif
+#ifdef WITH_KAFKA_BRIDGE
+					if (reload) continue; // FIXME
+					token = strtok_r(NULL, " ", &saveptr);
+					if (token) {
+						config->kafka_bridge_count++;
+						config->kafka_bridges = mosquitto__realloc(config->kafka_bridges,
+																   config->kafka_bridge_count * sizeof(struct kafka__bridge));
+						if (!config->kafka_bridges) {
+							log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
+							return MOSQ_ERR_NOMEM;
+						}
+						cur_kafka_bridge = &(config->kafka_bridges[config->kafka_bridge_count - 1]);
+						memset(cur_kafka_bridge, 0, sizeof(struct kafka__bridge));
+						cur_kafka_bridge->name = mosquitto__strdup(token);
+						if (!cur_kafka_bridge->name) {
+							log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
+							return MOSQ_ERR_NOMEM;
+						}
+					} else {
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Empty kafka_connection value in configuration.");
+						return MOSQ_ERR_INVAL;
+					}
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Kafka bridge support not available.");
+#endif
 				}else if(!strcmp(token, "keepalive_interval")){
 #ifdef WITH_BRIDGE
 					if(reload) continue; // FIXME
@@ -1586,8 +1680,29 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: TLS support not available.");
 #endif
 				}else if(!strcmp(token, "topic")){
-#ifdef WITH_BRIDGE
+#if defined(WITH_BRIDGE) || defined(WITH_KAFKA_BRIDGE)
 					if(reload) continue; // FIXME
+					bool configuration_parsed = false;
+#ifdef WITH_KAFKA_BRIDGE
+					if(cur_kafka_bridge){
+						token = strtok_r(NULL, " ", &saveptr);
+						cur_kafka_bridge->topic_count++;
+						cur_kafka_bridge->topics = mosquitto__realloc(cur_kafka_bridge->topics,
+																	  sizeof(char*)*cur_kafka_bridge->topic_count);
+						if(!cur_kafka_bridge->topics){
+							log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
+							return MOSQ_ERR_NOMEM;
+						}
+						char** current_topic = &cur_kafka_bridge->topics[cur_kafka_bridge->topic_count-1];
+						*current_topic = mosquitto__strdup(token);
+						if(!*current_topic){
+							log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
+							return MOSQ_ERR_NOMEM;
+						}
+						configuration_parsed = true;
+					}
+#endif
+#ifdef WITH_BRIDGE
 					if(!cur_bridge){
 						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge configuration.");
 						return MOSQ_ERR_INVAL;
@@ -1729,9 +1844,15 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 							log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
 							return MOSQ_ERR_NOMEM;
 						}
+						configuration_parsed = true;
+					}
+#endif
+					if(!configuration_parsed){
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid Kafka or MQTT bridge configuration.");
+						return MOSQ_ERR_INVAL;
 					}
 #else
-					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge support not available.");
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Kafka or MQTT bridge support not available.");
 #endif
 				}else if(!strcmp(token, "try_private")){
 #ifdef WITH_BRIDGE

--- a/src/kafka_bridge.c
+++ b/src/kafka_bridge.c
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2016 Markus Klostermann <mklostermann@student.tugraz.at>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+ 
+The Eclipse Public License is available at
+   http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+ 
+Contributors:
+   Markus Klostermann - initial implementation and documentation.
+*/
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+
+#include "mosquitto.h"
+#include "mosquitto_broker_internal.h"
+#include "packet_mosq.h"
+#include "memory_mosq.h"
+
+#ifdef WITH_KAFKA_BRIDGE
+
+#include <librdkafka/rdkafka.h>
+
+#define KAFKA_BRIDGE_ID_PREFIX "kafka_bridge"
+
+int kafka_bridge__new(struct mosquitto_db *db, struct kafka__bridge *kafka_bridge, int num)
+{
+	log__printf(NULL, MOSQ_LOG_DEBUG, "Creating new Kafka bridge %s", kafka_bridge->name);
+	struct mosquitto *new_context = NULL;
+
+	assert(db);
+	assert(kafka_bridge);
+
+	new_context = context__init(db, INVALID_SOCKET);
+	if(!new_context){
+		return MOSQ_ERR_NOMEM;
+	}
+	int len = strlen(KAFKA_BRIDGE_ID_PREFIX) + strlen(kafka_bridge->name) + 2;
+	new_context->id = mosquitto__malloc(len);
+	if(!new_context->id){
+		return MOSQ_ERR_NOMEM;
+	}
+	snprintf(new_context->id, len, "%s.%s", KAFKA_BRIDGE_ID_PREFIX, kafka_bridge->name);
+
+	HASH_ADD_KEYPTR(hh_id, db->contexts_by_id, new_context->id, strlen(new_context->id), new_context);
+	new_context->kafka_bridge = kafka_bridge;
+	db->kafka_bridge_count++;
+
+	return kafka_bridge__connect(db, new_context, num);
+}
+
+/* Connects to Apache Kafka. The underlying library takes care of reconnecting after failure and much more. */
+int kafka_bridge__connect(struct mosquitto_db *db, struct mosquitto *context, int num)
+{
+	int i;
+	char errstr[512];
+
+	// rd_kafka_new will destroy the conf object, so create a copy first
+	rd_kafka_conf_t *kafka_conf = rd_kafka_conf_dup(context->kafka_bridge->conf);
+	context->kafka_bridge->producer = rd_kafka_new(RD_KAFKA_PRODUCER, kafka_conf, errstr, sizeof(errstr));
+	if (!context->kafka_bridge->producer){
+		log__printf(NULL, MOSQ_LOG_ERR, "Error: Could not create Kafka producer: %s", errstr);
+		return MOSQ_ERR_UNKNOWN;
+	}
+
+	context->state = mosq_cs_connected;
+	context->sock = -2 - num; // fake fd
+	context->keepalive = 0;
+	HASH_ADD(hh_sock, db->contexts_by_sock, sock, sizeof(context->sock), context);
+
+	// add topic subscriptions
+	sub__clean_session(db, context);
+	for(i=0; i<context->kafka_bridge->topic_count; i++){
+		log__printf(NULL, MOSQ_LOG_INFO, "Kafka bridge %s doing local SUBSCRIBE on topic %s", context->id, context->kafka_bridge->topics[i]);
+		if(sub__add(db, context, context->kafka_bridge->topics[i], 0, &db->subs)) return 1;
+	}
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+/* Replace characters not allowed in Kafka topic names (allowed: [a-zA-Z0-9/_\-]). */
+void kafka_bridge__convert_topic_name(char* mqtt_topic){
+	char* ch = mqtt_topic;
+	do{
+		if(*ch == '/'){
+			*ch = '.';
+		} else if(*ch != '_' && *ch != '-'
+				  && (*ch < 'a' || *ch > 'z') && (*ch < 'A' || *ch > 'Z') && (*ch < '0' || *ch > '9')){
+			*ch = '-';
+		}
+	}while(*(++ch));
+}
+
+#endif

--- a/src/loop.c
+++ b/src/loop.c
@@ -139,6 +139,9 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 #ifdef WITH_BRIDGE
 		context_count += db->bridge_count;
 #endif
+#ifdef WITH_KAFKA_BRIDGE
+		context_count += db->kafka_bridge_count;
+#endif
 
 		if(listensock_count + context_count > pollfd_count || !pollfds){
 			pollfd_count = listensock_count + context_count;

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -355,6 +355,16 @@ int main(int argc, char *argv[])
 	}
 #endif
 
+#ifdef WITH_KAFKA_BRIDGE
+	for(i=0; i<config.kafka_bridge_count; i++){
+		if(kafka_bridge__new(&int_db, &(config.kafka_bridges[i]), i)){
+			log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Unable to connect to Kafka bridge %s.",
+						config.kafka_bridges[i].name);
+		}
+	}
+
+#endif
+
 #ifdef WITH_SYSTEMD
 	sd_notify(0, "READY=1");
 #endif

--- a/test/broker/11-kafka-bridge.conf
+++ b/test/broker/11-kafka-bridge.conf
@@ -1,0 +1,6 @@
+port 1888
+
+kafka_connection kafka_sample
+kafka_config metadata.broker.list localhost:9092
+kafka_config api.version.request true
+topic #

--- a/test/broker/11-kafka-bridge.py
+++ b/test/broker/11-kafka-bridge.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+# Test whether a Kafka connection works. Needs a running Kafka broker at localhost:9092 (use
+# 11-kafka-bridge_kafka.conf and 11-kafka-bridge_zookeeper.properties).
+# Dependencies: kafka-python (http://kafka-python.readthedocs.io/)
+#               Paho Python client (https://www.eclipse.org/paho/clients/python/)
+
+import inspect, os, sys
+
+# From http://stackoverflow.com/questions/279237/python-import-a-module-from-a-folder
+cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],'..')))
+if cmd_subfolder not in sys.path:
+    sys.path.insert(0, cmd_subfolder)
+
+import mosq_test, logging
+import paho.mqtt.publish as publish
+from kafka import KafkaConsumer
+
+rc = 1
+keepalive = 10
+broker = mosq_test.start_broker(filename=os.path.basename(__file__))
+
+# create a Kafka consumer
+logging.getLogger('kafka').addHandler(logging.NullHandler())
+consumer = KafkaConsumer('test.kafka', bootstrap_servers=['localhost:9092'], consumer_timeout_ms=10)
+
+messages = []
+try:
+    for qos in range(3):
+        messages.append("Test message (QoS %d)" % (qos, ))
+        publish.single("test/kafka", messages[-1], hostname="localhost", port=1888, qos=qos)
+    rc = 0
+finally:
+    broker.terminate()
+    broker.wait()
+    if rc:
+        (stdo, stde) = broker.communicate()
+        print(stde)
+
+# validate message sent to Kafka
+receivedMessages = consumer.poll(1000)
+for i in range(len(messages)):
+    received = receivedMessages.values()[0][i]
+    if received.value != messages[i] or received.topic != 'test.kafka':
+        print 'Test message was not correctly transmitted to Kafka consumer, received: {0}'.format(received)
+        rc = 1
+
+consumer.close()
+exit(rc)
+

--- a/test/broker/11-kafka-bridge_kafka.conf
+++ b/test/broker/11-kafka-bridge_kafka.conf
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# see kafka.server.KafkaConfig for additional details and defaults
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id=0
+
+# Switch to enable topic deletion or not, default value is false
+delete.topic.enable=true
+auto.create.topics.enable=true
+
+############################# Socket Server Settings #############################
+
+# The address the socket server listens on. It will get the value returned from
+# java.net.InetAddress.getCanonicalHostName() if not configured.
+#   FORMAT:
+#     listeners = security_protocol://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+listeners=PLAINTEXT://:9092
+
+# Hostname and port the broker will advertise to producers and consumers. If not set,
+# it uses the value for "listeners" if configured.  Otherwise, it will use the value
+# returned from java.net.InetAddress.getCanonicalHostName().
+#advertised.listeners=PLAINTEXT://your.host.name:9092
+
+# The number of threads handling network requests
+num.network.threads=3
+
+# The number of threads doing disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=102400
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=102400
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+############################# Log Basics #############################
+
+# A comma seperated list of directories under which to store log files
+log.dirs=/tmp/kafka-logs
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions=1
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir=1
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to exceessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
+# segments don't drop below log.retention.bytes.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes=1073741824
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=300000
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect=localhost:2181
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=6000

--- a/test/broker/11-kafka-bridge_zookeeper.properties
+++ b/test/broker/11-kafka-bridge_zookeeper.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# the directory where the snapshot is stored.
+dataDir=/tmp/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+# disable the per-ip limit on the number of connections since this is a non-production config
+maxClientCnxns=0

--- a/test/broker/readme.txt
+++ b/test/broker/readme.txt
@@ -12,3 +12,5 @@ Numbering is as follows:
 05: Clean session tests
 06: Bridge tests
 07: Will tests
+
+11: Kafka bridge tests


### PR DESCRIPTION
Mosquitto can be configured to forward messages to an Apache Kafka broker.
The configuration is desribed in mosquitto.conf.
The compiler flag WITH_KAFKA_BRIDGE needs to be set to use the new
feature. Currently, the Kafka bridge only ensures QoS 0.

Dependencies: librdkafka
Test dependencies: python-kafka

Signed-off-by: Markus Klostermann <mklostermann@student.tugraz.at>