### PR TITLE
Build fixes ++ (#791)

### DIFF
--- a/config.h
+++ b/config.h
@@ -28,4 +28,5 @@
 #define uthash_malloc(sz) mosquitto__malloc(sz)
 #define uthash_free(ptr,sz) mosquitto__free(ptr)
 
+#define _GNU_SOURCE
 #define _POSIX_C_SOURCE 200809L

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -29,6 +29,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef WITH_WEBSOCKETS
 
+#include "config.h"
+
 #include <libwebsockets.h>
 #include "mosquitto_internal.h"
 #include "mosquitto_broker_internal.h"


### PR DESCRIPTION
With this commit https://github.com/eclipse/mosquitto/commit/62d99ecbc2a359c0703894c4a0bb10fcca3e5495, we have many warning.

example:
```
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
```
and if you replace _BSD_SOURCE by _DEFAULT_SOURCE, you have just many warnings,
example:
```
In file included from ../lib/mosquitto_internal.h:21:0,
                 from websockets.c:35:
../config.h:31:0: warning: "_DEFAULT_SOURCE" redefined
 #define _DEFAULT_SOURCE
 
In file included from /usr/include/stdint.h:25:0,
                 from /usr/lib/gcc/arm-linux-gnueabihf/6/include/stdint.h:9,
                 from /usr/local/include/libwebsockets.h:50,
                 from websockets.c:34:
/usr/include/features.h:185:0: note: this is the location of the previous definition
 # define _DEFAULT_SOURCE 1
```

The solution is replace _BSD_SOURCE by _GNU_SOURCE.

From the Linux man page on [feature test macros](http://man7.org/linux/man-pages/man7/feature_test_macros.7.html):
```
Since glibc 2.19, defining _GNU_SOURCE also has the effect of implicitly defining
_DEFAULT_SOURCE. In glibc versions before 2.20, defining _GNU_SOURCE also 
had the effect of implicitly defining _BSD_SOURCE and _SVID_SOURCE.
```
This commit close the #791 PR


Signed-off-by: Tifaifai Maupiti <tifaifai.maupiti@gmail.com>