### PR TITLE
Add websockets_headers_size option

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -784,6 +784,18 @@
 							Defaults to 0.</para>
 					</listitem>
 				</varlistentry>
+				<varlistentry>
+					<term><option>websockets_headers_size</option> <replaceable>size</replaceable></term>
+					<listitem>
+                        <para>Change the websockets headers size. This is a
+							global option, it is not possible to set per
+							listener. This is the value passed to libwebsockets
+							max_http_header_data which is used for the buffer size
+							to process HTTP headers. See the libwebsockets documention
+							for more details. A value of 0 (the default) means to
+							use libwebsockets' default (which is 1024).</para>
+					</listitem>
+				</varlistentry>
 			</variablelist>
 		</refsect2>
 		<refsect2>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -503,6 +503,14 @@
 # libwebsockets documentation for more details. "log_type websockets" must also
 # be enabled.
 #websockets_log_level 0
+#
+# Change the websockets headers size. This is a global option, it is not
+# possible to set per listener. This is the value passed to libwebsockets
+# max_http_header_data which is used for the buffer size to process HTTP
+# headers. See the libwebsockets documentation for more details.
+# A value of 0 (the default) means to use libwebsockets' default (which is
+# 1024).
+#websockets_headers_size 0
 
 # If set to true, client connection and disconnection messages will be included
 # in the log.

--- a/src/conf.c
+++ b/src/conf.c
@@ -1813,6 +1813,16 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 #else
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Websockets support not available.");
 #endif
+				}else if(!strcmp(token, "websockets_headers_size")){
+#ifdef WITH_WEBSOCKETS
+#if defined(LWS_LIBRARY_VERSION_NUMBER) && LWS_LIBRARY_VERSION_NUMBER>=1007000
+					if(conf__parse_int(&token, "websockets_headers_size", &config->websockets_headers_size, saveptr)) return MOSQ_ERR_INVAL;
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Websockets headers size require libwebsocket 1.7+");
+#endif
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Websockets support not available.");
+#endif
 				}else if(!strcmp(token, "trace_level")
 						|| !strcmp(token, "ffdc_output")
 						|| !strcmp(token, "max_log_entries")

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -320,7 +320,7 @@ int main(int argc, char *argv[])
 			}
 		}else if(config.listeners[i].protocol == mp_websockets){
 #ifdef WITH_WEBSOCKETS
-			config.listeners[i].ws_context = mosq_websockets_init(&config.listeners[i], config.websockets_log_level);
+			config.listeners[i].ws_context = mosq_websockets_init(&config.listeners[i], &config);
 			if(!config.listeners[i].ws_context){
 				log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to create websockets listener on port %d.", config.listeners[i].port);
 				return 1;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -216,6 +216,7 @@ struct mosquitto__config {
 	bool verbose;
 #ifdef WITH_WEBSOCKETS
 	int websockets_log_level;
+	int websockets_headers_size;
 	bool have_websockets_listener;
 #endif
 #ifdef WITH_BRIDGE
@@ -616,9 +617,9 @@ void service_run(void);
  * ============================================================ */
 #ifdef WITH_WEBSOCKETS
 #  if defined(LWS_LIBRARY_VERSION_NUMBER)
-struct lws_context *mosq_websockets_init(struct mosquitto__listener *listener, int log_level);
+struct lws_context *mosq_websockets_init(struct mosquitto__listener *listener, const struct mosquitto__config *conf);
 #  else
-struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *listener, int log_level);
+struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *listener, const struct mosquitto__config *conf);
 #  endif
 #endif
 void do_disconnect(struct mosquitto_db *db, struct mosquitto *context);

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -583,7 +583,7 @@ static void log_wrap(int level, const char *line)
 	log__printf(NULL, MOSQ_LOG_WEBSOCKETS, "%s", l);
 }
 
-struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *listener, int log_level)
+struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *listener, const struct mosquitto__config *conf)
 {
 	struct lws_context_creation_info info;
 	struct libwebsocket_protocols *p;
@@ -625,6 +625,9 @@ struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *li
 #if LWS_LIBRARY_VERSION_MAJOR>1
 	info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
 #endif
+#if defined(LWS_LIBRARY_VERSION_NUMBER) && LWS_LIBRARY_VERSION_NUMBER>=1007000
+    info.max_http_header_data = conf->websockets_headers_size;
+#endif
 
 	user = mosquitto__calloc(1, sizeof(struct libws_mqtt_hack));
 	if(!user){
@@ -650,7 +653,7 @@ struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *li
 	info.user = user;
 	listener->ws_protocol = p;
 
-	lws_set_log_level(log_level, log_wrap);
+	lws_set_log_level(conf->websockets_log_level, log_wrap);
 
 	log__printf(NULL, MOSQ_LOG_INFO, "Opening websockets listen socket on port %d.", listener->port);
 	return libwebsocket_create_context(&info);


### PR DESCRIPTION
This PR fix #208 by adding an option websockets_headers_size which is passed to libwebsockets max_http_header_data.
