### PR TITLE
Support using SSL connection over SOCKS5 PROXY

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -653,7 +653,10 @@ int _mosquitto_socket_connect(struct mosquitto *mosq, const char *host, uint16_t
 	if(rc > 0) return rc;
 
 	mosq->sock = sock;
-	rc = _mosquitto_socket_connect_step3(mosq, host, port, bind_address, blocking);
+
+	/* Set up ssl only if not using proxy */
+	if( mosq->state == mosq_cs_new )
+		rc = _mosquitto_socket_connect_step3(mosq, host, port, bind_address, blocking);
 
 	return rc;
 }

--- a/lib/socks_mosq.c
+++ b/lib/socks_mosq.c
@@ -364,6 +364,7 @@ int mosquitto__socks5_read(struct mosquitto *mosq)
 			/* Auth passed */
 			_mosquitto_packet_cleanup(&mosq->in_packet);
 			mosq->state = mosq_cs_new;
+			_mosquitto_socket_connect_step3(mosq, mosq->host, mosq->port, mosq->bind_address, true);
 			return _mosquitto_send_connect(mosq, mosq->keepalive, mosq->clean_session);
 		}else{
 			i = mosq->in_packet.payload[1];


### PR DESCRIPTION
This patch adds support to use SSL over SOCKS5 PROXY.
The issue was:
- when SSL was used, all SOCKS5 messages would be encrypted as well
- SOCKS5 proxy server can't interpret the encrypted SOCKS5 message
- the connection would be rejected in this case.
The solution is to enable SSL configuration after SOCKS5 connection is
completed if proxy is used.

Signed-off-by: Bin Li <bin.li@windriver.com>