### PR TITLE
 #419 Broker sometimes kills connection to client

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -464,6 +464,7 @@ int _mosquitto_try_connect(struct mosquitto *mosq, const char *host, uint16_t po
 int mosquitto__socket_connect_tls(struct mosquitto *mosq)
 {
 	int ret, err;
+	ERR_clear_error();
 	ret = SSL_connect(mosq->ssl);
 	if(ret != 1) {
 		err = SSL_get_error(mosq->ssl, ret);
@@ -762,6 +763,7 @@ ssize_t _mosquitto_net_read(struct mosquitto *mosq, void *buf, size_t count)
 	errno = 0;
 #ifdef WITH_TLS
 	if(mosq->ssl){
+		ERR_clear_error();
 		ret = SSL_read(mosq->ssl, buf, count);
 		if(ret <= 0){
 			err = SSL_get_error(mosq->ssl, ret);
@@ -812,6 +814,7 @@ ssize_t _mosquitto_net_write(struct mosquitto *mosq, void *buf, size_t count)
 #ifdef WITH_TLS
 	if(mosq->ssl){
 		mosq->want_write = false;
+		ERR_clear_error();
 		ret = SSL_write(mosq->ssl, buf, count);
 		if(ret < 0){
 			err = SSL_get_error(mosq->ssl, ret);

--- a/src/net.c
+++ b/src/net.c
@@ -165,6 +165,7 @@ int mqtt3_socket_accept(struct mosquitto_db *db, mosq_sock_t listensock)
 					new_context->want_write = true;
 					bio = BIO_new_socket(new_sock, BIO_NOCLOSE);
 					SSL_set_bio(new_context->ssl, bio, bio);
+					ERR_clear_error();
 					rc = SSL_accept(new_context->ssl);
 					if(rc != 1){
 						rc = SSL_get_error(new_context->ssl, rc);


### PR DESCRIPTION
I believe the problem is related to clearing the SSL error queue before the appropriate SSL call. I added this clearing before each call whose error status is then probed and it seems that it solved the issue for us.