### PR TITLE
Add Epoll.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -89,6 +89,9 @@ WITH_STATIC_LIBRARIES:=no
 # Build with async dns lookup support for bridges (temporary). Requires glibc.
 #WITH_ADNS:=yes
 
+# Build with epoll support.
+WITH_EPOLL:=no
+
 # =============================================================================
 # End of user configuration
 # =============================================================================
@@ -272,3 +275,11 @@ STRIP?=strip
 ifeq ($(WITH_STRIP),yes)
 	STRIP_OPTS:=-s --strip-program=${CROSS_COMPILE}${STRIP}
 endif
+
+ifeq ($(WITH_EPOLL),yes)
+	ifeq ($(UNAME),Linux)
+		BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_EPOLL
+	endif
+endif
+
+

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Add epoll.
 */
 
 #ifndef MOSQUITTO_INTERNAL_H
@@ -273,8 +274,12 @@ struct mosquitto {
 	UT_hash_handle hh_sock;
 	struct mosquitto *for_free_next;
 #endif
+#ifdef WITH_EPOLL
+	uint32_t events;
+#endif
 };
 
 #define STREMPTY(str) (str[0] == '\0')
 
 #endif
+

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Add epoll.
 */
 
 #ifndef MOSQUITTO_BROKER_INTERNAL_H
@@ -370,6 +371,9 @@ struct mosquitto_db{
 	int retained_count;
 #endif
 	struct mosquitto *ll_for_free;
+#ifdef WITH_EPOLL
+	int epollfd;
+#endif
 };
 
 enum mosquitto__bridge_direction{
@@ -618,3 +622,4 @@ struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *li
 void do_disconnect(struct mosquitto_db *db, struct mosquitto *context);
 
 #endif
+


### PR DESCRIPTION
Added epoll for Linux.
Using epoll system-call instead of poll, mosquitto can get performance improvement especially  in handling huge concurrent connections. I confirmed it on my test environment.
Compile option: "$ make binary WITH_EPOLL=yes" to try.

Signed-off-by: Tatsuzo Osawa (toast-uz) #