### PR TITLE
fix incorrect return code when connecting in non-blocking mode

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -645,7 +645,7 @@ int _mosquitto_socket_connect_step3(struct mosquitto *mosq, const char *host, ui
 int _mosquitto_socket_connect(struct mosquitto *mosq, const char *host, uint16_t port, const char *bind_address, bool blocking)
 {
 	mosq_sock_t sock = INVALID_SOCKET;
-	int rc;
+	int rc, rc2;
 
 	if(!mosq || !host || !port) return MOSQ_ERR_INVAL;
 
@@ -653,7 +653,8 @@ int _mosquitto_socket_connect(struct mosquitto *mosq, const char *host, uint16_t
 	if(rc > 0) return rc;
 
 	mosq->sock = sock;
-	rc = _mosquitto_socket_connect_step3(mosq, host, port, bind_address, blocking);
+	rc2 = _mosquitto_socket_connect_step3(mosq, host, port, bind_address, blocking);
+	if (rc2 > 0) return rc2;
 
 	return rc;
 }


### PR DESCRIPTION
Problem: When a broker is configured to make a bridge connection, the bridge connection is no longer established.
Platform: Windows

When the broker is configured to make a bridge connection, the _mqtt3_bridge_connect_ function fails, because the non-blocking __mosquitto_send_connect_ call returns an error (WSAENOTCONN=10057).
The error happens because the socket connection is still pending, but the __mosquitto_socket_connect_ call doesn't return MOSQ_ERR_CONN_PENDING in this case.
Apparently, the return code is overwritten in __mosquitto_socket_connect_.