### PR TITLE
Makefile modifications to allow compilation agains specific sysroot

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -9,25 +9,25 @@ static : static_pub static_sub
 	# libmosquitto only.
 
 static_pub : pub_client.o client_shared.o ../lib/libmosquitto.a
-	${CROSS_COMPILE}${CC} $^ -o mosquitto_pub ${CLIENT_LDFLAGS} -lssl -lcrypto -lpthread
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $^ -o mosquitto_pub ${CLIENT_LDFLAGS} -lssl -lcrypto -lpthread
 
 static_sub : sub_client.o client_shared.o ../lib/libmosquitto.a
-	${CROSS_COMPILE}${CC} $^ -o mosquitto_sub ${CLIENT_LDFLAGS} -lssl -lcrypto -lpthread
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $^ -o mosquitto_sub ${CLIENT_LDFLAGS} -lssl -lcrypto -lpthread
 
 mosquitto_pub : pub_client.o client_shared.o
-	${CROSS_COMPILE}${CC} $^ -o $@ ${CLIENT_LDFLAGS}
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $^ -o $@ ${CLIENT_LDFLAGS}
 
 mosquitto_sub : sub_client.o client_shared.o
-	${CROSS_COMPILE}${CC} $^ -o $@ ${CLIENT_LDFLAGS}
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $^ -o $@ ${CLIENT_LDFLAGS}
 
 pub_client.o : pub_client.c ../lib/libmosquitto.so.${SOVERSION}
-	${CROSS_COMPILE}${CC} -c $< -o $@ ${CLIENT_CFLAGS}
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} -c $< -o $@ ${CLIENT_CFLAGS}
 
 sub_client.o : sub_client.c ../lib/libmosquitto.so.${SOVERSION}
-	${CROSS_COMPILE}${CC} -c $< -o $@ ${CLIENT_CFLAGS}
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} -c $< -o $@ ${CLIENT_CFLAGS}
 
 client_shared.o : client_shared.c client_shared.h
-	${CROSS_COMPILE}${CC} -c $< -o $@ ${CLIENT_CFLAGS}
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} -c $< -o $@ ${CLIENT_CFLAGS}
 
 ../lib/libmosquitto.so.${SOVERSION} :
 	$(MAKE) -C ../lib

--- a/config.mk
+++ b/config.mk
@@ -92,6 +92,14 @@ WITH_STATIC_LIBRARIES:=no
 # Build with epoll support.
 WITH_EPOLL:=yes
 
+# Prefix for gcc and g++ used to crosscompile mosquitto. If empty (default)
+# it is compiled for the host machine
+CROSS_COMPILE:=
+
+# sysroot to be used by the linker when searching for libraries. If empty (default)
+# the libraries on the host machine root filesystem will be used
+SYSROOT:=
+
 # =============================================================================
 # End of user configuration
 # =============================================================================

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -67,98 +67,98 @@ clean :
 	$(MAKE) -C cpp clean
 
 libmosquitto.so.${SOVERSION} : ${MOSQ_OBJS}
-	${CROSS_COMPILE}$(CC) -shared $(LIB_LDFLAGS) $^ -o $@ ${LIB_LIBS}
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} -shared $(LIB_LDFLAGS) $^ -o $@ ${LIB_LIBS}
 
 libmosquitto.a : ${MOSQ_OBJS}
 	${CROSS_COMPILE}$(AR) cr $@ $^
 
 mosquitto.o : mosquitto.c mosquitto.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_connack.o : handle_connack.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_publish.o : handle_publish.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_ping.o : handle_ping.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_pubackcomp.o : handle_pubackcomp.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_pubrec.o : handle_pubrec.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_pubrel.o : handle_pubrel.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_suback.o : handle_suback.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 handle_unsuback.o : handle_unsuback.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 helpers.o : helpers.c
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 logging_mosq.o : logging_mosq.c logging_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 messages_mosq.o : messages_mosq.c messages_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 memory_mosq.o : memory_mosq.c memory_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 net_mosq.o : net_mosq.c net_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 packet_mosq.o : packet_mosq.c packet_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 read_handle.o : read_handle.c read_handle.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 send_connect.o : send_connect.c send_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 send_disconnect.o : send_disconnect.c send_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 send_mosq.o : send_mosq.c send_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 send_publish.o : send_publish.c send_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 send_subscribe.o : send_subscribe.c send_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 send_unsubscribe.o : send_unsubscribe.c send_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 socks_mosq.o : socks_mosq.c
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 srv_mosq.o : srv_mosq.c
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 thread_mosq.o : thread_mosq.c
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 time_mosq.o : time_mosq.c
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 tls_mosq.o : tls_mosq.c
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 utf8_mosq.o : utf8_mosq.c
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 util_mosq.o : util_mosq.c util_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 
 will_mosq.o : will_mosq.c will_mosq.h
-	${CROSS_COMPILE}$(CC) $(LIB_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CC) --sysroot=${SYSROOT} $(LIB_CFLAGS) -c $< -o $@
 

--- a/lib/cpp/Makefile
+++ b/lib/cpp/Makefile
@@ -35,11 +35,11 @@ clean :
 	-rm -f *.o libmosquittopp.so.${SOVERSION} libmosquittopp.a
 
 libmosquittopp.so.${SOVERSION} : mosquittopp.o
-	${CROSS_COMPILE}$(CXX) -shared $(LIB_LDFLAGS) $< -o $@ ../libmosquitto.so.${SOVERSION}
+	${CROSS_COMPILE}$(CXX) --sysroot=${SYSROOT} -shared $(LIB_LDFLAGS) $< -o $@ ../libmosquitto.so.${SOVERSION}
 
 libmosquittopp.a : mosquittopp.o
 	${CROSS_COMPILE}$(AR) cr $@ $^
 
 mosquittopp.o : mosquittopp.cpp mosquittopp.h
-	${CROSS_COMPILE}$(CXX) $(LIB_CXXFLAGS) -c $< -o $@
+	${CROSS_COMPILE}$(CXX) --sysroot=${SYSROOT} $(LIB_CXXFLAGS) -c $< -o $@
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,154 +56,154 @@ OBJS=	mosquitto.o \
 		will_mosq.o
 
 mosquitto : ${OBJS}
-	${CROSS_COMPILE}${CC} $^ -o $@ ${LDFLAGS} $(BROKER_LIBS)
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $^ -o $@ ${LDFLAGS} $(BROKER_LIBS)
 
 mosquitto.o : mosquitto.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 bridge.o : bridge.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 conf.o : conf.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 conf_includedir.o : conf_includedir.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 context.o : context.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 database.o : database.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_connack.o : handle_connack.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_connect.o : handle_connect.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_ping.o : ../lib/handle_ping.c ../lib/read_handle.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_pubackcomp.o : ../lib/handle_pubackcomp.c ../lib/read_handle.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_publish.o : handle_publish.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_pubrec.o : ../lib/handle_pubrec.c ../lib/read_handle.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_pubrel.o : ../lib/handle_pubrel.c ../lib/read_handle.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_suback.o : ../lib/handle_suback.c ../lib/read_handle.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_subscribe.o : handle_subscribe.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_unsuback.o : ../lib/handle_unsuback.c ../lib/read_handle.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 handle_unsubscribe.o : handle_unsubscribe.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 logging.o : logging.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 loop.o : loop.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 memory_mosq.o : ../lib/memory_mosq.c ../lib/memory_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 net.o : net.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 net_mosq.o : ../lib/net_mosq.c ../lib/net_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 persist.o : persist.c persist.h mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 packet_mosq.o : ../lib/packet_mosq.c ../lib/packet_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 plugin.o : plugin.c mosquitto_plugin.h mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 read_handle.o : read_handle.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 security.o : security.c mosquitto_broker_internal.h
 	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
 
 security_default.o : security_default.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_connect.o : ../lib/send_connect.c ../lib/send_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_disconnect.o : ../lib/send_disconnect.c ../lib/send_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_connack.o : send_connack.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_mosq.o : ../lib/send_mosq.c ../lib/send_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_publish.o : ../lib/send_publish.c ../lib/send_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_suback.o : send_suback.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_subscribe.o : ../lib/send_subscribe.c ../lib/send_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 send_unsubscribe.o : ../lib/send_unsubscribe.c ../lib/send_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 service.o : service.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 signals.o : signals.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 subs.o : subs.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 sys_tree.o : sys_tree.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 time_mosq.o : ../lib/time_mosq.c ../lib/time_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 tls_mosq.o : ../lib/tls_mosq.c
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 util_mosq.o : ../lib/util_mosq.c ../lib/util_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 utf8_mosq.o : ../lib/utf8_mosq.c
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 websockets.o : websockets.c mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 will_mosq.o : ../lib/will_mosq.c ../lib/will_mosq.h
-	${CROSS_COMPILE}${CC} $(BROKER_CFLAGS) -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(BROKER_CFLAGS) -c $< -o $@
 
 mosquitto_passwd : mosquitto_passwd.o
-	${CROSS_COMPILE}${CC} $^ -o $@ ${LDFLAGS} $(PASSWD_LIBS)
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $^ -o $@ ${LDFLAGS} $(PASSWD_LIBS)
 
 mosquitto_passwd.o : mosquitto_passwd.c
-	${CROSS_COMPILE}${CC} $(CFLAGS) ${CPPFLAGS} -c $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} $(CFLAGS) ${CPPFLAGS} -c $< -o $@
 
 plugin_defer.so : plugin_defer.c mosquitto_plugin.h mosquitto_broker.h mosquitto_broker_internal.h
-	${CROSS_COMPILE}${CC} -I. -I../lib -fPIC -shared $< -o $@
+	${CROSS_COMPILE}${CC} --sysroot=${SYSROOT} -I. -I../lib -fPIC -shared $< -o $@
 
 install : all
 	$(INSTALL) -d "${DESTDIR}$(prefix)/sbin"


### PR DESCRIPTION
Added variable SYS_ROOT to Makefiles to allow compilation against a specific sysroot. This variable is useful when crosscompiling using a specific or 3rd party toolchain with a defined or prefixed sysroot. The usage is the same as variable CROSS_COMPILE, already present

Signed-off-by: Dani Ezquerra <dezque@gmail.com>