### PR TITLE
Fix issue when SSL_connect() returns SSL_ERROR_WANT_READ.

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -875,7 +875,11 @@ int _mosquitto_packet_write(struct mosquitto *mosq)
 	}
 	pthread_mutex_unlock(&mosq->out_packet_mutex);
 
+#if defined(WITH_TLS) && !defined(WITH_BROKER)
+	if((mosq->state == mosq_cs_connect_pending)||mosq->want_connect){
+#else
 	if(mosq->state == mosq_cs_connect_pending){
+#endif
 		pthread_mutex_unlock(&mosq->current_out_packet_mutex);
 		return MOSQ_ERR_SUCCESS;
 	}


### PR DESCRIPTION
Fix issue when SSL_connect() returns SSL_ERROR_WANT_READ. A call to SSL_write here will later transmit a new client hello and make ssl connection fail.

Se issue #608#

Signed-off-by: JonoJensen <jono.jensen@yahoo.se>