### PR TITLE
Add support for auth-plugin per listener

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -127,8 +127,6 @@ int db__open(struct mosquitto__config *config, struct mosquitto_db *db)
 	subhier = sub__add_hier_entry(&db->subs, "$SYS", strlen("$SYS"));
 	if(!subhier) return MOSQ_ERR_NOMEM;
 
-	db->unpwd = NULL;
-
 #ifdef WITH_PERSISTENCE
 	if(config->persistence && config->persistence_filepath){
 		if(persist__restore(db)) return 1;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -148,7 +148,23 @@ struct mosquitto__listener {
 	int sock_count;
 	int client_count;
 	enum mosquitto_protocol protocol;
+	char *acl_file;
+	char *clientid_prefixes;
+	char *password_file;
+	char *psk_file;
+	struct mosquitto__auth_plugin_config *auth_plugins_config;
+	int auth_plugin_config_count;
 	bool use_username_as_clientid;
+	bool allow_anonymous;
+	bool allow_zero_length_clientid;
+	char *auto_id_prefix;
+	int auto_id_prefix_len;
+	struct mosquitto__unpwd *unpwd;
+	struct mosquitto__acl_user *acl_list;
+	struct mosquitto__acl *acl_patterns;
+	struct mosquitto__unpwd *psk_id;
+	struct mosquitto__auth_plugin *auth_plugins;
+	int auth_plugin_count;
 #ifdef WITH_TLS
 	char *cafile;
 	char *capath;
@@ -180,15 +196,9 @@ struct mosquitto__auth_plugin_config
 
 struct mosquitto__config {
 	char *config_file;
-	char *acl_file;
-	bool allow_anonymous;
 	bool allow_duplicate_messages;
-	bool allow_zero_length_clientid;
-	char *auto_id_prefix;
-	int auto_id_prefix_len;
 	int autosave_interval;
 	bool autosave_on_changes;
-	char *clientid_prefixes;
 	bool connection_messages;
 	bool daemon;
 	struct mosquitto__listener default_listener;
@@ -201,14 +211,12 @@ struct mosquitto__config {
 	char *log_file;
 	FILE *log_fptr;
 	uint32_t message_size_limit;
-	char *password_file;
 	bool persistence;
 	char *persistence_location;
 	char *persistence_file;
 	char *persistence_filepath;
 	time_t persistent_client_expiration;
 	char *pid_file;
-	char *psk_file;
 	bool queue_qos0_messages;
 	int sys_interval;
 	bool upgrade_outgoing_qos;
@@ -222,8 +230,6 @@ struct mosquitto__config {
 	struct mosquitto__bridge *bridges;
 	int bridge_count;
 #endif
-	struct mosquitto__auth_plugin_config *auth_plugins;
-	int auth_plugin_count;
 };
 
 struct mosquitto__subleaf {
@@ -345,10 +351,6 @@ struct mosquitto__auth_plugin{
 struct mosquitto_db{
 	dbid_t last_db_id;
 	struct mosquitto__subhier *subs;
-	struct mosquitto__unpwd *unpwd;
-	struct mosquitto__acl_user *acl_list;
-	struct mosquitto__acl *acl_patterns;
-	struct mosquitto__unpwd *psk_id;
 	struct mosquitto *contexts_by_id;
 	struct mosquitto *contexts_by_sock;
 	struct mosquitto *contexts_for_free;
@@ -364,8 +366,6 @@ struct mosquitto_db{
 	int msg_store_count;
 	unsigned long msg_store_bytes;
 	struct mosquitto__config *config;
-	struct mosquitto__auth_plugin *auth_plugins;
-	int auth_plugin_count;
 #ifdef WITH_SYS_TREE
 	int subscription_count;
 	int retained_count;
@@ -599,8 +599,8 @@ int mosquitto_security_init_default(struct mosquitto_db *db, bool reload);
 int mosquitto_security_apply_default(struct mosquitto_db *db);
 int mosquitto_security_cleanup_default(struct mosquitto_db *db, bool reload);
 int mosquitto_acl_check_default(struct mosquitto_db *db, struct mosquitto *context, const char *topic, int access);
-int mosquitto_unpwd_check_default(struct mosquitto_db *db, const char *username, const char *password);
-int mosquitto_psk_key_get_default(struct mosquitto_db *db, const char *hint, const char *identity, char *key, int max_key_len);
+int mosquitto_unpwd_check_default(struct mosquitto_db *db, struct mosquitto *context, const char *username, const char *password);
+int mosquitto_psk_key_get_default(struct mosquitto_db *db, struct mosquitto *context, const char *hint, const char *identity, char *key, int max_key_len);
 
 /* ============================================================
  * Window service related functions


### PR DESCRIPTION
This PR includes first step to fix #242. It adds per-listener authentication/authorization settings.

The following option is now per-listener:
* allow_anonymous
* password_file
* psk_file
* acl_file
* clientid_prefixes
* allow_zero_length_clientid
* auto_id_prefix
* auth_plugin
* auth_opt_*

To keep compatibility with existing config file, if any of those option is present before a listener directive, it will be used as global/default value. Having both global and per-listener works, but the per-listener override it.

Example:
```
acl_file acl-global
password_file pw-global
auth_plugin plugin-global.so

listener 1883
acl_file acl-listenner1
auth_plugin plugin-1.so
auth_plugin plugin-2.so

listener 1884
password_file pw-1884

listener 1885
```
Will result in three listeners:
* On port 1883:
  * acl_file from acl-listenner1
  * password_file from pw-global
  * auth_plugin plugin-1.so, then plugin-2.so
* On port 1884:
  * acl_file from acl-global
  * password_file from pw-1884
  * auth_plugin plugin-global.so
* On port 1885:
  * acl_file from acl-global
  * password_file from pw-global
  * auth_plugin plugin-global.so (the SAME instance as the one used by listener of port 1884)

Note:
* there is a breaking change: if someone specify auth options after a listener directive, it's no longer global.
* Override work per option. If a listener define password_file, only password_file is overridden. Another behavior could be that if any authentication/authorization option is defined in a listener, no global option are used for this listener (use case: use ACL file/password file by default, and for one listener use auth_plugin but not files).
* In the above example, auth_plugin used in global option is instantiated only once (e.g. call to plugin's mosquitto_auth_plugin_init & co) even if used by multiple listeners. This avoid a breaking change with plugin that does not support being instantiated multiple time (for example due to usage of some global variables).
* On the other hand if the same plugin is used within multiple listener directive, it will be instantiated multiple times.

Tasks to do:
* validate that the behavior for global/override is the one user expect.
* write some tests
* write some docs
* There is one gotcha with persistent session. Subscription of disconnected client/disconnected client don't store the associated listener, therefor when a disconnected client receive a message, an ACL check will be performed with no associated listener. In this case we can not perform the ACL check using the correct listener configuration and with this PR the global one is used. Note: currently mosquitto will perform another ACL check when the client reconnect, at this time the listener will be defined and correct ACL will be performed, assuming the global ACL check didn't rejected the message.