### PR TITLE
Fix for issue #537: should not log connection message if option disabled

### DIFF
--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -334,8 +334,8 @@ libmosq_EXPORT int mosquitto_username_pw_set(struct mosquitto *mosq, const char 
  * 	mosq -      a valid mosquitto instance.
  * 	host -      the hostname or ip address of the broker to connect to.
  * 	port -      the network port to connect to. Usually 1883.
- * 	keepalive - the number of seconds after which the broker should send a PING
- *              message to the client if no other messages have been exchanged
+ * 	keepalive - the number of seconds after which the client should send a PING
+ *              message to the broker if no other messages have been exchanged
  *              in that time.
  *
  * Returns:
@@ -362,8 +362,8 @@ libmosq_EXPORT int mosquitto_connect(struct mosquitto *mosq, const char *host, i
  * 	mosq -         a valid mosquitto instance.
  * 	host -         the hostname or ip address of the broker to connect to.
  * 	port -         the network port to connect to. Usually 1883.
- * 	keepalive -    the number of seconds after which the broker should send a PING
- *                 message to the client if no other messages have been exchanged
+ * 	keepalive -    the number of seconds after which the client should send a PING
+ *                 message to the broker if no other messages have been exchanged
  *                 in that time.
  *  bind_address - the hostname or ip address of the local network interface to
  *                 bind to.
@@ -395,8 +395,8 @@ libmosq_EXPORT int mosquitto_connect_bind(struct mosquitto *mosq, const char *ho
  * 	mosq -      a valid mosquitto instance.
  * 	host -      the hostname or ip address of the broker to connect to.
  * 	port -      the network port to connect to. Usually 1883.
- * 	keepalive - the number of seconds after which the broker should send a PING
- *              message to the client if no other messages have been exchanged
+ * 	keepalive - the number of seconds after which the client should send a PING
+ *              message to the broker if no other messages have been exchanged
  *              in that time.
  *
  * Returns:
@@ -430,8 +430,8 @@ libmosq_EXPORT int mosquitto_connect_async(struct mosquitto *mosq, const char *h
  * 	mosq -         a valid mosquitto instance.
  * 	host -         the hostname or ip address of the broker to connect to.
  * 	port -         the network port to connect to. Usually 1883.
- * 	keepalive -    the number of seconds after which the broker should send a PING
- *                 message to the client if no other messages have been exchanged
+ * 	keepalive -    the number of seconds after which the client should send a PING
+ *                 message to the broker if no other messages have been exchanged
  *                 in that time.
  *  bind_address - the hostname or ip address of the local network interface to
  *                 bind to.
@@ -466,8 +466,8 @@ libmosq_EXPORT int mosquitto_connect_bind_async(struct mosquitto *mosq, const ch
  * Parameters:
  * 	mosq -         a valid mosquitto instance.
  * 	host -         the hostname or ip address of the broker to connect to.
- * 	keepalive -    the number of seconds after which the broker should send a PING
- *                 message to the client if no other messages have been exchanged
+ * 	keepalive -    the number of seconds after which the client should send a PING
+ *                 message to the broker if no other messages have been exchanged
  *                 in that time.
  *  bind_address - the hostname or ip address of the local network interface to
  *                 bind to.

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -116,7 +116,7 @@
 					<para><code>user &lt;username&gt;</code></para>
 
 					<para>The username referred to here is the same as in
-						<option>password_fil</option>e. It is not the
+						<option>password_file</option>. It is not the
 						clientid.</para>
 
 					<para>It is also possible to define ACLs based on pattern
@@ -189,7 +189,7 @@
 				<term><option>auth_opt_*</option> <replaceable>value</replaceable></term>
 				<listitem>
 					<para>Options to be passed to the auth plugin. See the
-						specific plugin instructions.  </para>
+						specific plugin instructions.</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>
@@ -698,7 +698,7 @@
 							client connected to a listener with mount point
 							<replaceable>example</replaceable> can only see
 							messages that are published in the topic hierarchy
-							<replaceable>example</replaceable> and above.</para>
+							<replaceable>example</replaceable> and below.</para>
 						<para>Not reloaded on reload signal.</para>
 					</listitem>
 				</varlistentry>

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ to build. For Windows, see also `readme-windows.md`.
 
 If you are building from the git repository then the documentation will not
 already be built. Use `make binary` to skip building the man pages, or install
-`docbook-xsl` on Debian/Ubuntu systems.
+`docbook-xsl` and `xsltproc` on Debian/Ubuntu systems.
 
 ### Build Dependencies
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -323,12 +323,14 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 					 * expire it and clean up.
 					 */
 					if(now_time > context->disconnect_t+db->config->persistent_client_expiration){
-						if(context->id){
-							id = context->id;
-						}else{
-							id = "<unknown>";
+						if(db->config->connection_messages == true){
+							if(context->id){
+								id = context->id;
+							}else{
+								id = "<unknown>";
+							}
+							_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "Expiring persistent client %s due to timeout.", id);
 						}
-						_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "Expiring persistent client %s due to timeout.", id);
 #ifdef WITH_SYS_TREE
 						g_clients_expired++;
 #endif

--- a/src/net.c
+++ b/src/net.c
@@ -4,12 +4,12 @@ Copyright (c) 2009-2014 Roger Light <roger@atchoo.org>
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 and Eclipse Distribution License v1.0 which accompany this distribution.
- 
+
 The Eclipse Public License is available at
    http://www.eclipse.org/legal/epl-v10.html
 and the Eclipse Distribution License is available at
   http://www.eclipse.org/org/documents/edl-v10.php.
- 
+
 Contributors:
    Roger Light - initial implementation and documentation.
 */
@@ -191,7 +191,9 @@ int mqtt3_socket_accept(struct mosquitto_db *db, mosq_sock_t listensock)
 	}
 #endif
 
-	_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "New connection from %s on port %d.", new_context->address, new_context->listener->port);
+    if(db->config->connection_messages == true){
+	    _mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "New connection from %s on port %d.", new_context->address, new_context->listener->port);
+    }
 
 	return new_sock;
 }

--- a/src/security.c
+++ b/src/security.c
@@ -242,11 +242,15 @@ int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, cons
 			* plugins against possible pattern based attacks.
 			*/
 			if(username && strpbrk(username, "+#")){
-				_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous username \"%s\"", username);
+				if(db->config->connection_messages == true){
+					_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous username \"%s\"", username);
+				}
 				return MOSQ_ERR_ACL_DENIED;
 			}
 			if(context->id && strpbrk(context->id, "+#")){
-				_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous client id \"%s\"", context->id);
+				if(db->config->connection_messages == true){
+					_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous client id \"%s\"", context->id);
+				}
 				return MOSQ_ERR_ACL_DENIED;
 			}
 		}

--- a/src/security_default.c
+++ b/src/security_default.c
@@ -274,12 +274,16 @@ int mosquitto_acl_check_default(struct mosquitto_db *db, struct mosquitto *conte
 		 * publish or receive messages to its own place in the hierarchy).
 		 */
 		if(context->username && strpbrk(context->username, "+#")){
-			_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous username \"%s\"", context->username);
+			if(db->config->connection_messages == true){
+				_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous username \"%s\"", context->username);
+			}
 			return MOSQ_ERR_ACL_DENIED;
 		}
 
 		if(context->id && strpbrk(context->id, "+#")){
-			_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous client id \"%s\"", context->id);
+			if(db->config->connection_messages == true){
+				_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "ACL denying access to client with dangerous client id \"%s\"", context->id);
+			}
 			return MOSQ_ERR_ACL_DENIED;
 		}
 	}

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -219,7 +219,9 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				return -1;
 			}
 			if(mosq->listener->max_connections > 0 && mosq->listener->client_count > mosq->listener->max_connections){
-				_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "Client connection from %s denied: max_connections exceeded.", mosq->address);
+				if(db->config->connection_messages == true){
+					_mosquitto_log_printf(NULL, MOSQ_LOG_NOTICE, "Client connection from %s denied: max_connections exceeded.", mosq->address);
+				}
 				_mosquitto_free(mosq);
 				u->mosq = NULL;
 				return -1;
@@ -535,7 +537,7 @@ static int callback_http(struct libwebsocket_context *context,
 												"Server: mosquitto\r\n"
 												"Content-Length: %u\r\n\r\n",
 												(unsigned int)filestat.st_size);
-            if(libwebsocket_write(wsi, buf, buflen, LWS_WRITE_HTTP) < 0){
+			if(libwebsocket_write(wsi, buf, buflen, LWS_WRITE_HTTP) < 0){
 				fclose(u->fptr);
 				u->fptr = NULL;
 				return -1;


### PR DESCRIPTION
Added configuration check before printing connection message.

Signed-off-by: Brandon Arrendondo <barrendo@gmail.com>