### PR TITLE
Fix SSL on Windows

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -784,6 +784,9 @@ ssize_t _mosquitto_net_read(struct mosquitto *mosq, void *buf, size_t count)
 				}
 				errno = EPROTO;
 			}
+#ifdef WIN32
+			WSASetLastError(errno);
+#endif
 		}
 		return (ssize_t )ret;
 	}else{


### PR DESCRIPTION
When trying to connect to MQTT over SSL on Windows the broker immediately disconnects the client.

Debugging shows the issue is that _mosquitto_net_read sets the errno variable to EAGAIN, but the code at the calling side in _mosquitto_packet_read overwrites the value assigning WSAGetLastError() on Windows platform. The WSAGetLastError() indicates no failure, but the following code does not expect that value.

The fix is to put back the altered errno using WSASetLastError() so that it can be picked up again.