### PR TITLE
Fix iOS crash issues

### DIFF
--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -971,9 +971,10 @@ int mosquitto_loop(struct mosquitto *mosq, int timeout, int max_packets)
 				/* Fake write possible, to stimulate output write even though
 				 * we didn't ask for it, because at that point the publish or
 				 * other command wasn't present. */
-				FD_SET(mosq->sock, &writefds);
+                if(mosq->sock != INVALID_SOCKET)
+                    FD_SET(mosq->sock, &writefds);
 			}
-			if(FD_ISSET(mosq->sock, &writefds)){
+			if(mosq->sock != INVALID_SOCKET && FD_ISSET(mosq->sock, &writefds)){
 #ifdef WITH_TLS
 				if(mosq->want_connect){
 					rc = mosquitto__socket_connect_tls(mosq);


### PR DESCRIPTION
Relate to issues #327 and #63.
mosq->sock may be closed before FD_SET(mosq->sock, &writefds) and
FD_ISSET(mosq->sock, &writefds) but after judgement in line 947
if(mosq->sock != INVALID_SOCKET). FD_SET(-1, ...) and FD_ISSET(-1, ...)
would certainly crash.

Signed-off-by: Zard1096 <mr.zardqi@gmail.com>