### PR TITLE
Fix CONNACK not send over WebSocket for bad auth

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -250,7 +250,7 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				return -1;
 			}
 			mosq = u->mosq;
-			if(!mosq || mosq->state == mosq_cs_disconnect_ws || mosq->state == mosq_cs_disconnecting){
+			if(!mosq){
 				return -1;
 			}
 
@@ -283,11 +283,17 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				count = packet->to_process;
 #endif
 				if(count < 0){
+					if (mosq->state == mosq_cs_disconnect_ws || mosq->state == mosq_cs_disconnecting){
+						return -1;
+					}
 					return 0;
 				}
 				packet->to_process -= count;
 				packet->pos += count;
 				if(packet->to_process > 0){
+					if (mosq->state == mosq_cs_disconnect_ws || mosq->state == mosq_cs_disconnecting){
+						return -1;
+					}
 					break;
 				}
 
@@ -304,6 +310,9 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				_mosquitto_free(packet);
 
 				mosq->next_msg_out = mosquitto_time() + mosq->keepalive;
+			}
+			if (mosq->state == mosq_cs_disconnect_ws || mosq->state == mosq_cs_disconnecting){
+				return -1;
 			}
 			if(mosq->current_out_packet){
 				libwebsocket_callback_on_writable(mosq->ws_context, mosq->wsi);
@@ -386,7 +395,12 @@ static int callback_mqtt(struct libwebsocket_context *context,
 
 				mosq->last_msg_in = mosquitto_time();
 
-				if(rc){
+				if(rc && (mosq->out_packet || mosq->current_out_packet)) {
+					if(mosq->state != mosq_cs_disconnecting){
+						mosq->state = mosq_cs_disconnect_ws;
+					}
+					libwebsocket_callback_on_writable(mosq->ws_context, mosq->wsi);
+				} else if (rc) {
 					do_disconnect(db, mosq);
 					return -1;
 				}


### PR DESCRIPTION
When client over WebSockets fail to authenticate, the CONNACK packet was
not sent because the connection was closed too early. Closes #18.

non-WebSockets connection don't have this issue because call to [_mosquitto_send_connack](https://github.com/eclipse/mosquitto/blob/a4e912079fd399dd1c6f7080e27d51787530a4bb/src/read_handle_server.c#L398) will write immediately to the socket ([code](https://github.com/eclipse/mosquitto/blob/a4e912079fd399dd1c6f7080e27d51787530a4bb/lib/net_mosq.c#L177)).

For Websockets, the packet is only queued, but since rc != 0, connection is closed because writable callback could be called ([code](https://github.com/eclipse/mosquitto/blob/a4e912079fd399dd1c6f7080e27d51787530a4bb/src/websockets.c#L389)).

This PR change this behavior: when rc != 0, the socket is not immediately closed if their is some outgoing packet. Also in the writable callback, when state is disconnect_ws, (try to) process one packet before disconnecting.