### PR TITLE
Maximize out buffer size

### DIFF
--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -194,6 +194,7 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_se
 	mosq->in_callback = false;
 	mosq->in_queue_len = 0;
 	mosq->out_queue_len = 0;
+	mosq->max_out_queue_len = 0;
 	mosq->reconnect_delay = 1;
 	mosq->reconnect_delay_max = 1;
 	mosq->reconnect_exponential_backoff = false;
@@ -617,7 +618,12 @@ int mosquitto_publish(struct mosquitto *mosq, int *mid, const char *topic, int p
 			}
 			pthread_mutex_unlock(&mosq->out_message_mutex);
 			return _mosquitto_send_publish(mosq, message->msg.mid, message->msg.topic, message->msg.payloadlen, message->msg.payload, message->msg.qos, message->msg.retain, message->dup);
-		}else{
+		} else if(queue_status == 2)
+		{
+			_mosquitto_message_cleanup(&message);
+			pthread_mutex_unlock(&mosq->out_message_mutex);
+			return MOSQ_ERR_UNKNOWN;
+		} else{
 			message->state = mosq_ms_invalid;
 			pthread_mutex_unlock(&mosq->out_message_mutex);
 			return MOSQ_ERR_SUCCESS;

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -1296,6 +1296,23 @@ libmosq_EXPORT int mosquitto_reconnect_delay_set(struct mosquitto *mosq, unsigne
 libmosq_EXPORT int mosquitto_max_inflight_messages_set(struct mosquitto *mosq, unsigned int max_inflight_messages);
 
 /*
+ * Function: mosquitto_max_out_queue_size_set
+ *
+ * Set 0 for unlimited size.
+ *
+ *  * Parameters:
+ *  mosq -                  a valid mosquitto instance.
+ *  max_queue_size -		the maximum number of messages in the outgoing queue. Defaults
+ *                          to 0.
+ *
+ * Returns:
+ *	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ */
+libmosq_EXPORT int mosquitto_max_out_queue_size_set(struct mosquitto *mosq, unsigned int max_queue_size);
+
+
+/*
  * Function: mosquitto_message_retry_set
  *
  * Set the number of seconds to wait before retrying messages. This applies to

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -253,6 +253,7 @@ struct mosquitto {
 	int port;
 	int in_queue_len;
 	int out_queue_len;
+	int max_out_queue_len;
 	char *bind_address;
 	unsigned int reconnect_delay;
 	unsigned int reconnect_delay_max;


### PR DESCRIPTION
We stuck in a problem when using MQTT QoS 1 or 2 that if a connection drops the out queue is growing without a limit (consuming all the memory) and - it seems, I may be wrong - there is no way of noticing that the connection has dropped (in case of *mosquitto_loop_start*). We made a little change to specify the out queue size and passing an error in *mosquitto_publish* when the queue is full. If you consider this a good feature I can fit the interface to mosquitto guidelines (if you provide one :)).