### PR TITLE
Fix a bug for use_identity_as_username for websockets

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -158,6 +158,12 @@ static int callback_mqtt(struct libwebsocket_context *context,
 	int rc;
 	uint8_t byte;
 
+#ifdef WITH_TLS
+	X509 *client_cert = NULL;
+	X509_NAME *name;
+	X509_NAME_ENTRY *name_entry;
+#endif
+
 	db = &int_db;
 
 	switch (reason) {
@@ -183,6 +189,19 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				mosq->ws_context = context;
 #endif
 				mosq->wsi = wsi;
+#ifdef WITH_TLS
+				if (in) {  // in should contains SSL Context
+					client_cert = SSL_get_peer_certificate((SSL *)in);
+					if ( client_cert ) {
+						name = X509_get_subject_name(client_cert);
+						name_entry = X509_NAME_get_entry(name, i);
+						mosq->username = _mosquitto_strdup((char *)ASN1_STRING_data(X509_NAME_ENTRY_get_data(name_entry)));
+
+					}
+					X509_free(client_cert);
+					client_cert = NULL;
+				}
+#endif /* WITH_TLS */
 				u->mosq = mosq;
 			}else{
 				return -1;


### PR DESCRIPTION
I have already opened an issue for this: #497

If parameter use_identity as_username is true, that works only for a MQTTS connection. If websockets are used, the username is not filled with content from UserCertificate.

I found the place in websocket.c and has fixed the bug. Implementation of use_identity as_username is now uniform.
We also liked to use DN as username. Configurable as parameters in the listener section of the configuration file.

We would like to know if such patches are also welcome.
Many Thanks.
Best regards, Alexander
Signed-off-by: Alexander Chestnov <Alexander.Chestnov@exceet.de>