### PR TITLE
Add a callback for manipulating the SSL context before connecting

### DIFF
--- a/lib/cpp/mosquittopp.cpp
+++ b/lib/cpp/mosquittopp.cpp
@@ -63,6 +63,12 @@ static void on_log_wrapper(struct mosquitto *mosq, void *userdata, int level, co
 	m->on_log(level, str);
 }
 
+static void on_ssl_ctx_wrapper(struct mosquitto *mosq, void *userdata, void *ssl_ctx)
+{
+	class mosquittopp *m = (class mosquittopp *)userdata;
+	m->on_ssl_ctx(ssl_ctx);
+}
+
 int lib_version(int *major, int *minor, int *revision)
 {
 	if(major) *major = LIBMOSQUITTO_MAJOR;
@@ -116,6 +122,7 @@ mosquittopp::mosquittopp(const char *id, bool clean_session)
 	mosquitto_subscribe_callback_set(m_mosq, on_subscribe_wrapper);
 	mosquitto_unsubscribe_callback_set(m_mosq, on_unsubscribe_wrapper);
 	mosquitto_log_callback_set(m_mosq, on_log_wrapper);
+	mosquitto_ssl_ctx_callback_set(m_mosq, on_ssl_ctx_wrapper);
 }
 
 mosquittopp::~mosquittopp()
@@ -135,6 +142,7 @@ int mosquittopp::reinitialise(const char *id, bool clean_session)
 		mosquitto_subscribe_callback_set(m_mosq, on_subscribe_wrapper);
 		mosquitto_unsubscribe_callback_set(m_mosq, on_unsubscribe_wrapper);
 		mosquitto_log_callback_set(m_mosq, on_log_wrapper);
+		mosquitto_ssl_ctx_callback_set(m_mosq, on_ssl_ctx_wrapper);
 	}
 	return rc;
 }

--- a/lib/cpp/mosquittopp.h
+++ b/lib/cpp/mosquittopp.h
@@ -99,6 +99,7 @@ class mosqpp_EXPORT mosquittopp {
 		virtual void on_subscribe(int /*mid*/, int /*qos_count*/, const int * /*granted_qos*/) {return;}
 		virtual void on_unsubscribe(int /*mid*/) {return;}
 		virtual void on_log(int /*level*/, const char * /*str*/) {return;}
+		virtual void on_ssl_ctx(void * /*ssl_ctx*/) {return;}
 		virtual void on_error() {return;}
 };
 

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -1286,6 +1286,15 @@ void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on_log)(struct mo
 	pthread_mutex_unlock(&mosq->log_callback_mutex);
 }
 
+void mosquitto_ssl_ctx_callback_set(struct mosquitto *mosq, void (*on_ssl_ctx)(struct mosquitto *, void *, void *))
+{
+#ifdef WITH_TLS
+	pthread_mutex_lock(&mosq->callback_mutex);
+	mosq->on_ssl_ctx = on_ssl_ctx;
+	pthread_mutex_unlock(&mosq->callback_mutex);
+#endif
+}
+
 void mosquitto_user_data_set(struct mosquitto *mosq, void *userdata)
 {
 	if(mosq){

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -1234,6 +1234,23 @@ libmosq_EXPORT void mosquitto_unsubscribe_callback_set(struct mosquitto *mosq, v
 libmosq_EXPORT void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on_log)(struct mosquitto *, void *, int, const char *));
 
 /*
+ * Function: mosquitto_ssl_ctx_callback_set
+ *
+ * Set the SSL_CTX callback. This should be used if you want to set additional parameters
+ * in the OpenSSL context before opening the connection.
+ *
+ *  mosq -       a valid mosquitto instance.
+ *  on_ssl_ctx - a callback function in the following form:
+ *               void callback(struct mosquitto *mosq, void *obj, void *ssl_ctx)
+
+ * Callback Parameters:
+ *  mosq -    the mosquitto instance making the callback.
+ *  obj -     the user data provided in <mosquitto_new>
+ *  ssl_ctx - the OpenSSL SSL_CTX structure
+ */
+libmosq_EXPORT void mosquitto_ssl_ctx_callback_set(struct mosquitto *mosq, void (*on_ssl_ctx)(struct mosquitto *, void *, void *));
+
+/*
  * Function: mosquitto_reconnect_delay_set
  *
  * Control the behaviour of the client when it has unexpectedly disconnected in

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -249,6 +249,7 @@ struct mosquitto {
 	void (*on_subscribe)(struct mosquitto *, void *userdata, int mid, int qos_count, const int *granted_qos);
 	void (*on_unsubscribe)(struct mosquitto *, void *userdata, int mid);
 	void (*on_log)(struct mosquitto *, void *userdata, int level, const char *str);
+	void (*on_ssl_ctx)(struct mosquitto *, void *userdata, void *ssl_ctx);
 	//void (*on_error)();
 	char *host;
 	int port;

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -615,6 +615,16 @@ int _mosquitto_socket_connect_step3(struct mosquitto *mosq, const char *host, ui
 #endif
 		}
 
+#ifndef WITH_BROKER
+		pthread_mutex_lock(&mosq->callback_mutex);
+		if(mosq->on_ssl_ctx){
+			mosq->in_callback = true;
+			mosq->on_ssl_ctx(mosq, mosq->userdata, mosq->ssl_ctx);
+			mosq->in_callback = false;
+		}
+		pthread_mutex_unlock(&mosq->callback_mutex);
+#endif
+
 		mosq->ssl = SSL_new(mosq->ssl_ctx);
 		if(!mosq->ssl){
 			COMPAT_CLOSE(mosq->sock);


### PR DESCRIPTION
This patch adds a new on_ssl_ctx callback which allows client applications to manipulate the OpenSSL context prior to making connections. libcurl provides a similar facility with its ssl_ctx_callback function.

This can be used to do advanced SSL validation, or for my particular use case, to override the check date for certificate date validation when the system time() command cannot be used in an embedded environment.

Signed-off-by: Joel Williams <joel@joelw.id.au>