### PR TITLE
support for 1.4.14 into docker

### DIFF
--- a/docker/1.4.14/Dockerfile
+++ b/docker/1.4.14/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:edge
+MAINTAINER David Audet <david.audet@ca.com>
+
+LABEL Description="Eclipse Mosquitto MQTT Broker"
+
+RUN apk --no-cache add mosquitto=1.4.14-r0 && \
+    mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
+    cp /etc/mosquitto/mosquitto.conf /mosquitto/config && \
+    chown -R mosquitto:mosquitto /mosquitto
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]

--- a/docker/1.4.14/README.md
+++ b/docker/1.4.14/README.md
@@ -1,0 +1,49 @@
+#Eclipse Mosquitto v1.4.14 Docker Image
+
+##Mount Points
+
+Three mount points have been created in the image to be used for configuration, persistent storage and logs.
+```
+/mosquitto/config
+/mosquitto/data
+/mosquitto/log
+```
+
+
+##Configuration
+
+When running the image, the default configuration values are used.
+To use a custom configuration file, mount a **local** configuration file to `/mosquitto/config/mosquitto.conf`
+```
+docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf eclipse-mosquitto:1.4.14
+```
+
+Configuration can be changed to:
+
+* persist data to `/mosquitto/data`
+* log to `/mosquitto/log/mosquitto.log`
+
+i.e. add the following to `mosquitto.conf`:
+```
+persistence true
+persistence_location /mosquitto/data/
+
+log_dest file /mosquitto/log/mosquitto.log
+```
+
+**Note**: If a volume is used, the data will persist between containers.
+
+##Build
+Build the image:
+```
+docker build -t eclipse-mosquitto:1.4.14 .
+```
+
+##Run
+Run a container using the new image:
+```
+docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log eclipse-mosquitto:1.4.14
+```
+:boom: if the mosquitto configuration (mosquitto.conf) was modified
+to use non-default ports, the docker run command will need to be updated
+to expose the ports that have been configured.

--- a/docker/1.4.14/docker-entrypoint.sh
+++ b/docker/1.4.14/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/ash
+
+set -e
+exec "$@"
+


### PR DESCRIPTION
As I encounter issue with 1.4.12, I needed to test with 1.4.14

Here is a pull request based on alpine:edge

please note that for reason that I ignore, docker-entrypoint.sh didnt wanted to run before I added specific permission, which isnt in your version.