### PR TITLE
Add unix domain socket listener.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Add unix domain socket listener.
 */
 
 #include <config.h>
@@ -1124,6 +1125,15 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 							return MOSQ_ERR_NOMEM;
 						}
 						tmp_int = atoi(token);
+#ifndef WIN32 	// Listeners for unix domain socket
+						if(strlen(token) > 5 && tmp_int == 0){
+							token = strtok_r(token, ":", &saveptr);
+							if(token && strcmp(token, "unix")) {
+									log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid listener string.");
+									return MOSQ_ERR_INVAL;
+							}
+						}else
+#endif
 						if(tmp_int < 1 || tmp_int > 65535){
 							log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid port value (%d).", tmp_int);
 							return MOSQ_ERR_INVAL;
@@ -1950,3 +1960,4 @@ static int conf__parse_string(char **token, const char *name, char **value, char
 	}
 	return MOSQ_ERR_SUCCESS;
 }
+


### PR DESCRIPTION
I added unix domain socket listener.
Because I used mosquitto with Nginx stream proxy on the same machine frequently, it will be better the communication between mosquitto and Nginx can support unix domain socket in order to reduce internal TCP port resources and optimize performance. Pls evaluate it. Thanks.
#USAGE: listener unix:<path_name>

Tastuzo Osawa <toast-uz>