### PR TITLE
Fix the TLS handshake problem if PSK has leading zero

### DIFF
--- a/lib/util_mosq.c
+++ b/lib/util_mosq.c
@@ -327,19 +327,33 @@ int _mosquitto_hex2bin(const char *hex, unsigned char *bin, int bin_max_len)
 {
 	BIGNUM *bn = NULL;
 	int len;
+	int leading_zero = 0;
+	int start = 0;
+	int i = 0;
+
+	/* Count the number of leading zero */
+	for(i=0; i<strlen(hex); i=i+2) {
+		if(strncmp(hex + i, "00", 2) == 0) {
+			leading_zero++;
+			/* output leading zero to bin */
+			bin[start++] = 0;
+		}else{
+			break;
+		}
+	}
 
 	if(BN_hex2bn(&bn, hex) == 0){
 		if(bn) BN_free(bn);
 		return 0;
 	}
-	if(BN_num_bytes(bn) > bin_max_len){
+	if(BN_num_bytes(bn) + leading_zero > bin_max_len){
 		BN_free(bn);
 		return 0;
 	}
 
-	len = BN_bn2bin(bn, bin);
+	len = BN_bn2bin(bn, bin + leading_zero);
 	BN_free(bn);
-	return len;
+	return len + leading_zero;
 }
 #endif
 


### PR DESCRIPTION
Incorrect psk will be provided by psk_server_callback() because leading zero
is skipped by BN_bn2bin() and BN_num_bytes()

Signed-off-by: Aska.Wu <askawu@gmail.com>