### PR TITLE
Fix use of unitialized memory in gets_quiet

### DIFF
--- a/src/mosquitto_passwd.c
+++ b/src/mosquitto_passwd.c
@@ -230,6 +230,7 @@ int gets_quiet(char *s, int len)
 	memset(s, 0, len);
 	h  = GetStdHandle(STD_INPUT_HANDLE);
 	GetConsoleMode(h, &con_orig);
+	con_quiet = con_orig;
 	con_quiet &= ~ENABLE_ECHO_INPUT;
 	con_quiet |= ENABLE_LINE_INPUT;
 	SetConsoleMode(h, con_quiet);


### PR DESCRIPTION
Spotted by cppcheck

Signed-off-by: Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>