### PR TITLE
If a connection to an IPv6 network and it fails, then on the next att…

### DIFF
--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -272,6 +272,10 @@ struct mosquitto {
 	UT_hash_handle hh_sock;
 	struct mosquitto *for_free_next;
 #endif
+	/* If set, ignore ipv6 addresses.
+	   This variable will be set to true when a connection to an ipv6 address is attempted.
+	   If the connection is successfully set-up, the value will be reset. */
+	bool ignore_ipv6;
 };
 
 #define STREMPTY(str) (str[0] == '\0')

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -402,6 +402,9 @@ int _mosquitto_try_connect(struct mosquitto *mosq, const char *host, uint16_t po
 	}
 
 	for(rp = ainfo; rp != NULL; rp = rp->ai_next){
+		/* Only ignore ipv6 if there is another entry in the list */
+		if (mosq->ignore_ipv6 && rp->ai_family == PF_INET6 && NULL != rp->ai_next) continue;
+
 		*sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
 		if(*sock == INVALID_SOCKET) continue;
 
@@ -456,6 +459,11 @@ int _mosquitto_try_connect(struct mosquitto *mosq, const char *host, uint16_t po
 		COMPAT_CLOSE(*sock);
 		*sock = INVALID_SOCKET;
 	}
+	if (rp && rp->ai_family == PF_INET6)
+		mosq->ignore_ipv6 = true;
+	else
+		mosq->ignore_ipv6 = false;
+
 	freeaddrinfo(ainfo);
 	if(bind_address){
 		freeaddrinfo(ainfo_bind);

--- a/lib/read_handle_client.c
+++ b/lib/read_handle_client.c
@@ -37,6 +37,7 @@ int _mosquitto_handle_connack(struct mosquitto *mosq)
 	pthread_mutex_lock(&mosq->callback_mutex);
 	if(mosq->on_connect){
 		mosq->in_callback = true;
+		mosq->ignore_ipv6 = false;
 		mosq->on_connect(mosq, mosq->userdata, result);
 		mosq->in_callback = false;
 	}


### PR DESCRIPTION
…empt try to connect to an IPv4 address instead.

Bug: https://github.com/eclipse/mosquitto/issues/574

Signed-off-by: Kevin Gardner <kevinhgardner@gmail.com>