### PR TITLE
Quote ${DESTDIR} usage in various Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,18 +44,18 @@ install : mosquitto
 ifeq ($(WITH_DOCS),yes)
 	set -e; for d in ${DOCDIRS}; do $(MAKE) -C $${d} install; done
 endif
-	$(INSTALL) -d ${DESTDIR}/etc/mosquitto
-	$(INSTALL) -m 644 mosquitto.conf ${DESTDIR}/etc/mosquitto/mosquitto.conf.example
-	$(INSTALL) -m 644 aclfile.example ${DESTDIR}/etc/mosquitto/aclfile.example
-	$(INSTALL) -m 644 pwfile.example ${DESTDIR}/etc/mosquitto/pwfile.example
-	$(INSTALL) -m 644 pskfile.example ${DESTDIR}/etc/mosquitto/pskfile.example
+	$(INSTALL) -d "${DESTDIR}/etc/mosquitto"
+	$(INSTALL) -m 644 mosquitto.conf "${DESTDIR}/etc/mosquitto/mosquitto.conf.example"
+	$(INSTALL) -m 644 aclfile.example "${DESTDIR}/etc/mosquitto/aclfile.example"
+	$(INSTALL) -m 644 pwfile.example "${DESTDIR}/etc/mosquitto/pwfile.example"
+	$(INSTALL) -m 644 pskfile.example "${DESTDIR}/etc/mosquitto/pskfile.example"
 
 uninstall :
 	set -e; for d in ${DIRS}; do $(MAKE) -C $${d} uninstall; done
-	rm -f ${DESTDIR}/etc/mosquitto/mosquitto.conf
-	rm -f ${DESTDIR}/etc/mosquitto/aclfile.example
-	rm -f ${DESTDIR}/etc/mosquitto/pwfile.example
-	rm -f ${DESTDIR}/etc/mosquitto/pskfile.example
+	rm -f "${DESTDIR}/etc/mosquitto/mosquitto.conf"
+	rm -f "${DESTDIR}/etc/mosquitto/aclfile.example"
+	rm -f "${DESTDIR}/etc/mosquitto/pwfile.example"
+	rm -f "${DESTDIR}/etc/mosquitto/pskfile.example"
 
 dist : reallyclean
 	set -e; for d in ${DISTDIRS}; do $(MAKE) -C $${d} dist; done

--- a/client/Makefile
+++ b/client/Makefile
@@ -36,13 +36,13 @@ client_shared.o : client_shared.c client_shared.h
 	$(MAKE) -C ../lib libmosquitto.a
 
 install : all
-	$(INSTALL) -d ${DESTDIR}$(prefix)/bin
-	$(INSTALL) ${STRIP_OPTS} mosquitto_pub ${DESTDIR}${prefix}/bin/mosquitto_pub
-	$(INSTALL) ${STRIP_OPTS} mosquitto_sub ${DESTDIR}${prefix}/bin/mosquitto_sub
+	$(INSTALL) -d "${DESTDIR}$(prefix)/bin"
+	$(INSTALL) ${STRIP_OPTS} mosquitto_pub "${DESTDIR}${prefix}/bin/mosquitto_pub"
+	$(INSTALL) ${STRIP_OPTS} mosquitto_sub "${DESTDIR}${prefix}/bin/mosquitto_sub"
 
 uninstall :
-	-rm -f ${DESTDIR}${prefix}/bin/mosquitto_pub
-	-rm -f ${DESTDIR}${prefix}/bin/mosquitto_sub
+	-rm -f "${DESTDIR}${prefix}/bin/mosquitto_pub"
+	-rm -f "${DESTDIR}${prefix}/bin/mosquitto_sub"
 
 reallyclean : clean
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -43,22 +43,22 @@ all : ${ALL_DEPS}
 	$(MAKE) -C cpp
 
 install : all
-	$(INSTALL) -d ${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/
-	$(INSTALL) ${STRIP_OPTS} libmosquitto.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so.${SOVERSION}
-	ln -sf libmosquitto.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so
+	$(INSTALL) -d "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/"
+	$(INSTALL) ${STRIP_OPTS} libmosquitto.so.${SOVERSION} "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so.${SOVERSION}"
+	ln -sf libmosquitto.so.${SOVERSION} "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so"
 ifeq ($(WITH_STATIC_LIBRARIES),yes)
-	$(INSTALL) libmosquitto.a ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.a
-	${CROSS_COMPILE}${STRIP} -g --strip-unneeded ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.a
+	$(INSTALL) libmosquitto.a "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.a"
+	${CROSS_COMPILE}${STRIP} -g --strip-unneeded "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.a"
 endif
-	$(INSTALL) -d ${DESTDIR}${prefix}/include/
-	$(INSTALL) mosquitto.h ${DESTDIR}${prefix}/include/mosquitto.h
+	$(INSTALL) -d "${DESTDIR}${prefix}/include/"
+	$(INSTALL) mosquitto.h "${DESTDIR}${prefix}/include/mosquitto.h"
 	$(MAKE) -C cpp install
 
 uninstall :
-	-rm -f ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so.${SOVERSION}
-	-rm -f ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so
-	-rm -f ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.a
-	-rm -f ${DESTDIR}${prefix}/include/mosquitto.h
+	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so.${SOVERSION}"
+	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.so"
+	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquitto.a"
+	-rm -f "${DESTDIR}${prefix}/include/mosquitto.h"
 
 reallyclean : clean
 

--- a/lib/cpp/Makefile
+++ b/lib/cpp/Makefile
@@ -15,21 +15,21 @@ endif
 all : ${ALL_DEPS}
 
 install : all
-	$(INSTALL) -d ${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/
-	$(INSTALL) ${STRIP_OPTS} libmosquittopp.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so.${SOVERSION}
-	ln -sf libmosquittopp.so.${SOVERSION} ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so
+	$(INSTALL) -d "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/"
+	$(INSTALL) ${STRIP_OPTS} libmosquittopp.so.${SOVERSION} "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so.${SOVERSION}"
+	ln -sf libmosquittopp.so.${SOVERSION} "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so"
 ifeq ($(WITH_STATIC_LIBRARIES),yes)
-	$(INSTALL) libmosquittopp.a ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.a
-	${CROSS_COMPILE}${STRIP} -g --strip-unneeded ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.a
+	$(INSTALL) libmosquittopp.a "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.a"
+	${CROSS_COMPILE}${STRIP} -g --strip-unneeded "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.a"
 endif
-	$(INSTALL) -d ${DESTDIR}${prefix}/include/
-	$(INSTALL) mosquittopp.h ${DESTDIR}${prefix}/include/mosquittopp.h
+	$(INSTALL) -d "${DESTDIR}${prefix}/include/"
+	$(INSTALL) mosquittopp.h "${DESTDIR}${prefix}/include/mosquittopp.h"
 	
 uninstall :
-	-rm -f ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so.${SOVERSION}
-	-rm -f ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so
-	-rm -f ${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.a
-	-rm -f ${DESTDIR}${prefix}/include/mosquittopp.h
+	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so.${SOVERSION}"
+	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so"
+	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.a"
+	-rm -f "${DESTDIR}${prefix}/include/mosquittopp.h"
 
 clean :
 	-rm -f *.o libmosquittopp.so.${SOVERSION} libmosquittopp.a

--- a/man/Makefile
+++ b/man/Makefile
@@ -20,29 +20,29 @@ reallyclean : clean
 dist : mosquitto.8 mosquitto-tls.7 mosquitto.conf.5 mosquitto_passwd.1 mosquitto_pub.1 mosquitto_sub.1 mqtt.7 libmosquitto.3
 
 install :
-	$(INSTALL) -d ${DESTDIR}$(mandir)/man8
-	$(INSTALL) -m 644 mosquitto.8 ${DESTDIR}${mandir}/man8/mosquitto.8
-	$(INSTALL) -d ${DESTDIR}$(mandir)/man5
-	$(INSTALL) -m 644 mosquitto.conf.5 ${DESTDIR}${mandir}/man5/mosquitto.conf.5
-	$(INSTALL) -d ${DESTDIR}$(mandir)/man1
-	$(INSTALL) -m 644 mosquitto_passwd.1 ${DESTDIR}${mandir}/man1/mosquitto_passwd.1
-	$(INSTALL) -m 644 mosquitto_pub.1 ${DESTDIR}${mandir}/man1/mosquitto_pub.1
-	$(INSTALL) -m 644 mosquitto_sub.1 ${DESTDIR}${mandir}/man1/mosquitto_sub.1
-	$(INSTALL) -d ${DESTDIR}$(mandir)/man7
-	$(INSTALL) -m 644 mqtt.7 ${DESTDIR}${mandir}/man7/mqtt.7
-	$(INSTALL) -m 644 mosquitto-tls.7 ${DESTDIR}${mandir}/man7/mosquitto-tls.7
-	$(INSTALL) -d ${DESTDIR}$(mandir)/man3
-	$(INSTALL) -m 644 libmosquitto.3 ${DESTDIR}${mandir}/man3/libmosquitto.3
+	$(INSTALL) -d "${DESTDIR}$(mandir)/man8"
+	$(INSTALL) -m 644 mosquitto.8 "${DESTDIR}${mandir}/man8/mosquitto.8"
+	$(INSTALL) -d "${DESTDIR}$(mandir)/man5"
+	$(INSTALL) -m 644 mosquitto.conf.5 "${DESTDIR}${mandir}/man5/mosquitto.conf.5"
+	$(INSTALL) -d "${DESTDIR}$(mandir)/man1"
+	$(INSTALL) -m 644 mosquitto_passwd.1 "${DESTDIR}${mandir}/man1/mosquitto_passwd.1"
+	$(INSTALL) -m 644 mosquitto_pub.1 "${DESTDIR}${mandir}/man1/mosquitto_pub.1"
+	$(INSTALL) -m 644 mosquitto_sub.1 "${DESTDIR}${mandir}/man1/mosquitto_sub.1"
+	$(INSTALL) -d "${DESTDIR}$(mandir)/man7"
+	$(INSTALL) -m 644 mqtt.7 "${DESTDIR}${mandir}/man7/mqtt.7"
+	$(INSTALL) -m 644 mosquitto-tls.7 "${DESTDIR}${mandir}/man7/mosquitto-tls.7"
+	$(INSTALL) -d "${DESTDIR}$(mandir)/man3"
+	$(INSTALL) -m 644 libmosquitto.3 "${DESTDIR}${mandir}/man3/libmosquitto.3"
 
 uninstall :
-	-rm -f ${DESTDIR}${mandir}/man8/mosquitto.8
-	-rm -f ${DESTDIR}${mandir}/man5/mosquitto.conf.5
-	-rm -f ${DESTDIR}${mandir}/man1/mosquitto_passwd.1
-	-rm -f ${DESTDIR}${mandir}/man1/mosquitto_pub.1
-	-rm -f ${DESTDIR}${mandir}/man1/mosquitto_sub.1
-	-rm -f ${DESTDIR}${mandir}/man7/mqtt.7
-	-rm -f ${DESTDIR}${mandir}/man7/mosquitto-tls.7
-	-rm -f ${DESTDIR}${mandir}/man3/libmosquitto.3
+	-rm -f "${DESTDIR}${mandir}/man8/mosquitto.8"
+	-rm -f "${DESTDIR}${mandir}/man5/mosquitto.conf.5"
+	-rm -f "${DESTDIR}${mandir}/man1/mosquitto_passwd.1"
+	-rm -f "${DESTDIR}${mandir}/man1/mosquitto_pub.1"
+	-rm -f "${DESTDIR}${mandir}/man1/mosquitto_sub.1"
+	-rm -f "${DESTDIR}${mandir}/man7/mqtt.7"
+	-rm -f "${DESTDIR}${mandir}/man7/mosquitto-tls.7"
+	-rm -f "${DESTDIR}${mandir}/man3/libmosquitto.3"
 
 mosquitto.8 : mosquitto.8.xml
 	$(XSLTPROC) $^

--- a/src/Makefile
+++ b/src/Makefile
@@ -206,21 +206,21 @@ plugin_defer.so : plugin_defer.c mosquitto_plugin.h mosquitto_broker.h mosquitto
 	${CROSS_COMPILE}${CC} -I. -I../lib -fPIC -shared $< -o $@
 
 install : all
-	$(INSTALL) -d ${DESTDIR}$(prefix)/sbin
-	$(INSTALL) ${STRIP_OPTS} mosquitto ${DESTDIR}${prefix}/sbin/mosquitto
-	$(INSTALL) -d ${DESTDIR}$(prefix)/include
-	$(INSTALL) mosquitto_broker.h ${DESTDIR}${prefix}/include/mosquitto_broker.h
-	$(INSTALL) mosquitto_plugin.h ${DESTDIR}${prefix}/include/mosquitto_plugin.h
+	$(INSTALL) -d "${DESTDIR}$(prefix)/sbin"
+	$(INSTALL) ${STRIP_OPTS} mosquitto "${DESTDIR}${prefix}/sbin/mosquitto"
+	$(INSTALL) -d "${DESTDIR}$(prefix)/include"
+	$(INSTALL) mosquitto_broker.h "${DESTDIR}${prefix}/include/mosquitto_broker.h"
+	$(INSTALL) mosquitto_plugin.h "${DESTDIR}${prefix}/include/mosquitto_plugin.h"
 ifeq ($(WITH_TLS),yes)
-	$(INSTALL) -d ${DESTDIR}$(prefix)/bin
-	$(INSTALL) ${STRIP_OPTS} mosquitto_passwd ${DESTDIR}${prefix}/bin/mosquitto_passwd
+	$(INSTALL) -d "${DESTDIR}$(prefix)/bin"
+	$(INSTALL) ${STRIP_OPTS} mosquitto_passwd "${DESTDIR}${prefix}/bin/mosquitto_passwd"
 endif
 
 uninstall :
-	-rm -f ${DESTDIR}${prefix}/sbin/mosquitto
-	-rm -f ${DESTDIR}${prefix}/include/mosquitto_broker.h
-	-rm -f ${DESTDIR}${prefix}/include/mosquitto_plugin.h
-	-rm -f ${DESTDIR}${prefix}/bin/mosquitto_passwd
+	-rm -f "${DESTDIR}${prefix}/sbin/mosquitto"
+	-rm -f "${DESTDIR}${prefix}/include/mosquitto_broker.h"
+	-rm -f "${DESTDIR}${prefix}/include/mosquitto_plugin.h"
+	-rm -f "${DESTDIR}${prefix}/bin/mosquitto_passwd"
 
 clean : 
 	-rm -f *.o mosquitto mosquitto_passwd


### PR DESCRIPTION
This prevents failures during make install when whitespace
is part of DESTDIR pathname.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>