### PR TITLE
websockets.c: unbreak build without TLS

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -201,12 +201,14 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				mosq->ws_context = context;
 #endif
 				mosq->wsi = wsi;
+#ifdef WITH_TLS
 				if(in){
 					mosq->ssl = (SSL *)in;
 					if(!mosq->listener->ssl_ctx){
 						mosq->listener->ssl_ctx = SSL_get_SSL_CTX(mosq->ssl);
 					}
 				}
+#endif
 				u->mosq = mosq;
 			}else{
 				return -1;
@@ -240,7 +242,9 @@ static int callback_mqtt(struct libwebsocket_context *context,
 					mosq->pollfd_index = -1;
 				}
 				mosq->wsi = NULL;
+#ifdef WITH_TLS
 				mosq->ssl = NULL;
+#endif
 				do_disconnect(db, mosq);
 			}
 			break;


### PR DESCRIPTION
Commit 7943072b1f3b (Fix use_identity_as_username not working on websockets
clients) added code which unconditionally accesses mosq-ssl, breaking the
build when TLS support is disabled.

Fix it by guarding this logic inside #ifdef WITH_TLS.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>