### PR TITLE
 Added new signal SIGWINCH to signal broker, that it should try to connect to disconnected bridge(s) now.

### DIFF
--- a/man/mosquitto.8.xml
+++ b/man/mosquitto.8.xml
@@ -452,6 +452,18 @@
 					testing feature only and may be removed at any time.</para>
 				</listitem>
 			</varlistentry>
+			<varlistentry>
+				<term>SIGWINCH</term>
+				<listitem>
+          <para>The SIGWINCH signal causes mosquitto to try to
+          reconnect to all bridges, which are disconnected at the
+          moment. It is useful when the internet connection is weak.
+          As soon as you have internet or vpn connectivity, you can
+          signal the broker, to try to reconnect. Set start_type to
+          auto (the default), and you can give a big number to
+          restart_timeout.</para>
+				</listitem>
+			</varlistentry>
 		</variablelist>
 	</refsect1>
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -59,6 +59,7 @@ extern bool flag_reload;
 extern bool flag_db_backup;
 #endif
 extern bool flag_tree_print;
+extern bool flag_bridge_reconnect;
 extern int run;
 
 #ifdef WITH_EPOLL
@@ -544,6 +545,21 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 			sub__tree_print(db->subs, 0);
 			flag_tree_print = false;
 		}
+#ifdef WITH_BRIDGE
+    if(flag_bridge_reconnect){
+      for(i=0; i<db->bridge_count; i++){
+        if(!db->bridges[i]) continue;
+
+        context = db->bridges[i];
+
+        if(context->sock == INVALID_SOCKET){
+          context->bridge->restart_t = 1;
+        }
+      }
+      flag_bridge_reconnect = false;
+    }
+#endif
+
 #ifdef WITH_WEBSOCKETS
 		for(i=0; i<db->config->listener_count; i++){
 			/* Extremely hacky, should be using the lws provided external poll

--- a/src/loop.c
+++ b/src/loop.c
@@ -137,6 +137,7 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 	sigaddset(&sigblock, SIGUSR1);
 	sigaddset(&sigblock, SIGUSR2);
 	sigaddset(&sigblock, SIGHUP);
+	sigaddset(&sigblock, SIGWINCH);
 #endif
 
 #ifndef WITH_EPOLL

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -61,6 +61,7 @@ bool flag_reload = false;
 bool flag_db_backup = false;
 #endif
 bool flag_tree_print = false;
+bool flag_bridge_reconnect = false;
 int run;
 #ifdef WITH_WRAP
 #include <syslog.h>
@@ -190,6 +191,14 @@ void mosquitto__daemonise(void)
 #endif
 }
 
+
+/* Signal handler for SIGWINCH - reconnect to bridge(s). */
+void handle_sigwinch(int signal)
+{
+#ifdef WITH_BRIDGE
+  flag_bridge_reconnect = true;
+#endif
+}
 
 int main(int argc, char *argv[])
 {
@@ -340,6 +349,7 @@ int main(int argc, char *argv[])
 #ifndef WIN32
 	signal(SIGUSR1, handle_sigusr1);
 	signal(SIGUSR2, handle_sigusr2);
+	signal(SIGWINCH, handle_sigwinch);
 	signal(SIGPIPE, SIG_IGN);
 #endif
 #ifdef WIN32


### PR DESCRIPTION
```
The SIGWINCH signal causes mosquitto to try to
reconnect to all bridges, which are disconnected at the
moment. It is useful when the internet connection is weak.
As soon as you have internet or vpn connectivity, you can
signal the broker, to try to reconnect. Set start_type to
auto (the default), and you can give a big number to
restart_timeout. This way as soon as you have internet,
you can reconnect with the bridge

Since there is no SIGUSR3, I picked one which is rarely used.
```