### PR TITLE
Adding tls host name extension (SNI)

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -4,12 +4,12 @@ Copyright (c) 2009-2014 Roger Light <roger@atchoo.org>
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 and Eclipse Distribution License v1.0 which accompany this distribution.
-
+ 
 The Eclipse Public License is available at
    http://www.eclipse.org/legal/epl-v10.html
 and the Eclipse Distribution License is available at
   http://www.eclipse.org/org/documents/edl-v10.php.
-
+ 
 Contributors:
    Roger Light - initial implementation and documentation.
 */
@@ -635,13 +635,13 @@ int _mosquitto_socket_connect_step3(struct mosquitto *mosq, const char *host, ui
 		}
 		SSL_set_bio(mosq->ssl, bio, bio);
 
-    /*
-     * required for the SNI resolving
-     */
-    if(SSL_set_tlsext_host_name(mosq->ssl, host) != 1) {
+		/*
+		 * required for the SNI resolving
+		 */
+		if(SSL_set_tlsext_host_name(mosq->ssl, host) != 1) {
 			COMPAT_CLOSE(mosq->sock);
 			return MOSQ_ERR_TLS;
-    }
+		}
 
 		if(mosquitto__socket_connect_tls(mosq)){
 			return MOSQ_ERR_TLS;
@@ -936,7 +936,7 @@ int _mosquitto_packet_write(struct mosquitto *mosq)
 			}
 			pthread_mutex_unlock(&mosq->callback_mutex);
 		}else if(((packet->command)&0xF0) == DISCONNECT){
-			/* FIXME what cleanup needs doing here?
+			/* FIXME what cleanup needs doing here? 
 			 * incoming/outgoing messages? */
 			_mosquitto_socket_close(mosq);
 

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -4,12 +4,12 @@ Copyright (c) 2009-2014 Roger Light <roger@atchoo.org>
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 and Eclipse Distribution License v1.0 which accompany this distribution.
- 
+
 The Eclipse Public License is available at
    http://www.eclipse.org/legal/epl-v10.html
 and the Eclipse Distribution License is available at
   http://www.eclipse.org/org/documents/edl-v10.php.
- 
+
 Contributors:
    Roger Light - initial implementation and documentation.
 */
@@ -635,6 +635,14 @@ int _mosquitto_socket_connect_step3(struct mosquitto *mosq, const char *host, ui
 		}
 		SSL_set_bio(mosq->ssl, bio, bio);
 
+    /*
+     * required for the SNI resolving
+     */
+    if(SSL_set_tlsext_host_name(mosq->ssl, host) != 1) {
+			COMPAT_CLOSE(mosq->sock);
+			return MOSQ_ERR_TLS;
+    }
+
 		if(mosquitto__socket_connect_tls(mosq)){
 			return MOSQ_ERR_TLS;
 		}
@@ -928,7 +936,7 @@ int _mosquitto_packet_write(struct mosquitto *mosq)
 			}
 			pthread_mutex_unlock(&mosq->callback_mutex);
 		}else if(((packet->command)&0xF0) == DISCONNECT){
-			/* FIXME what cleanup needs doing here? 
+			/* FIXME what cleanup needs doing here?
 			 * incoming/outgoing messages? */
 			_mosquitto_socket_close(mosq);
 

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -183,7 +183,7 @@ int mqtt3_bridge_connect_step1(struct mosquitto_db *db, struct mosquitto *contex
 		if(context->bridge->notification_topic){
 			if(!context->bridge->initial_notification_done){
 				notification_payload = '0';
-				mqtt3_db_messages_easy_queue(db, context, context->bridge->notification_topic, 1, 1, &notification_payload, 1);
+				db__messages_easy_queue(db, context, context->bridge->notification_topic, 1, 1, &notification_payload, 1);
 				context->bridge->initial_notification_done = true;
 			}
 			notification_payload = '0';
@@ -200,7 +200,7 @@ int mqtt3_bridge_connect_step1(struct mosquitto_db *db, struct mosquitto *contex
 
 			if(!context->bridge->initial_notification_done){
 				notification_payload = '0';
-				mqtt3_db_messages_easy_queue(db, context, notification_topic, 1, 1, &notification_payload, 1);
+				db__messages_easy_queue(db, context, notification_topic, 1, 1, &notification_payload, 1);
 				context->bridge->initial_notification_done = true;
 			}
 

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -183,7 +183,7 @@ int mqtt3_bridge_connect_step1(struct mosquitto_db *db, struct mosquitto *contex
 		if(context->bridge->notification_topic){
 			if(!context->bridge->initial_notification_done){
 				notification_payload = '0';
-				db__messages_easy_queue(db, context, context->bridge->notification_topic, 1, 1, &notification_payload, 1);
+				mqtt3_db_messages_easy_queue(db, context, context->bridge->notification_topic, 1, 1, &notification_payload, 1);
 				context->bridge->initial_notification_done = true;
 			}
 			notification_payload = '0';
@@ -200,7 +200,7 @@ int mqtt3_bridge_connect_step1(struct mosquitto_db *db, struct mosquitto *contex
 
 			if(!context->bridge->initial_notification_done){
 				notification_payload = '0';
-				db__messages_easy_queue(db, context, notification_topic, 1, 1, &notification_payload, 1);
+				mqtt3_db_messages_easy_queue(db, context, notification_topic, 1, 1, &notification_payload, 1);
 				context->bridge->initial_notification_done = true;
 			}
 


### PR DESCRIPTION
The SNI feature is essential in some cloud setups, e.g. when accessing mqtt broker behind a ha-proxy serving multiple domains from the same IP address.

Signed-off-by: Viktor Gotwig <viktor.gotwig@q-loud.de>