### PR TITLE
MQTT version 5 (limited to basic packet transfer).

### DIFF
--- a/lib/handle_pubrec.c
+++ b/lib/handle_pubrec.c
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
 
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Add mqtt version 5.
 */
 
 #include <assert.h>
@@ -23,6 +24,7 @@ Contributors:
 #include "memory_mosq.h"
 #include "messages_mosq.h"
 #include "mqtt3_protocol.h"
+#include "mqtt5_protocol.h"
 #include "net_mosq.h"
 #include "packet_mosq.h"
 #include "read_handle.h"
@@ -37,12 +39,29 @@ int handle__pubrec(struct mosquitto *mosq)
 {
 	uint16_t mid;
 	int rc;
+	uint8_t result = 0;
 
 	assert(mosq);
 	rc = packet__read_uint16(&mosq->in_packet, &mid);
 	if(rc) return rc;
+
+	if(mosq->protocol == mosq_p_mqtt5){
+		if(mosq->in_packet.remaining_length > 2){
+			rc = packet__read_byte(&mosq->in_packet, &result);
+			if(rc) return rc;
+		}
+		if(mosq->in_packet.remaining_length >= 4){
+			/* Skip v5 property so far. Should be implimented in the future. */
+			rc = packet__read_property(mosq, &mosq->in_packet);
+			if(rc) return rc;
+		}
+	}
 #ifdef WITH_BROKER
-	log__printf(NULL, MOSQ_LOG_DEBUG, "Received PUBREC from %s (Mid: %d)", mosq->id, mid);
+	if(mosq->protocol == mosq_p_mqtt5){
+		log__printf(NULL, MOSQ_LOG_DEBUG, "Received PUBREC from %s (Mid: %d) (%d)", mosq->id, mid, result);
+	}else{
+		log__printf(NULL, MOSQ_LOG_DEBUG, "Received PUBREC from %s (Mid: %d)", mosq->id, mid);
+	}
 
 	rc = db__message_update(mosq, mid, mosq_md_out, mosq_ms_wait_for_pubcomp);
 #else
@@ -60,4 +79,5 @@ int handle__pubrec(struct mosquitto *mosq)
 
 	return MOSQ_ERR_SUCCESS;
 }
+
 

--- a/lib/handle_pubrel.c
+++ b/lib/handle_pubrel.c
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
 
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Add mqtt version 5.
 */
 
 #include <assert.h>
@@ -23,6 +24,7 @@ Contributors:
 #include "memory_mosq.h"
 #include "messages_mosq.h"
 #include "mqtt3_protocol.h"
+#include "mqtt5_protocol.h"
 #include "net_mosq.h"
 #include "packet_mosq.h"
 #include "read_handle.h"
@@ -41,17 +43,34 @@ int handle__pubrel(struct mosquitto_db *db, struct mosquitto *mosq)
 	struct mosquitto_message_all *message = NULL;
 #endif
 	int rc;
+	uint8_t result = 0;
 
 	assert(mosq);
-	if(mosq->protocol == mosq_p_mqtt311){
+	if((mosq->protocol == mosq_p_mqtt311) || (mosq->protocol == mosq_p_mqtt5)){
 		if((mosq->in_packet.command&0x0F) != 0x02){
 			return MOSQ_ERR_PROTOCOL;
 		}
 	}
 	rc = packet__read_uint16(&mosq->in_packet, &mid);
 	if(rc) return rc;
+
+	if(mosq->protocol == mosq_p_mqtt5){
+		if(mosq->in_packet.remaining_length > 2){
+			rc = packet__read_byte(&mosq->in_packet, &result);
+			if(rc) return rc;
+		}
+		if(mosq->in_packet.remaining_length >= 4){
+			/* Skip v5 property so far. Should be implimented in the future. */
+			rc = packet__read_property(mosq, &mosq->in_packet);
+			if(rc) return rc;
+		}
+	}
 #ifdef WITH_BROKER
-	log__printf(NULL, MOSQ_LOG_DEBUG, "Received PUBREL from %s (Mid: %d)", mosq->id, mid);
+	if(mosq->protocol == mosq_p_mqtt5){
+		log__printf(NULL, MOSQ_LOG_DEBUG, "Received PUBREL from %s (Mid: %d) (%d)", mosq->id, mid, result);
+	}else{
+		log__printf(NULL, MOSQ_LOG_DEBUG, "Received PUBREL from %s (Mid: %d)", mosq->id, mid);
+	}
 
 	if(db__message_release(db, mosq, mid, mosq_md_in)){
 		/* Message not found. Still send a PUBCOMP anyway because this could be
@@ -79,4 +98,5 @@ int handle__pubrel(struct mosquitto_db *db, struct mosquitto *mosq)
 
 	return MOSQ_ERR_SUCCESS;
 }
+
 

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -12,7 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
-   Tatsuzo Osawa - Add epoll.
+   Tatsuzo Osawa - Add epoll, add mqtt version 5.
 */
 
 #ifndef MOSQUITTO_INTERNAL_H
@@ -113,7 +113,8 @@ enum mosquitto__protocol {
 	mosq_p_invalid = 0,
 	mosq_p_mqtt31 = 1,
 	mosq_p_mqtt311 = 2,
-	mosq_p_mqtts = 3
+	mosq_p_mqtts = 3,
+	mosq_p_mqtt5 = 4,
 };
 
 enum mosquitto__threaded_state {
@@ -283,4 +284,5 @@ struct mosquitto {
 #define STREMPTY(str) (str[0] == '\0')
 
 #endif
+
 

--- a/lib/mqtt5_protocol.h
+++ b/lib/mqtt5_protocol.h
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2009-2017 Roger Light <roger@atchoo.org>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+ 
+The Eclipse Public License is available at
+   http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+ 
+Contributors:
+   Tatsuzo Osawa - Add mqtt version 5.
+*/
+
+#ifndef MQTT5_PROTOCOL_H
+#define MQTT5_PROTOCOL_H
+
+/* For version 5 of the MQTT protocol */
+
+#define PROTOCOL_NAME_v5 "MQTT"
+#define PROTOCOL_VERSION_v5 5
+
+#define AUTH 0xF0  // Added a new message type for version 5
+
+/* Reason Codes for version 5 */
+
+#define MQTT5_RC_SUCCESS 0
+#define MQTT5_RC_NORMAL_DISCONNECTION 0
+#define MQTT5_RC_GRANTED_QOS_0 0
+#define MQTT5_RC_GRANTED_QOS_1 1
+#define MQTT5_RC_GRANTED_QOS_2 2
+#define MQTT5_RC_DISCONNECT_WITH_WILL_MESSAGE 4
+#define MQTT5_RC_NO_MATCHING_SUBSCRIBERS 16
+#define MQTT5_RC_NO_SUBSCRIPTION_FOUND 17
+#define MQTT5_RC_CONTINUE_AUTHENTICATION 24
+#define MQTT5_RC_RE_AUTHENTICATE 25
+#define MQTT5_RC_UNSPECIFIED_ERROR 128
+#define MQTT5_RC_MALFORMED_PACKET 129
+#define MQTT5_RC_PROTOCOL_ERROR 130
+#define MQTT5_RC_IMPLEMENTATION_SPECIFIC_ERROR 131
+#define MQTT5_RC_UNSUPPORTED_PROTOCOL_VERSION 132
+#define MQTT5_RC_CLIENT_IDENTIFIER_NOT_VALID 133
+#define MQTT5_RC_BAD_USER_NAME_OR_PASSWORD 134
+#define MQTT5_RC_NOT_AUTHORIZED 135
+#define MQTT5_RC_SERVER_UNAVAILABLE 136
+#define MQTT5_RC_SERVER_BUSY 137
+#define MQTT5_RC_BANNED 138
+#define MQTT5_RC_SERVER_SHUTTING_DOWN 139
+#define MQTT5_RC_BAD_AUTHENTICATION_METHOD 140
+#define MQTT5_RC_KEEP_ALIVE_TIMEOUT 141
+#define MQTT5_RC_SESSION_TAKEN_OVER 142
+#define MQTT5_RC_TOPIC_FILTER_INVALID 143
+#define MQTT5_RC_TOPIC_NAME_INVALID 144
+#define MQTT5_RC_PACKET_IDENTIFIER_IN_USE 145
+#define MQTT5_RC_PACKET_IDENTIFIER_NOT_FOUND 146
+#define MQTT5_RC_RECEIVE_MAXIMUM_EXCEEDED 147
+#define MQTT5_RC_TOPIC_ALIAS_INVALID 148
+#define MQTT5_RC_PACKET_TOO_LARGE 149
+#define MQTT5_RC_MESSAGE_RATE_TOO_HIGH 150
+#define MQTT5_RC_QUOTA_EXCEEDED 151
+#define MQTT5_RC_ADMINISTRATIVE_ACTION 152
+#define MQTT5_RC_PAYLOAD_FORMAT_INVALID 153
+#define MQTT5_RC_RETAIN_NOT_SUPPORTED 154
+#define MQTT5_RC_QOS_NOT_SUPPORTED 155
+#define MQTT5_RC_USE_ANOTHER_SERVER 156
+#define MQTT5_RC_SERVER_MOVED 157
+#define MQTT5_RC_SHARED_SUBSCRIPTION_NOT_SUPPORTED 158
+#define MQTT5_RC_CONNECTION_RATE_EXCEEDED 159
+#define MQTT5_RC_MAXIMUM_CONNECT_TIME 160
+#define MQTT5_RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED 161
+#define MQTT5_RC_WILDCARD_SUBSCRIPTIONS_NOT_SUPPORTED 162
+
+/* Property Identifiers for version 5 */
+
+	// Add in the future.
+
+#endif
+

--- a/lib/packet_mosq.h
+++ b/lib/packet_mosq.h
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Add mqtt version 5.   
 */
 #ifndef PACKET_MOSQ_H
 #define PACKET_MOSQ_H
@@ -27,15 +28,23 @@ int packet__alloc(struct mosquitto__packet *packet);
 void packet__cleanup(struct mosquitto__packet *packet);
 int packet__queue(struct mosquitto *mosq, struct mosquitto__packet *packet);
 
+typedef uint32_t varint_t;
+size_t varint_len(varint_t x);
+#define MAX_VARIABLE_BYTE_INT 268435455
+
 int packet__read_byte(struct mosquitto__packet *packet, uint8_t *byte);
 int packet__read_bytes(struct mosquitto__packet *packet, void *bytes, uint32_t count);
 int packet__read_string(struct mosquitto__packet *packet, char **str);
 int packet__read_uint16(struct mosquitto__packet *packet, uint16_t *word);
+int packet__read_varint(struct mosquitto__packet *packet, varint_t *x);
+int packet__read_property(struct mosquitto *mosq, struct mosquitto__packet *packet);
 
 void packet__write_byte(struct mosquitto__packet *packet, uint8_t byte);
 void packet__write_bytes(struct mosquitto__packet *packet, const void *bytes, uint32_t count);
 void packet__write_string(struct mosquitto__packet *packet, const char *str, uint16_t length);
 void packet__write_uint16(struct mosquitto__packet *packet, uint16_t word);
+void packet__write_varint(struct mosquitto__packet *packet, varint_t x);
+void packet__write_property(struct mosquitto *mosq, struct mosquitto__packet *packet);
 
 int packet__write(struct mosquitto *mosq);
 #ifdef WITH_BROKER
@@ -45,3 +54,4 @@ int packet__read(struct mosquitto *mosq);
 #endif
 
 #endif
+

--- a/lib/send_mosq.h
+++ b/lib/send_mosq.h
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Add mqtt version 5.
 */
 #ifndef SEND_MOSQ_H
 #define SEND_MOSQ_H
@@ -24,6 +25,7 @@ int send__real_publish(struct mosquitto *mosq, uint16_t mid, const char *topic, 
 
 int send__connect(struct mosquitto *mosq, uint16_t keepalive, bool clean_session);
 int send__disconnect(struct mosquitto *mosq);
+int send__disconnect_v5(struct mosquitto *mosq, int result);
 int send__pingreq(struct mosquitto *mosq);
 int send__pingresp(struct mosquitto *mosq);
 int send__puback(struct mosquitto *mosq, uint16_t mid);
@@ -35,3 +37,4 @@ int send__subscribe(struct mosquitto *mosq, int *mid, const char *topic, uint8_t
 int send__unsubscribe(struct mosquitto *mosq, int *mid, const char *topic);
 
 #endif
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set (MOSQ_SRCS
 	../lib/send_disconnect.c
 	../lib/send_publish.c
 	send_suback.c
+	send_unsuback.c
 	signals.c
 	../lib/send_subscribe.c
 	../lib/send_unsubscribe.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,6 +43,7 @@ OBJS=	mosquitto.o \
 		send_publish.o \
 		send_suback.o \
 		send_subscribe.o \
+		send_unsuback.o \
 		send_unsubscribe.o \
 		service.o \
 		signals.o \
@@ -161,6 +162,9 @@ send_suback.o : send_suback.c mosquitto_broker_internal.h
 	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
 
 send_subscribe.o : ../lib/send_subscribe.c ../lib/send_mosq.h
+	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+
+send_unsuback.o : send_unsuback.c mosquitto_broker_internal.h
 	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
 
 send_unsubscribe.o : ../lib/send_unsubscribe.c ../lib/send_mosq.h

--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -554,7 +554,7 @@ int handle__connect(struct mosquitto_db *db, struct mosquitto *context)
 			}
 		}
 
-		if(context->protocol == mosq_p_mqtt311){
+		if((context->protocol == mosq_p_mqtt311) || (context->protocol == mosq_p_mqtt5)){
 			if(clean_session == 0){
 				connect_ack |= 0x01;
 			}
@@ -748,6 +748,7 @@ int handle__disconnect(struct mosquitto_db *db, struct mosquitto *context)
 	do_disconnect(db, context);
 	return MOSQ_ERR_SUCCESS;
 }
+
 
 
 

--- a/src/handle_subscribe.c
+++ b/src/handle_subscribe.c
@@ -86,6 +86,7 @@ int handle__subscribe(struct mosquitto_db *db, struct mosquitto *context)
 						"Malformed UTF-8 in subscription string from %s, disconnecting.",
 						context->id);
 				mosquitto__free(sub);
+				mosquitto__free(payload);
 				return MOSQ_ERR_PROTOCOL;
 			}
 
@@ -210,6 +211,7 @@ int handle__subscribe(struct mosquitto_db *db, struct mosquitto *context)
 
 	return rc;
 }
+
 
 
 

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -493,6 +493,7 @@ int restore_privileges(void);
  * ============================================================ */
 int send__connack(struct mosquitto *context, int ack, int result);
 int send__suback(struct mosquitto *context, uint16_t mid, uint32_t payloadlen, const void *payload);
+int send__unsuback(struct mosquitto *context, uint16_t mid, uint32_t payloadlen, const void *payload);
 
 /* ============================================================
  * Network functions
@@ -624,4 +625,5 @@ struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *li
 void do_disconnect(struct mosquitto_db *db, struct mosquitto *context);
 
 #endif
+
 

--- a/src/send_unsuback.c
+++ b/src/send_unsuback.c
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2009-2016 Roger Light <roger@atchoo.org>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+   Tatsuzo Osawa - Add mqtt version 5.
+*/
+
+#include "config.h"
+
+#include "mosquitto_broker_internal.h"
+#include "mqtt3_protocol.h"
+#include "mqtt5_protocol.h"
+#include "memory_mosq.h"
+#include "packet_mosq.h"
+#include "util_mosq.h"
+
+
+int send__unsuback(struct mosquitto *context, uint16_t mid, uint32_t payloadlen, const void *payload)
+{
+	struct mosquitto__packet *packet = NULL;
+	int rc;
+
+	log__printf(NULL, MOSQ_LOG_DEBUG, "Sending UNSUBACK to %s", context->id);
+
+	packet = mosquitto__calloc(1, sizeof(struct mosquitto__packet));
+	if(!packet) return MOSQ_ERR_NOMEM;
+
+	packet->command = UNSUBACK;
+	packet->remaining_length = 2+payloadlen;
+	if(context->protocol == mosq_p_mqtt5){
+		packet->remaining_length += varint_len(0);
+	}
+	rc = packet__alloc(packet);
+	if(rc){
+		mosquitto__free(packet);
+		return rc;
+	}
+	packet__write_uint16(packet, mid);
+	if(context->protocol == mosq_p_mqtt5){
+		packet__write_property(context, packet);
+	}
+	if(payloadlen){
+		packet__write_bytes(packet, payload, payloadlen);
+	}
+
+	return packet__queue(context, packet);
+}
+
+

--- a/test/broker/12-mqttv5.py
+++ b/test/broker/12-mqttv5.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# MQTT version 5 tests.
+base_dir = '/home/centos/paho.mqtt.testing/interoperability/'
+test_filename = 'client_test5.py'
+
+import inspect, os, sys, subprocess, distutils.spawn
+
+try:
+    assert(distutils.spawn.find_executable('python3'))
+except:
+    print("WARNING: python3 not available, skipping mqttv5 test.")
+    exit(0)
+
+try:
+    assert(os.path.exists(base_dir + test_filename))
+except:
+    print("WARNING: paho.mqtt.testing module not available, skipping mqttv5 test.")
+    print("Preparing test environment:")
+    print("  $ git clone https://github.com/eclipse/paho.mqtt.testing/")
+    print("  $ cd paho.mqtt.testing")
+    print("  $ git checkout -b mqttv5 origin/mqttv5")
+    print("  and set proper base_dir in mosquitto's 12-mqttv5_test.py")
+    exit(0)
+
+# From http://stackoverflow.com/questions/279237/python-import-a-module-from-a-folder
+cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"..")))
+if cmd_subfolder not in sys.path:
+    sys.path.insert(0, cmd_subfolder)
+
+import mosq_test
+
+availabe_test = [
+    'test_basic',
+    'test_retained_message',
+    'test_zero_length_clientid',
+    'test_overlapping_subscriptions',
+    'test_redelivery_on_reconnect',
+    'test_dollar_topics',
+    'test_user_properties',
+    'test_payload_format',
+    'test_request_response']
+
+for i in availabe_test:
+    rc = 1
+    print('mqttv5 ' + i)
+    cmd = ['../../src/mosquitto', '-p', '1883']
+    broker = mosq_test.start_broker(filename=os.path.basename(__file__), cmd=cmd, port=1883)
+
+    try:
+        subprocess.check_call(['python3', base_dir + test_filename, 'Test.' + i], cwd = base_dir)
+        rc = 0
+    finally:
+        broker.terminate()
+        broker.wait()
+        if rc:
+            (stdo, stde) = broker.communicate()
+            print(stde)
+            exit(rc)
+
+exit(rc)
+
+

--- a/test/broker/Makefile
+++ b/test/broker/Makefile
@@ -12,7 +12,7 @@ clean :
 test-compile : 
 	$(MAKE) -C c
 
-test : test-compile 01 02 03 04 05 06 07 08 09 10 11
+test : test-compile 01 02 03 04 05 06 07 08 09 10 11 12
 
 01 :
 	./01-connect-success.py
@@ -100,3 +100,7 @@ endif
 
 11 :
 	./11-persistent-subscription.py
+
+12 :
+	./12-mqttv5.py
+


### PR DESCRIPTION
Reimplemented MQTT version 5 support.
- Focus on the broker's features of basic packet transfer.
- Integrate test using paho.mqtt.testing
  (Need to revise 08-ssl-bridge.conf and skip 11-persistent-subscription.py for reaching the tests of 12-mqttv5.py)

Please evaluate.

Signed-off-by: Tatsuzo Osawa (toast-uz)