### PR TITLE
Use config from user writable snap directory

### DIFF
--- a/snap/default_config.conf
+++ b/snap/default_config.conf
@@ -1,0 +1,2 @@
+port 1883
+persistence false

--- a/snap/launcher.sh
+++ b/snap/launcher.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Wrapper to check for custom config in $SNAP_USER_COMMON and use it
+# otherwise fall back to the included basic config which will at least
+# allow mosquitto to run and do something.
+# This script will also copy the full example config in to SNAP_USER_COMMON
+# so that people can refer to it.
+
+CONFIG_FILE="$SNAP/default_config.conf"
+CUSTOM_CONFIG="$SNAP_USER_COMMON/mosquitto.conf"
+
+
+# Copy the example config if it doesn't exist
+if [ ! -e "$SNAP_USER_COMMON/mosquitto_example.conf" ]
+then
+  echo "Copying example config to $SNAP_USER_COMMON/mosquitto_example.conf"
+  echo "You can create a custom config by creating a file called $CUSTOM_CONFIG"
+  cp $SNAP/mosquitto.conf $SNAP_USER_COMMON/mosquitto_example.conf
+fi
+
+
+# Does the custom config exist?  If so use it.
+if [ -e "$CUSTOM_CONFIG" ]
+then
+  echo "Found config in $CUSTOM_CONFIG"
+  CONFIG_FILE=$CUSTOM_CONFIG
+else
+  echo "Using default config from $CONFIG_FILE"
+fi
+
+# Launch the snap
+$SNAP/usr/local/sbin/mosquitto -c $CONFIG_FILE $@

--- a/snap/mosquitto.conf
+++ b/snap/mosquitto.conf
@@ -1,3 +1,0 @@
-port 1883
-persistence true
-user root

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,10 +9,11 @@ description: This is a message broker that supports version 3.1 and 3.1.1 of the
     where a sensor or other simple device may be implemented using an arduino for
     example.
 confinement: strict
+grade: stable
 
 apps:
   mosquitto:
-    command: usr/local/sbin/mosquitto -c $SNAP/mosquitto.conf
+    command: launcher.sh
     daemon: simple
     restart-condition: always
     plugs: [network, network-bind]
@@ -23,7 +24,14 @@ parts:
     plugin: dump
     source: snap/
     prime:
-    - mosquitto.conf
+      - default_config.conf
+      - launcher.sh
+  config:
+    plugin: dump
+    source: .
+    prime:
+      - mosquitto.conf
+
 
 
   mosquitto:
@@ -42,8 +50,7 @@ parts:
       - libuuid1
       - libc-ares2
     prime:
-    - usr/local/sbin/mosquitto
-    - lib/*-linux-gnu/libcrypto.so*
-    - lib/*-linux-gnu/libssl.so*
-    - lib/*-linux-gnu/libuuid.so*
-
+      - usr/local/sbin/mosquitto
+      - lib/*-linux-gnu/libcrypto.so*
+      - lib/*-linux-gnu/libssl.so*
+      - lib/*-linux-gnu/libuuid.so*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,8 @@ parts:
       - libc-ares-dev
       - xsltproc
       - docbook-xsl
+      - gcc
+      - g++
     stage-packages:
       - libssl1.0.0
       - libuuid1


### PR DESCRIPTION
This PR allows the loading of config from a user writable area on disk.  $SNAP_USER_COMMON is not versioned on upgrades, and so the user's config will remain the same across upgrades.

I've created a new "default_config.conf" file based on the config that was being shipped inside the snap directory (and removed the mosquitto.conf file).  The launcher script will fall back to this file if there isn't a user config file in the specified location.  This should mean that when run, the snap will actually do something useful.  I dropped "user root" from this example, as I don't think that it needs to run as root, but I might be wrong.  It seems to work ok here.

The launcher script first copies the example config (from the root of the source) in to the $SNAP_USER_COMMON directory, so that people can find it and read it, copy it, etc.  The launcher only does this if the file doesn't already exist. The launcher also tells the user where it is, so they'll hopefully be able to find it again later.

The launcher then looks in the $SNAP_USER_COMMON dir for "mosquitto.conf".  If it finds one it will pass it to mosquitto to use.  If not, it will fall back to using the default one included in the snap dir in source (and in the application's $SNAP dir on the machine it is installed on).  It will also echo some hints on what's going on so the user can understand where the config is being loaded from.

Launcher scripts like this are fairly standard practice where you need to access files at run time that can't exist at build time - because we can't be sure where on disk the will end up when installed.

It might be worth setting the CWD to $SNAP_USER_COMMON so that the persistence database gets written there as well, but I haven't made that change.  Should be simple enough if required.

