### PR TITLE
Update build dependencies content of readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ already be built. Use `make binary` to skip building the man pages, or install
 
 ### Build Dependencies
 
-* c-ares (libc-ares-dev on Debian based systems) - disable with `make WITH_DNS_SRV=no`
+* c-ares (libc-ares-dev on Debian based systems) - disable with `make WITH_SRV=no`
 * libuuid (uuid-dev) - disable with `make WITH_UUID=no`
 * libwebsockets (libwebsockets-dev) - enable with `make WITH_LIBWEBSOCKETS=yes`
 * openssl (libssl-dev on Debian based systems) - disable with `make WITH_TLS=no`


### PR DESCRIPTION
For the dependency of disabling DNS service by make command, the macro "WITH_DNS_SRV" should be update to "WITH_SRV"

* c-ares (libc-ares-dev on Debian based systems) - disable with `make WITH_SRV=no`