### PR TITLE
Apline latest package version is 1.4.14-r1

### DIFF
--- a/docker/1.4.14/Dockerfile
+++ b/docker/1.4.14/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER David Audet <david.audet@ca.com>
 
 LABEL Description="Eclipse Mosquitto MQTT Broker"
 
-RUN apk --no-cache add mosquitto=1.4.14-r0 && \
+RUN apk --no-cache add mosquitto=1.4.14-r1 && \
     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
     cp /etc/mosquitto/mosquitto.conf /mosquitto/config && \
     chown -R mosquitto:mosquitto /mosquitto

--- a/docker/1.4.14/Dockerfile
+++ b/docker/1.4.14/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER David Audet <david.audet@ca.com>
 
 LABEL Description="Eclipse Mosquitto MQTT Broker"
 
-RUN apk --no-cache add mosquitto=1.4.14-r1 && \
+RUN apk --no-cache add mosquitto=1.4.14-r2 && \
     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
     cp /etc/mosquitto/mosquitto.conf /mosquitto/config && \
     chown -R mosquitto:mosquitto /mosquitto


### PR DESCRIPTION
The latest package on Alpine is version 1.4.14-r1 on 1.4.14.

See: [Alpine packages - mosquitto x86_64](https://pkgs.alpinelinux.org/packages?name=mosquitto&branch=&repo=&arch=x86_64&maintainer=)
