### PR TITLE
Fix: use websockets without OpenSSL / TLS.

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -183,12 +183,14 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				mosq->ws_context = context;
 #endif
 				mosq->wsi = wsi;
+#ifdef WITH_TLS
 				if(in){
 					mosq->ssl = (SSL *)in;
 					if(!mosq->listener->ssl_ctx){
 						mosq->listener->ssl_ctx = SSL_get_SSL_CTX(mosq->ssl);
 					}
 				}
+#endif
 				u->mosq = mosq;
 			}else{
 				return -1;
@@ -222,7 +224,9 @@ static int callback_mqtt(struct libwebsocket_context *context,
 					mosq->pollfd_index = -1;
 				}
 				mosq->wsi = NULL;
+#ifdef WITH_TLS
 				mosq->ssl = NULL;
+#endif
 				do_disconnect(db, mosq);
 			}
 			break;


### PR DESCRIPTION
If you use websockets without OpenSSL / TLS support, you don't compile mosquitto.
This fix propose to resolve this problem.

THX
Signed-off-by: Tifaifai Maupiti <tifaifai.maupiti@gmail.com>