### PR TITLE
Fix for persistent subscription issue #501.

### DIFF
--- a/src/subs.c
+++ b/src/subs.c
@@ -468,7 +468,7 @@ int sub__add(struct mosquitto_db *db, struct mosquitto *context, const char *sub
 		}
 
 	}
-	rc = sub__add_recurse(db, context, qos, subhier, tokens);
+	rc = sub__add_recurse(db, context, qos, subhier, tokens->next);
 
 	sub__topic_tokens_free(tokens);
 
@@ -490,7 +490,7 @@ int sub__remove(struct mosquitto_db *db, struct mosquitto *context, const char *
 
 	HASH_FIND(hh, root, UHPA_ACCESS_TOPIC(tokens), tokens->topic_len, subhier);
 	if(subhier){
-		rc = sub__remove_recurse(db, context, subhier, tokens);
+		rc = sub__remove_recurse(db, context, subhier, tokens->next);
 	}else{
 		printf("nope\n");
 	}
@@ -523,9 +523,9 @@ int sub__messages_queue(struct mosquitto_db *db, const char *source_id, const ch
 			/* We have a message that needs to be retained, so ensure that the subscription
 			 * tree for its topic exists.
 			 */
-			sub__add_recurse(db, NULL, 0, subhier, tokens);
+			sub__add_recurse(db, NULL, 0, subhier, tokens->next);
 		}
-		sub__search(db, subhier, tokens, source_id, topic, qos, retain, *stored, true);
+		sub__search(db, subhier, tokens->next, source_id, topic, qos, retain, *stored, true);
 	}
 	sub__topic_tokens_free(tokens);
 
@@ -725,7 +725,7 @@ int sub__retain_queue(struct mosquitto_db *db, struct mosquitto *context, const 
 	HASH_FIND(hh, db->subs, UHPA_ACCESS_TOPIC(tokens), tokens->topic_len, subhier);
 
 	if(subhier){
-		retain__search(db, subhier, tokens, context, sub, sub_qos, 0);
+		retain__search(db, subhier, tokens->next, context, sub, sub_qos, 0);
 	}
 	while(tokens){
 		tail = tokens->next;

--- a/test/broker/03-pattern-matching-sys.py
+++ b/test/broker/03-pattern-matching-sys.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Test whether a patter subscribe match or not $SYS
+import subprocess
+import threading
+import time
+
+try:
+    import paho.mqtt.client
+except ImportError:
+    print("WARNING: paho.mqtt module not available, skipping pattern matching $SYS")
+    exit(0)
+
+
+rc = 1
+
+broker = subprocess.Popen(['../../src/mosquitto', '-p', '1888'], stderr=subprocess.PIPE)
+# Wait for broker to start
+time.sleep(1)
+
+
+def wait_sys_msg(topic="$SYS/#"):
+    """ Connect a client and wait for any message on $SYS
+    """
+    def on_sys_message(client, userdata, msg):
+        assert msg.topic.startswith('$SYS/')
+        client.disconnect()
+
+    client = paho.mqtt.client.Client("sys-monitor")
+    client.connect("localhost", port=1888)
+    client.message_callback_add("$SYS/#", on_sys_message)
+    client.subscribe("$SYS/broker/publish/messages/dropped")
+    client.loop_forever()
+
+
+def test_pattern(sub_topic, sys_topic="$SYS/#"):
+    msgs = []
+    sub_finished = threading.Event()
+    def on_message(client, userdata, msg):
+        msgs.append(msg)
+
+    def on_subscribe(client, userdata, mid, granted_qos):
+        sub_finished.set()
+
+    client = paho.mqtt.client.Client("pattern-matching-sys", userdata=msgs)
+    client.connect("localhost", port=1888)
+    client.on_message = on_message
+    client.on_subscribe = on_subscribe
+    client.subscribe(sub_topic, qos=1)
+    client.loop_start()
+
+    sub_finished.wait(5)
+    assert sub_finished.is_set(), "subscribe timedout"
+    wait_sys_msg()
+    client.loop_stop()
+    for m in msgs:
+        if m.topic.startswith("$SYS"):
+            print("Received message on topic %s" % m.topic)
+            return False
+    return True
+
+
+try:
+    assert test_pattern("#")
+    assert test_pattern("+/#")
+
+    # $SYS/broker/version or $SYS/broker/uptime, ...
+    assert test_pattern("+/broker/+", '$SYS/broker/+')
+    assert test_pattern("+/+/+", '$SYS/+/+')
+
+    rc = 0
+finally:
+    broker.terminate()
+    (stdo, stde) = broker.communicate()
+    if rc:
+        print(stde)
+
+exit(rc)
+

--- a/test/broker/11-persistent-subscription-sys.conf
+++ b/test/broker/11-persistent-subscription-sys.conf
@@ -1,0 +1,3 @@
+port 1888
+persistence true
+persistence_file mosquitto-test.db

--- a/test/broker/11-persistent-subscription-sys.py
+++ b/test/broker/11-persistent-subscription-sys.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# Test whether a pattern subscribe match or not $SYS
+import Queue
+import subprocess
+import threading
+import time
+
+try:
+    import paho.mqtt.client
+except ImportError:
+    print("WARNING: paho.mqtt module not available, skipping pattern matching $SYS")
+    exit(0)
+
+
+import inspect, os, sys
+# From http://stackoverflow.com/questions/279237/python-import-a-module-from-a-folder
+cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(inspect.getfile( inspect.currentframe() ))[0],"..")))
+if cmd_subfolder not in sys.path:
+    sys.path.insert(0, cmd_subfolder)
+
+import mosq_test
+
+
+rc = 1
+
+broker = mosq_test.start_broker(filename=os.path.basename(__file__))
+# Wait for broker to start
+time.sleep(1)
+
+
+sys_client = 'client-sys'
+
+clients_config = [
+    # client-id, topic
+    (sys_client, '$SYS/broker/uptime'),
+    ('client1', '#'),
+    ('client2', '+/+/+'),
+    ('client3', '+/#'),
+]
+
+
+msgs = Queue.Queue()
+
+(stdo1, stde1) = ("", "")
+try:
+    clients = []
+    def on_message(client, userdata, msg):
+        msgs.put((userdata, msg))
+
+    for (client_id, topic) in clients_config:
+        client = paho.mqtt.client.Client(
+            client_id, userdata=client_id, clean_session=False,
+        )
+        client.connect("localhost", port=1888)
+        client.on_message = on_message
+        client.subscribe(topic, qos=1)
+        client.loop_start()
+
+    # Wait for connection and subscription
+    time.sleep(3)
+
+    broker.terminate()
+    broker.wait()
+    (stdo1, stde1) = broker.communicate()
+    broker = None
+
+    try:
+        sys_has_message = False
+        while True:
+            (client_id, msg) = msgs.get_nowait()
+            if msg.topic.startswith("$SYS"):
+                if client_id != sys_client:
+                    raise ValueError("Received message on topic %s" % msg.topic)
+                else:
+                    sys_has_message = True
+    except Queue.Empty:
+        pass
+    assert sys_has_message
+
+    broker = mosq_test.start_broker(filename=os.path.basename(__file__))
+
+    try:
+        sys_has_message = False
+        while True:
+            (client_id, msg) = msgs.get(timeout=5)
+            if msg.topic.startswith("$SYS"):
+                if client_id != sys_client:
+                    raise ValueError("Received message on topic %s" % msg.topic)
+                else:
+                    sys_has_message = True
+    except Queue.Empty:
+        pass
+    assert sys_has_message
+    rc = 0
+finally:
+    if broker:
+        broker.terminate()
+        (stdo, stde) = broker.communicate()
+    else:
+        stde = ""
+    if rc:
+        print(stde1 + stde)
+    if os.path.exists('mosquitto-test.db'):
+        os.unlink('mosquitto-test.db')
+
+exit(rc)
+

--- a/test/broker/Makefile
+++ b/test/broker/Makefile
@@ -50,6 +50,7 @@ endif
 	./03-publish-b2c-disconnect-qos2.py
 	./03-pattern-matching.py
 	./03-publish-qos1-queued-bytes.py
+	./03-pattern-matching-sys.py
 
 04 :
 	./04-retain-qos0.py
@@ -100,3 +101,4 @@ endif
 
 11 :
 	./11-persistent-subscription.py
+	./11-persistent-subscription-sys.py


### PR DESCRIPTION
This is an alternative fix to #532.

While looking at subs.c, I've found out that always search twice in the subs hierarchy using the very first token.
For example with sub_add/sub_add_recurse:
* sub__add will use the first token (" " or "$SYS") to find the subhier [link](https://github.com/eclipse/mosquitto/blob/d3239920d789a16cb9c54c598f4fc7d5ef03f2e9/src/subs.c#L461) 
* sub__add will call sub__add_recurse with the same token (e.g. not token->next)
* sub__add_recurse will once more use the first token to find the subhier [link](https://github.com/eclipse/mosquitto/blob/d3239920d789a16cb9c54c598f4fc7d5ef03f2e9/src/subs.c#L312)

This could be also seen with the sub__tree_print (signal USR2):
Without the fix:
```
1504888920: Socket error on client test, disconnecting.
     
       
        thetopic (test, 1)
    $SYS
      $SYS
        broker
```

With the fix:
```
1504888794: Socket error on client test, disconnecting.
     
      thetopic (test, 1)
    $SYS
      broker
```

Note that $SYS is present twice, also note that "thetopic" is indented on more level and an additional line (for the " " root prefix) is also present.