### PR TITLE
add full path to config file to fix docker run error

### DIFF
--- a/docker/1.4.10/README.md
+++ b/docker/1.4.10/README.md
@@ -15,7 +15,7 @@ Three mount points have been created in the image to be used for configuration, 
 When running the image, the default configuration values are used. 
 To use a custom configuration file, mount a **local** configuration file to `/mosquitto/config/mosquitto.conf`
 ```
-docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf mosquitto:1.4.10
+docker run -it -p 1883:1883 -p 9001:9001 -v $(pwd)/<path-to-configuration-file>:/mosquitto/config/mosquitto.conf mosquitto:1.4.10
 ```
 
 Configuration can be changed to:
@@ -42,7 +42,7 @@ docker build -t mosquitto:1.4.10 .
 ##Run
 Run a container using the new image:
 ```
-docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log mosquitto:1.4.10
+docker run -it -p 1883:1883 -p 9001:9001 -v $(pwd)/<path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log mosquitto:1.4.10
 ```
 :boom: if the mosquitto configuration (mosquitto.conf) was modified
 to use non-default ports, the docker run command will need to be updated

--- a/docker/1.4.4/README.md
+++ b/docker/1.4.4/README.md
@@ -15,7 +15,7 @@ Three mount points have been created in the image to be used for configuration, 
 When running the image, the default configuration values are used. 
 To use a custom configuration file, mount a **local** configuration file to `/mosquitto/config/mosquitto.conf`
 ```
-docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf mosquitto:1.4.4
+docker run -it -p 1883:1883 -p 9001:9001 -v $(pwd)/<path-to-configuration-file>:/mosquitto/config/mosquitto.conf mosquitto:1.4.4
 ```
 
 Configuration can be changed to:
@@ -42,7 +42,7 @@ docker build -t mosquitto:1.4.4 .
 ##Run
 Run a container using the new image:
 ```
-docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log mosquitto:1.4.4
+docker run -it -p 1883:1883 -p 9001:9001 -v $(pwd)/<path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log mosquitto:1.4.4
 ```
 :boom: if the mosquitto configuration (mosquitto.conf) was modified
 to use non-default ports, the docker run command will need to be updated

--- a/docker/1.4.8/README.md
+++ b/docker/1.4.8/README.md
@@ -15,7 +15,7 @@ Three mount points have been created in the image to be used for configuration, 
 When running the image, the default configuration values are used. 
 To use a custom configuration file, mount a **local** configuration file to `/mosquitto/config/mosquitto.conf`
 ```
-docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf mosquitto:1.4.8
+docker run -it -p 1883:1883 -p 9001:9001 -v $(pwd)/<path-to-configuration-file>:/mosquitto/config/mosquitto.conf mosquitto:1.4.8
 ```
 
 Configuration can be changed to:
@@ -42,7 +42,7 @@ docker build -t mosquitto:1.4.8 .
 ##Run
 Run a container using the new image:
 ```
-docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log mosquitto:1.4.8
+docker run -it -p 1883:1883 -p 9001:9001 -v $(pwd)/<path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log mosquitto:1.4.8
 ```
 :boom: if the mosquitto configuration (mosquitto.conf) was modified
 to use non-default ports, the docker run command will need to be updated


### PR DESCRIPTION
This should prevent cut-n-paste of the readme from  causing issue #457.  Should also get patched in the coverity-develop branch docker readme.