### PR TITLE
Wrong Docbook Path

### DIFF
--- a/man/manpage.xsl
+++ b/man/manpage.xsl
@@ -1,6 +1,6 @@
 <!-- Set parameters for manpage xsl -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-	<xsl:import href="/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl"/>
+	<xsl:import href="/usr/share/sgml/docbook/xsl-ns-stylesheets-1.78.1/manpages/docbook.xsl"/>
 	<xsl:strip-space elements="member"/>
 	<!-- Don't display notes list of link urls. -->
 	<xsl:param name="man.endnotes.list.enabled">0</xsl:param>


### PR DESCRIPTION
Fixed an issue where Mosquitto would search for the wrong Docbook path during build. 
