### PR TITLE
Add test for persistent subscription

### DIFF
--- a/test/broker/11-persistent-subscription.conf
+++ b/test/broker/11-persistent-subscription.conf
@@ -1,0 +1,3 @@
+port 1888
+persistence true
+persistence_file mosquitto-test.db

--- a/test/broker/11-persistent-subscription.py
+++ b/test/broker/11-persistent-subscription.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+# Test whether a client subscribed to a topic receives its own message sent to that topic.
+
+import inspect, os, sys
+# From http://stackoverflow.com/questions/279237/python-import-a-module-from-a-folder
+cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"..")))
+if cmd_subfolder not in sys.path:
+    sys.path.insert(0, cmd_subfolder)
+
+import mosq_test
+
+rc = 1
+mid = 530
+keepalive = 60
+connect_packet = mosq_test.gen_connect(
+    "persitent-subscription-test", keepalive=keepalive, clean_session=False,
+)
+connack_packet = mosq_test.gen_connack(rc=0)
+connack_packet2 = mosq_test.gen_connack(rc=0, resv=1)  # session present
+
+subscribe_packet = mosq_test.gen_subscribe(mid, "subpub/qos1", 1)
+suback_packet = mosq_test.gen_suback(mid, 1)
+
+mid = 300
+publish_packet = mosq_test.gen_publish("subpub/qos1", qos=1, mid=mid, payload="message")
+puback_packet = mosq_test.gen_puback(mid)
+
+mid = 1
+publish_packet2 = mosq_test.gen_publish("subpub/qos1", qos=1, mid=mid, payload="message")
+
+if os.path.exists('mosquitto-test.db'):
+    os.unlink('mosquitto-test.db')
+
+broker = mosq_test.start_broker(filename=os.path.basename(__file__))
+
+(stdo1, stde1) = ("", "")
+try:
+    sock = mosq_test.do_client_connect(connect_packet, connack_packet, timeout=20)
+    sock.send(subscribe_packet)
+
+    if mosq_test.expect_packet(sock, "suback", suback_packet):
+        broker.terminate()
+        broker.wait()
+        (stdo1, stde1) = broker.communicate()
+        sock.close()
+        broker = mosq_test.start_broker(filename=os.path.basename(__file__))
+
+        sock = mosq_test.do_client_connect(connect_packet, connack_packet2, timeout=20)
+
+        sock.send(publish_packet)
+
+        if mosq_test.expect_packet(sock, "puback", puback_packet):
+
+            if mosq_test.expect_packet(sock, "publish2", publish_packet2):
+                rc = 0
+
+    sock.close()
+finally:
+    broker.terminate()
+    broker.wait()
+    if rc:
+        (stdo, stde) = broker.communicate()
+        print(stde1 + stde)
+    if os.path.exists('mosquitto-test.db'):
+        os.unlink('mosquitto-test.db')
+
+
+exit(rc)
+

--- a/test/broker/Makefile
+++ b/test/broker/Makefile
@@ -12,7 +12,7 @@ clean :
 test-compile : 
 	$(MAKE) -C c
 
-test : test-compile 01 02 03 04 05 06 07 08 09 10
+test : test-compile 01 02 03 04 05 06 07 08 09 10 11
 
 01 :
 	./01-connect-success.py
@@ -98,3 +98,5 @@ endif
 10 :
 	./10-listener-mount-point.py
 
+11 :
+	./11-persistent-subscription.py


### PR DESCRIPTION
The PR add test for persistent subscription.
This test show a bug currently present in develop branch (and not in master).

The issue is that subscription are not correctly persisted in the database. Without the test, we can reproduce the bug with:
```
$ cat mosquitto.conf 
persistence true
listener 1888
$ rm -f mosquitto.db
$ ./mosquitto -c mosquitto.conf&
$ ./client/mosquitto_sub -p 1888 -q 1 -t thetopic -c -i test   # Stop it as soon as it connected to broker
$ ./client/mosquitto_pub -p 1888 -q 1 -t thetopic -m "message sent before restart"
# Stop the broker and restart it
$ ./mosquitto -c mosquitto.conf&
$ ./client/mosquitto_pub -p 1888 -q 1 -t thetopic -m "message sent after restart (not received)"
$ ./client/mosquitto_pub -p 1888 -q 1 -t " /thetopic" -m "message sent after restart on another topic"
$ ./client/mosquitto_sub -p 1888 -q 1 -t thetopic -c -i test
message sent before restart
message sent after restart on another topic
```

By reading mosquitto.db, the topic stored in mosquitto.db is not "thetopic", but "<whitespace>/thetopic".

This issue was introduced by 883af8a, which prefix all topics by a whitespace (except $SYS). I'm no sure to understand why that whitespace is added and tried to remove [the if that add it](https://github.com/eclipse/mosquitto/blob/c26b852c530d471e8a51439f78b4d0821bfc790d/src/subs.c#L186), while it worked for basic subscription (and presitence), it breaks 03-pattern-matching test.
