### PR TITLE
Fix bridge restart waits double time with ADNS

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -132,7 +132,6 @@ int mqtt3_bridge_new(struct mosquitto_db *db, struct _mqtt3_bridge *bridge)
 	}
 
 #if defined(__GLIBC__) && defined(WITH_ADNS)
-	new_context->bridge->restart_t = 1; /* force quick restart of bridge */
 	return mqtt3_bridge_connect_step1(db, new_context);
 #else
 	return mqtt3_bridge_connect(db, new_context);
@@ -227,6 +226,7 @@ int mqtt3_bridge_connect_step1(struct mosquitto_db *db, struct mosquitto *contex
 
 		return rc;
 	}
+	context->bridge->restart_t = 1; /* force quick restart of bridge */
 
 	return MOSQ_ERR_SUCCESS;
 }


### PR DESCRIPTION
A bridge with ADNS may wait double restart timeout to connect to the
broker. Force quick restart should apply for all step 1 connect.

Signed-off-by: Yingyou Chen <lwindg@gmail.com>