### PR TITLE
Fix subs memory issue.

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -144,7 +144,6 @@ static void subhier_clean(struct mosquitto_db *db, struct mosquitto__subhier **s
 	struct mosquitto__subhier *peer, *subhier_tmp;
 	struct mosquitto__subleaf *leaf, *nextleaf;
 
-	if(!*subhier) return;	
 	HASH_ITER(hh, *subhier, peer, subhier_tmp){
 		leaf = peer->subs;
 		while(leaf){
@@ -158,15 +157,9 @@ static void subhier_clean(struct mosquitto_db *db, struct mosquitto__subhier **s
 		subhier_clean(db, &peer->children);
 		UHPA_FREE_TOPIC(peer);
 
-		// skip head for preventing to collapse *subhier
-		if(*subhier != peer){
-			HASH_DELETE(hh, *subhier, peer);
-			mosquitto__free(peer);
-		}
+		HASH_DELETE(hh, *subhier, peer);
+		mosquitto__free(peer);
 	}
-	peer = *subhier;
-	HASH_DELETE(hh, *subhier, peer);
-	mosquitto__free(peer);	
 }
 
 int db__close(struct mosquitto_db *db)

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -12,7 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
-   Tatsuzo Osawa - Add epoll.
+   Tatsuzo Osawa - Add epoll. Fix subs memory issue.
 */
 
 #ifndef MOSQUITTO_BROKER_INTERNAL_H
@@ -547,7 +547,7 @@ void sys_tree__update(struct mosquitto_db *db, int interval, time_t start_time);
  * Subscription functions
  * ============================================================ */
 int sub__add(struct mosquitto_db *db, struct mosquitto *context, const char *sub, int qos, struct mosquitto__subhier **root);
-struct mosquitto__subhier *sub__add_hier_entry(struct mosquitto__subhier **parent, const char *topic, size_t len);
+struct mosquitto__subhier *sub__add_hier_entry(struct mosquitto__subhier *parent, struct mosquitto__subhier **head, const char *topic, size_t len);
 int sub__remove(struct mosquitto_db *db, struct mosquitto *context, const char *sub, struct mosquitto__subhier *root);
 void sub__tree_print(struct mosquitto__subhier *root, int level);
 int sub__clean_session(struct mosquitto_db *db, struct mosquitto *context);

--- a/src/subs.c
+++ b/src/subs.c
@@ -12,6 +12,7 @@ and the Eclipse Distribution License is available at
  
 Contributors:
    Roger Light - initial implementation and documentation.
+   Tatsuzo Osawa - Fix subs memory issue.
 */
 
 /* A note on matching topic subscriptions.
@@ -314,7 +315,7 @@ static int sub__add_recurse(struct mosquitto_db *db, struct mosquitto *context, 
 		return sub__add_recurse(db, context, qos, branch, tokens->next);
 	}else{
 		/* Not found */
-		branch = sub__add_hier_entry(&subhier->children, UHPA_ACCESS_TOPIC(tokens), tokens->topic_len+1);
+		branch = sub__add_hier_entry(subhier, &subhier->children, UHPA_ACCESS_TOPIC(tokens), tokens->topic_len+1);
 		if(!branch) return MOSQ_ERR_NOMEM;
 
 		return sub__add_recurse(db, context, qos, branch, tokens->next);
@@ -406,18 +407,18 @@ static void sub__search(struct mosquitto_db *db, struct mosquitto__subhier *subh
 }
 
 
-struct mosquitto__subhier *sub__add_hier_entry(struct mosquitto__subhier **parent, const char *topic, size_t len)
+struct mosquitto__subhier *sub__add_hier_entry(struct mosquitto__subhier *parent, struct mosquitto__subhier **head, const char *topic, size_t len)
 {
 	struct mosquitto__subhier *child;
 
-	assert(parent);
+	assert(head);
 
 	child = mosquitto__malloc(sizeof(struct mosquitto__subhier));
 	if(!child){
 		log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
 		return NULL;
 	}
-	child->parent = *parent;
+	child->parent = parent;
 	child->topic_len = strlen(topic);
 	if(UHPA_ALLOC_TOPIC(child) == 0){
 		child->topic_len = 0;
@@ -433,13 +434,13 @@ struct mosquitto__subhier *sub__add_hier_entry(struct mosquitto__subhier **paren
 
 	if(child->topic_len+1 > sizeof(child->topic.array)){
 		if(child->topic.ptr){
-			HASH_ADD_KEYPTR(hh, *parent, child->topic.ptr, child->topic_len, child);
+			HASH_ADD_KEYPTR(hh, *head, child->topic.ptr, child->topic_len, child);
 		}else{
 			mosquitto__free(child);
 			return NULL;
 		}
 	}else{
-		HASH_ADD(hh, *parent, topic.array, child->topic_len, child);
+		HASH_ADD(hh, *head, topic.array, child->topic_len, child);
 	}
 
 	return child;
@@ -460,7 +461,7 @@ int sub__add(struct mosquitto_db *db, struct mosquitto *context, const char *sub
 
 	HASH_FIND(hh, *root, UHPA_ACCESS_TOPIC(tokens), tokens->topic_len, subhier);
 	if(!subhier){
-		subhier = sub__add_hier_entry(root, UHPA_ACCESS_TOPIC(tokens), tokens->topic_len+1);
+		subhier = sub__add_hier_entry(NULL, root, UHPA_ACCESS_TOPIC(tokens), tokens->topic_len+1);
 		if(!subhier){
 			sub__topic_tokens_free(tokens);
 			log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
@@ -545,12 +546,14 @@ static struct mosquitto__subhier *tmp_remove_subs(struct mosquitto__subhier *sub
 		return NULL;
 	}
 
-	if(sub->children || sub->subs){
+	if(sub->children || sub->subs || sub->retained){
 		return NULL;
 	}
 
 	parent = sub->parent;
-	HASH_DELETE(hh, parent, sub);
+	HASH_DELETE(hh, parent->children, sub);
+	UHPA_FREE_TOPIC(sub);
+	mosquitto__free(sub);
 
 	if(parent->subs == NULL
 			&& parent->children == NULL


### PR DESCRIPTION
Sorry for #528  closed accidentally.

------------
Rearranged subhier relation architecture and fixed memory issue #505 .

FYI, a sample dump of subhier after fix:

```
lv: children generation level
h: head of hash
f: following item of hash
p: parent of item
c: children of item

1503576769: lv:0 h:0x104f400   -> f:0x104f400   (p:(nil) c:(nil))
1503576769: lv:0 h:0x104f400   -> f:0x104f6d0 $SYS (p:(nil) c:0x104f860 $SYS)
1503576769: lv:1 h:0x104f860 $SYS -> f:0x104f860 $SYS (p:0x104f6d0 c:0x104fb30 broker)
1503576769: lv:2 h:0x104fb30 broker -> f:0x104fb30 broker (p:0x104f860 c:0x104fe00 version)
1503576769: lv:3 h:0x104fe00 version -> f:0x104fe00 version (p:0x104fb30 c:(nil))
1503576769: lv:3 h:0x104fe00 version -> f:0x10501d0 timestamp (p:0x104fb30 c:(nil))
1503576769: lv:3 h:0x104fe00 version -> f:0x10503f0 uptime (p:0x104fb30 c:(nil))
1503576769: lv:3 h:0x104fe00 version -> f:0x1050530 clients (p:0x104fb30 c:0x10505a0 total)
1503576769: lv:4 h:0x10505a0 total -> f:0x10505a0 total (p:0x1050530 c:(nil))
1503576769: lv:4 h:0x10505a0 total -> f:0x1050910 inactive (p:0x1050530 c:(nil))
1503576769: lv:4 h:0x10505a0 total -> f:0x1050a50 disconnected (p:0x1050530 c:(nil))
1503576769: lv:4 h:0x10505a0 total -> f:0x1050b50 active (p:0x1050530 c:(nil))
1503576769: lv:4 h:0x10505a0 total -> f:0x1050cb0 connected (p:0x1050530 c:(nil))
Comparing with before fix in #505 helps your understanding.
At last, the parent pointed the real parent.
```

Comparing with before fix in #505 helps your understanding.
At last, the parent pointed the real parent.

Signed-off-by: Tatsuzo Osawa (toast-uz)
