### PR TITLE
Out queue maximum size

### DIFF
--- a/lib/linker.version
+++ b/lib/linker.version
@@ -86,4 +86,5 @@ MOSQ_1.5 {
 		mosquitto_message_free_contents;
 		mosquitto_validate_utf8;
 		mosquitto_userdata;
+		mosquitto_max_out_queue_size_set;
 } MOSQ_1.4;

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -611,7 +611,7 @@ int mosquitto_publish(struct mosquitto *mosq, int *mid, const char *topic, int p
 		{
             message__cleanup(&message);
 			pthread_mutex_unlock(&mosq->out_message_mutex);
-			return MOSQ_ERR_UNKNOWN;
+            return MOSQ_ERR_QUEUE_IS_FULL;
         } else{
 			message->state = mosq_ms_invalid;
 			pthread_mutex_unlock(&mosq->out_message_mutex);
@@ -1315,6 +1315,8 @@ const char *mosquitto_strerror(int mosq_errno)
 			return "Proxy error.";
 		case MOSQ_ERR_MALFORMED_UTF8:
 			return "Malformed UTF-8";
+        case MOSQ_ERR_QUEUE_IS_FULL:
+            return "Outgoing queue is full.";
 		default:
 			return "Unknown error.";
 	}

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -82,7 +82,8 @@ enum mosq_err_t {
 	MOSQ_ERR_EAI = 15,
 	MOSQ_ERR_PROXY = 16,
 	MOSQ_ERR_PLUGIN_DEFER = 17,
-	MOSQ_ERR_MALFORMED_UTF8 = 18
+    MOSQ_ERR_MALFORMED_UTF8 = 18,
+    MOSQ_ERR_QUEUE_IS_FULL = 19
 };
 
 /* Error values */
@@ -597,6 +598,7 @@ libmosq_EXPORT int mosquitto_disconnect(struct mosquitto *mosq);
  *                            broker.
  * 	MOSQ_ERR_PAYLOAD_SIZE -   if payloadlen is too large.
  * 	MOSQ_ERR_MALFORMED_UTF8 - if the topic is not valid UTF-8
+ *  MOSQ_ERR_QUEUE_IS_FULL -  if the outgoing queue is full
  *
  * See Also: 
  *	<mosquitto_max_inflight_messages_set>
@@ -1319,6 +1321,8 @@ libmosq_EXPORT int mosquitto_max_inflight_messages_set(struct mosquitto *mosq, u
 /*
  * Function: mosquitto_max_out_queue_size_set
  *
+ * Sets the maximum size of the outgoing queue in case of messages with qos > 0. If the
+ * queue limit is reached, mosquitto_publish() will return error.
  * Set 0 for unlimited size.
  *
  *  * Parameters:

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -1317,6 +1317,23 @@ libmosq_EXPORT int mosquitto_reconnect_delay_set(struct mosquitto *mosq, unsigne
 libmosq_EXPORT int mosquitto_max_inflight_messages_set(struct mosquitto *mosq, unsigned int max_inflight_messages);
 
 /*
+ * Function: mosquitto_max_out_queue_size_set
+ *
+ * Set 0 for unlimited size.
+ *
+ *  * Parameters:
+ *  mosq -                  a valid mosquitto instance.
+ *  max_queue_size -		the maximum number of messages in the outgoing queue. Defaults
+ *                          to 0.
+ *
+ * Returns:
+ *	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ */
+libmosq_EXPORT int mosquitto_max_out_queue_size_set(struct mosquitto *mosq, unsigned int max_queue_size);
+
+
+/*
  * Function: mosquitto_message_retry_set
  *
  * This function now has no effect.

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -255,6 +255,7 @@ struct mosquitto {
 	int port;
 	int in_queue_len;
 	int out_queue_len;
+	int max_out_queue_len;
 	char *bind_address;
 	unsigned int reconnect_delay;
 	unsigned int reconnect_delay_max;


### PR DESCRIPTION
I rebased my work on limiting the outgoing queue size onto the develop branch. I edited the linker.version file as well. Apart from these I introduced a new error constant because no other constant explains the situation exactly (NOMEM is used for memory allocation errors).