### PR TITLE
listener_allow_anonymous

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -160,6 +160,7 @@
 						then another means of connection should be created to
 						control authenticated client access.  Defaults to
 						<replaceable>true</replaceable>.</para>
+					<para>See also <replaceable>listener_allow_anonymous</replaceable>.</para>
 					<para>Reloaded on reload signal.</para>
 				</listitem>
 			</varlistentry>
@@ -672,6 +673,21 @@
 							also the <option>mount_point</option>
 							option.</para>
 						<para>Not reloaded on reload signal.</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term><option>listener_allow_anonymous</option> [ true | false ]</term>
+					<listitem>
+						<para>Boolean value that determines whether clients that
+							connect without providing a username are allowed to
+							connect. If set to <replaceable>false</replaceable>
+							then another means of connection should be created to
+							control authenticated client access.  Defaults to
+							<replaceable>false</replaceable>.</para>
+						<para>See also <replaceable>allow_anonymous</replaceable>.</para>
+						<para>Anonymous connections are allowed if any of <code>allow_anonymous</code> or
+							the listener's <code>listener_allow_anonymous</code> is <code>true</code>.</para>
+						<para>Reloaded on reload signal.</para>
 					</listitem>
 				</varlistentry>
 				<varlistentry>

--- a/src/conf.c
+++ b/src/conf.c
@@ -1142,6 +1142,8 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 						log__printf(NULL, MOSQ_LOG_ERR, "Error: Empty listener value in configuration.");
 						return MOSQ_ERR_INVAL;
 					}
+				}else if(!strcmp(token, "listener_allow_anonymous")){
+					if(conf__parse_bool(&token, token, &cur_listener->allow_anonymous, saveptr)) return MOSQ_ERR_INVAL;
 				}else if(!strcmp(token, "local_clientid")){
 #ifdef WITH_BRIDGE
 					if(reload) continue; // FIXME

--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -442,7 +442,7 @@ int handle__connect(struct mosquitto_db *db, struct mosquitto *context)
 			password = NULL;
 		}
 
-		if(!username_flag && db->config->allow_anonymous == false){
+		if(!username_flag && db->config->allow_anonymous == false && !context->listener->allow_anonymous){
 			send__connack(context, 0, CONNACK_REFUSED_NOT_AUTHORIZED);
 			rc = 1;
 			goto handle_connect_error;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -148,6 +148,7 @@ struct mosquitto__listener {
 	int client_count;
 	enum mosquitto_protocol protocol;
 	bool use_username_as_clientid;
+	bool allow_anonymous;
 #ifdef WITH_TLS
 	char *cafile;
 	char *capath;

--- a/src/security_default.c
+++ b/src/security_default.c
@@ -732,7 +732,7 @@ int mosquitto_security_apply_default(struct mosquitto_db *db)
 	
 	HASH_ITER(hh_id, db->contexts_by_id, context, ctxt_tmp){
 		/* Check for anonymous clients when allow_anonymous is false */
-		if(!allow_anonymous && !context->username){
+		if(!allow_anonymous && !context->username && !context->listener->allow_anonymous){
 			context->state = mosq_cs_disconnecting;
 			do_disconnect(db, context);
 			continue;


### PR DESCRIPTION
This commit introduces a (per-listener) listener_allow_anonymous
option that controls what to do with anonymous connections.
For backward compatibility, this option is prefixed with 'listener_'
and the global 'allow_anonymous' is still in use, i.e. anonymous
connections are allowed if any of allow_anonymous and
listener_allow_anonymous are true.

Signed-off-by: Kurt Van Dijck <dev.kurt@vandijck-laurijssen.be>