### PR TITLE
Dev client ticket support

### DIFF
--- a/client/client_shared.h
+++ b/client/client_shared.h
@@ -70,6 +70,9 @@ struct mosq_config {
 	char *psk;
 	char *psk_identity;
 #  endif
+#  ifdef WITH_TLS_TICKET
+	char *sessionfile;
+#  endif
 #endif
 	bool clean_session;
 	char **topics; /* sub */
@@ -97,5 +100,10 @@ void client_config_cleanup(struct mosq_config *cfg);
 int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg);
 int client_id_generate(struct mosq_config *cfg, const char *id_base);
 int client_connect(struct mosquitto *mosq, struct mosq_config *cfg);
+
+#if defined(WITH_TLS) && defined(WITH_TLS_TICKET)
+int client_read_file(const char* fname, char** buf);
+int client_write_file(const char* fname, const char* buf);
+#endif
 
 #endif

--- a/config.mk
+++ b/config.mk
@@ -28,6 +28,11 @@ WITH_TLS:=yes
 # This must be disabled if using openssl < 1.0.
 WITH_TLS_PSK:=yes
 
+# Comment out to disable TLS Ticket key length suport. Requires
+# WITH_TLS=yes.
+# This must be disabled if using openssl < 1.0.
+WITH_TLS_TICKET:=yes
+
 # Comment out to disable client client threading support.
 WITH_THREADING:=yes
 
@@ -189,6 +194,11 @@ ifeq ($(WITH_TLS),yes)
 		BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_TLS_PSK
 		LIB_CFLAGS:=$(LIB_CFLAGS) -DWITH_TLS_PSK
 		CLIENT_CFLAGS:=$(CLIENT_CFLAGS) -DWITH_TLS_PSK
+	endif
+	ifeq ($(WITH_TLS_TICKET),yes)
+		BROKER_CFLAGS:=$(BROKER_CFLAGS) -DWITH_TLS_TICKET
+		LIB_CFLAGS:=$(LIB_CFLAGS) -DWITH_TLS_TICKET
+		CLIENT_CFLAGS:=$(CLIENT_CFLAGS) -DWITH_TLS_TICKET
 	endif
 endif
 

--- a/lib/linker.version
+++ b/lib/linker.version
@@ -86,4 +86,7 @@ MOSQ_1.5 {
 		mosquitto_message_free_contents;
 		mosquitto_validate_utf8;
 		mosquitto_userdata;
+		mosquitto_tls_session_set;
+		mosquitto_tls_session_get;
+		mosquitto_tls_session_free;
 } MOSQ_1.4;

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -1020,6 +1020,69 @@ libmosq_EXPORT int mosquitto_tls_set(struct mosquitto *mosq,
 		int (*pw_callback)(char *buf, int size, int rwflag, void *userdata));
 
 /*
+ * Function: mosquitto_tls_session_set
+ *
+ * Load tls session with a saved session in pem format to use a received
+ * tls ticket.
+ * Must be called before <mosquitto_connect>.
+ *
+ * Parameters:
+ *  mosq -        a valid mosquitto instance.
+ *  pem_session - string received from previous call to
+ *                mosquitto_tls_session_get
+ *
+ * Returns:
+ *  MOSQ_ERR_SUCCESS - on success.
+ *  MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ *  MOSQ_ERR_NOMEM -   if an out of memory condition occurred.
+ *
+ * See Also:
+ *	<mosquitto_tls_session_get>
+ */
+libmosq_EXPORT int mosquitto_tls_session_set(struct mosquitto *mosq, const char* pem_session);
+
+/*
+ * Function: mosquitto_tls_session_get
+ *
+ * Get saved tls session in pem format possibly containg a saved tls ticket.
+ * Data returned is a copy (if not returning NULL) and must be freed by the client
+ * using a call to <mosquitto_tls_session_free>.
+ *
+ * Parameters:
+ *  mosq -            a valid mosquitto instance.
+ *  pem_session_ptr - set pointing to a copy of the session or NULL.
+ *
+ * Returns:
+ *  MOSQ_ERR_SUCCESS -       on success.
+ *  MOSQ_ERR_INVAL -         if the input parameters were invalid.
+ *  MOSQ_ERR_NOT_SUPPORTED - if not compiled with tls
+ *  MOSQ_ERR_NOMEM -         if an out of memory condition occurred.
+ *
+ * See Also:
+ *	<mosquitto_tls_session_set>, <mosquitto_tls_session_free>
+ */
+libmosq_EXPORT int mosquitto_tls_session_get(struct mosquitto *mosq, char** pem_session_ptr);
+
+/*
+ * Function: mosquitto_tls_session_free
+ *
+ * Free string returned by <mosquitto_tls_session_get>.
+ *
+ * Parameters:
+ *  mosq -            a valid mosquitto instance.
+ *  pem_session_ptr - set pointing to string in mosq object if any. Else set to null.
+ *
+ * Returns:
+ *  MOSQ_ERR_SUCCESS -       on success.
+ *  MOSQ_ERR_INVAL -         if the input parameters were invalid.
+ *  MOSQ_ERR_NOT_SUPPORTED - if not compiled with tls
+ *
+ * See Also:
+ *	<mosquitto_tls_session_get>
+ */
+libmosq_EXPORT int mosquitto_tls_session_free(char* pem_session);
+
+/*
  * Function: mosquitto_tls_insecure_set
  *
  * Configure verification of the server hostname in the server certificate. If

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -188,6 +188,9 @@ struct mosquitto {
 	char *tls_psk_identity;
 	int tls_cert_reqs;
 	bool tls_insecure;
+#if !defined(WITH_BROKER) && defined(WITH_TLS_TICKET)
+	char* tls_ticket_data;
+#endif
 #endif
 	bool want_write;
 	bool want_connect;
@@ -201,6 +204,9 @@ struct mosquitto {
 	pthread_mutex_t in_message_mutex;
 	pthread_mutex_t out_message_mutex;
 	pthread_mutex_t mid_mutex;
+#ifdef WITH_TLS_TICKET
+	pthread_mutex_t tls_ticket_mutex;
+#endif
 	pthread_t thread_id;
 #endif
 	bool clean_session;

--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -268,7 +268,11 @@ int packet__write(struct mosquitto *mosq)
 	}
 	pthread_mutex_unlock(&mosq->out_packet_mutex);
 
+#if defined(WITH_TLS) && !defined(WITH_BROKER)
+	if((mosq->state == mosq_cs_connect_pending)||mosq->want_connect){
+#else
 	if(mosq->state == mosq_cs_connect_pending){
+#endif
 		pthread_mutex_unlock(&mosq->current_out_packet_mutex);
 		return MOSQ_ERR_SUCCESS;
 	}

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -972,6 +972,28 @@
 							used. No password will be used.</para>
 					</listitem>
 				</varlistentry>
+				<varlistentry>
+					<term><option>tls_ticket_time</option> <replaceable>duration</replaceable></term>
+					<listitem>
+						<para>Set <option>tls_ticket_time</option> to use a
+							specific tls ticket key lifespan. If set, replaces
+							the default OpenSSL implementation. The implementation
+							used issues new tickets valid within a lifespan specified.
+							When the time has passes, the cipher keys are rotated and
+							all tickets will be invalid. No new tickets are issued on
+							the same session. Each client will have to renegotiate a
+							new session on the next connection.</para>
+						<para>The valid period should be an integer followed
+							by one of h d for hour, day respectively.
+							For example:</para>
+						<itemizedlist mark="circle">
+							<listitem><para>tls_ticket_time 4h</para></listitem>
+							<listitem><para>tls_ticket_time 2d</para></listitem>
+						</itemizedlist>
+						<para>As this is a non-standard option, the default if not
+							set is to use openSSL default implementation.</para>
+					</listitem>
+				</varlistentry>
 			</variablelist>
 		</refsect2>
 	</refsect1>

--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -431,6 +431,11 @@ int handle__connect(struct mosquitto_db *db, struct mosquitto *context)
 			}
 			X509_free(client_cert);
 			client_cert = NULL;
+#ifdef WITH_TLS_TICKET
+			if (SSL_session_reused(context->ssl)){
+				log__printf(NULL, MOSQ_LOG_DEBUG, "TLS Session reused.");
+			}
+#endif
 #ifdef REAL_WITH_TLS_PSK
 		}
 #endif /* REAL_WITH_TLS_PSK */

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -162,6 +162,9 @@ struct mosquitto__listener {
 	bool use_subject_as_username;
 	bool require_certificate;
 	char *tls_version;
+#ifdef WITH_TLS_TICKET
+	int tls_ticket_time;
+#endif
 #endif
 #ifdef WITH_WEBSOCKETS
 	struct libwebsocket_context *ws_context;


### PR DESCRIPTION
Adds TLS ticket support to client lib and test clients.
Adds control over TLS ticket life length to server.
(Does not reissue tickets on same session to force renegotiation when time expires.)
Requires issue #608 fix.