### PR TITLE
Fix two issues with Websocket

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -525,6 +525,12 @@ static void loop_handle_reads_writes(struct mosquitto_db *db, struct pollfd *pol
 		if(context->pollfd_index < 0){
 			continue;
 		}
+#ifdef WITH_WEBSOCKETS
+		if(context->wsi){
+			// Websocket are already handled above
+			continue;
+		}
+#endif
 
 #ifdef WITH_TLS
 		if(pollfds[context->pollfd_index].revents & POLLIN ||

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -593,7 +593,7 @@ static int callback_http(struct libwebsocket_context *context,
 		case LWS_CALLBACK_DEL_POLL_FD:
 		case LWS_CALLBACK_CHANGE_MODE_POLL_FD:
 			HASH_FIND(hh_sock, db->contexts_by_sock, &pollargs->fd, sizeof(pollargs->fd), mosq);
-			if(mosq){
+			if(mosq && (pollargs->events & POLLOUT)){
 				mosq->ws_want_write = true;
 			}
 			break;


### PR DESCRIPTION
I've seen two issue with Websocket introduced by c07ba2a:

* As soon as a Websocket client is connected, Mosquitto eat 100% CPU
* If a Websocket client publish a "large" message (4096 seem to be the threshold), the message is never received by the broker and connection get stuck.

Seen this on fixes branch with libwebsocket 1.7.3.

# Step to reproduce

Run Mosquitto (fixes branch, to include commit c07ba2a):
```
cat > mosquitto.conf << EOF
listener 1888
protocol websockets
log_type all
EOF
mosquitto -c mosquitto.conf
```

Using Python client:
```
import logging
logging.basicConfig(level=logging.DEBUG)
import paho.mqtt.client as mqttc
client = mqttc.Client(transport='websockets')
client.enable_logger()
client.connect('localhost', 1888)
client.loop_start()
```

We seen that client connect correctly (both Mosquitto log and client logs should show it), but Mosquitto is using 100% CPU

Continue with Python client:
```
client.publish("topic", b"message", qos=1)  # publish works. Once more both logs show publish & puback
client.publish("topic", b"m" * 4096, qos=1)  # fail :(
```

The "large" publish fail. No puback on client side, no publish on server side.

# Cause for the 100% CPU

In callback for LWS_CALLBACK_ADD_POLL_FD, LWS_CALLBACK_DEL_POLL_FD or LWS_CALLBACK_CHANGE_MODE_POLL_FD it's always marking the FD as want_read, but libwebsocket may call us when it only want to watch for read event. Or even (esp. in cas of DEL_POLL_FD) to stop watching for even.
This create an infinite loop:
* poll() return immediately because the FD is writable
* we call lws_service_fd()
* libwebsocket wall us with  LWS_CALLBACK_CHANGE_MODE_POLL_FD with event=POLLIN
* we mark the FD as want_write and in next poll() call we will watch for writable event.

# Cause for lost large message

In the loop_handle_reads_writes, read and write for websocket are handled in first iteration over context (iteration that handle writes for non-websocket FD).
But then in second iteration (the one which handle reads for non-websocket FD) there was nothing special for websocket FD. I assume this cause Mosquitto to read over the websocket FD and "stealing" data from libwebsocket.
This probably only occurred when message were "large" enough, because libwebsocket probably read 4096 bytes at one time, if message were small, libwebsocket read all packet and it was fine, but with larger packet, libwebsocket read only the begining and Mosquitto eat the next part.