### PR TITLE
Fix bridge->restart_t won't be reset

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -246,7 +246,7 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 				}else{
 					if((context->bridge->start_type == bst_lazy && context->bridge->lazy_reconnect)
 							|| (context->bridge->start_type == bst_automatic && now > context->bridge->restart_t)){
-
+						context->bridge->restart_t = 0;
 #if defined(__GLIBC__) && defined(WITH_ADNS)
 						if(context->adns){
 							/* Waiting on DNS lookup */


### PR DESCRIPTION
If bridge use a non-existed PSK Identity or connection failed it will retry to connect continuously without any timeouts.

This issue is introduced by [Start of fix for [344]](https://github.com/eclipse/mosquitto/commit/e13af18ed9c527b8152697c9ede62f0e4e81bdd6#diff-3ca823489e2803bdd90f0774bbdd0c09L266).

Affected version: v1.4.11
