### PR TITLE
Add unix domain socket listener.

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -700,6 +700,17 @@
 					</listitem>
 				</varlistentry>
 				<varlistentry>
+					<term><option>listener</option> <replaceable>unix:unix-path</replaceable></term>
+					<listitem>
+						<para>Listen for incoming internal connection on the
+							unix domain socket represented by unix-path.
+						</para>
+						<para>This can be applied both mqtt and websockets. To use websockets, this need libwebsockets 2.0 or later compiled with unix domain socket support option. Mosquitto must have proper privileges to handle the path.</para>
+						<para>This option may be specified multiple times. Mosquitto can create simultaniously both TCP and unix listener.</para>
+						<para>Not reloaded on reload signal.</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
 					<term><option>max_connections</option> <replaceable>count</replaceable></term>
 					<listitem>
 						<para>Limit the total number of clients connected for
@@ -1522,3 +1533,4 @@ topic clients/total in 0 test/mosquitto/org $SYS/broker/
 		<para>Roger Light <email>roger@atchoo.org</email></para>
 	</refsect1>
 </refentry>
+

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -291,6 +291,15 @@
 # Note that for a websockets listener it is not possible to bind to a host
 # name.
 # listener port-number [ip address/host name]
+#
+# If unix: directive and unix path is given, mosquitto will attempt
+# to bind the listener to an unix domain socket represented by the path.
+# This can be applied both mqtt and websockets. To use websockets,
+# this need libwebsockets 2.0 or later compiled with unix domain socket
+# support option.
+# Mosquitto must have proper privileges to handle the path. 
+# Mosquitto can create simultaniously both TCP and unix listener. 
+# listener unix:unix-path
 #listener
 
 # The maximum number of client connections to allow. This is 
@@ -842,3 +851,4 @@
 #max_log_entries
 #trace_level
 #trace_output
+

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -13,6 +13,7 @@ and the Eclipse Distribution License is available at
 Contributors:
    Roger Light - initial implementation and documentation.
    Tatsuzo Osawa - Add epoll.
+   Tatsuzo Osawa - Add unix domain socket listener.
 */
 
 #ifndef MOSQUITTO_BROKER_INTERNAL_H
@@ -167,6 +168,9 @@ struct mosquitto__listener {
 	struct libwebsocket_context *ws_context;
 	char *http_dir;
 	struct libwebsocket_protocols *ws_protocol;
+#endif
+#ifndef WIN32
+	bool use_unixsocket;
 #endif
 };
 
@@ -624,4 +628,5 @@ struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *li
 void do_disconnect(struct mosquitto_db *db, struct mosquitto *context);
 
 #endif
+
 


### PR DESCRIPTION
I added unix domain socket listener.
Because I use mosquitto with Nginx stream proxy on the same machine frequently, it will be better the communication between mosquitto and Nginx can support unix domain socket in order to reduce internal TCP port resources and optimize performance. Plz evaluate it. Thanks.
#USAGE: listener unix:<path_name>

Signed-off-by: Tatsuzo Osawa  (toast-uz) #