### PR TITLE
[344] Only link libanl when WITH_ADNS=yes

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -159,10 +159,6 @@ ifeq ($(UNAME),QNX)
 	LIB_LIBS:=$(LIB_LIBS) -lsocket
 endif
 
-ifeq ($(UNAME),Linux)
-	BROKER_LIBS:=$(BROKER_LIBS) -lanl
-endif
-
 ifeq ($(WITH_WRAP),yes)
 	BROKER_LIBS:=$(BROKER_LIBS) -lwrap
 	BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_WRAP


### PR DESCRIPTION
Removes the hard link of libanl for Linux, leaving the protected link
when WITH_ADNS is specified.

Fixes: 433ee5c4d6852b507b43eae9c9a2c9028c6b48e5

Signed-off-by: Karl Palsson <karlp@etactica.com>

*note* This fix is also needed in "develop" and should apply cleanly, but this patch is explicitly against the "fixes" branch