### PR TITLE
Adding compiled Alpine Docker image, generic for all versions

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -33,6 +33,7 @@ Dirk O. Kaar
 Dominik Obermaier
 Dominik Zajac
 Ed Morris
+Emmanuel Frecon
 Fabian Ruff
 Fang Chong
 Frank Hansen

--- a/docker/generic/Dockerfile
+++ b/docker/generic/Dockerfile
@@ -3,40 +3,61 @@ MAINTAINER Emmanuel Frecon <efrecon@gmail.com>
 
 LABEL Description="Eclipse Mosquitto MQTT Broker"
 
-ARG VERSION=1.4.15
+ARG VERSION=1.5
+ARG WS_VERSION=3.0.0
 
 RUN set -ex \
     # Add build dependencies, remove after build
     && apk --no-cache add --virtual .build-deps \
         build-base \
-        libressl-dev \
+        openssl-dev \
         c-ares-dev \
         util-linux-dev \
-        libwebsockets-dev \
+        zlib-dev \
+        cmake \
     # Add fetch dependencies, remove after build
     && apk --no-cache add --virtual .fetch-deps \
         git \
         curl \
     # Add run dependencies, keep after build
     && apk --no-cache add --virtual .run-deps \
-        libressl \
+        openssl \
+        zlib \
         c-ares \
         util-linux \
-        libwebsockets \
+    # Manually compile and install libwebsockets to keep relying on openssl
+    && mkdir /tmp/libwebsockets \
+    && cd /tmp/libwebsockets \
+    && curl -sqL https://github.com/warmcat/libwebsockets/archive/v${WS_VERSION}.tar.gz | tar zxf - \
+    && cd libwebsockets-${WS_VERSION} \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+		-DCMAKE_BUILD_TYPE=MinSizeRel \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_VERBOSE_MAKEFILE=TRUE \
+    && make \
+    # Do not make install blindly as installing the examples is neither needed
+    # nor works.
+    && cmake -DCOMPONENT=libraries -P cmake_install.cmake \
+    && cmake -DCOMPONENT=dev -P cmake_install.cmake \
     # Checkout and compile, versions are branched with a "v" in front of the
     # version number, but tagged at the Docker registry without the "v".
     && git clone --depth 1 -b v${VERSION} https://github.com/eclipse/mosquitto.git /tmp/mosquitto \
     && cd /tmp/mosquitto \
-    && curl -qsL https://git.alpinelinux.org/cgit/aports/plain/main/mosquitto/libressl.patch -o libressl.patch \
-    && git apply libressl.patch \
+    # Manually patch the Makefile to arrange for not making the documentation
+    # (and not having to bring in xslt). This is to be able to run against older
+    # version of Mosquitto where WITH_DOCS did not (yet) exist.
+    && sed -i -e "s|^DOCDIRS=.*$|DOCDIRS=|g" Makefile \
+    # Since we compile under Alpine, with musl, we cannot add support for async
+    # dns lookup as this requires glibc
     && make \
-        WITH_MEMORY_TRACKING=no \
         WITH_WEBSOCKETS=yes \
         WITH_SRV=yes \
-        WITH_TLS_PSK=no \
         WITH_ADNS=no \
-        WITH_DOCS=no \
         prefix=/usr \
+    # Manually patch the Makefile to make sure we can still run on older
+    # releases of Mosquitto where WITH_STRIP did not (yet) exist.
     && sed -i -e "s|(INSTALL) -s|(INSTALL)|g" -e 's|--strip-program=${CROSS_COMPILE}${STRIP}||' */Makefile */*/Makefile \
     && make WITH_DOCS=no prefix=/usr install \
     && addgroup -S mosquitto \
@@ -45,6 +66,8 @@ RUN set -ex \
     && cp /etc/mosquitto/mosquitto.conf.example /mosquitto/config/mosquitto.conf \
     && chown -R mosquitto:mosquitto /mosquitto \
     && apk --purge del .build-deps .fetch-deps \
+    && rm -rf /tmp/libwebsockets \
+    && rm -rf /tmp/mosquitto \
     && rm -rf /var/cache/apk/*
 
 COPY docker-entrypoint.sh /

--- a/docker/generic/Dockerfile
+++ b/docker/generic/Dockerfile
@@ -1,0 +1,52 @@
+FROM alpine:3.7
+MAINTAINER Emmanuel Frecon <efrecon@gmail.com>
+
+LABEL Description="Eclipse Mosquitto MQTT Broker"
+
+ARG VERSION=1.4.15
+
+RUN set -ex \
+    # Add build dependencies, remove after build
+    && apk --no-cache add --virtual .build-deps \
+        build-base \
+        libressl-dev \
+        c-ares-dev \
+        util-linux-dev \
+        libwebsockets-dev \
+    # Add fetch dependencies, remove after build
+    && apk --no-cache add --virtual .fetch-deps \
+        git \
+        curl \
+    # Add run dependencies, keep after build
+    && apk --no-cache add --virtual .run-deps \
+        libressl \
+        c-ares \
+        util-linux \
+        libwebsockets \
+    # Checkout and compile, versions are branched with a "v" in front of the
+    # version number, but tagged at the Docker registry without the "v".
+    && git clone --depth 1 -b v${VERSION} https://github.com/eclipse/mosquitto.git /tmp/mosquitto \
+    && cd /tmp/mosquitto \
+    && curl -qsL https://git.alpinelinux.org/cgit/aports/plain/main/mosquitto/libressl.patch -o libressl.patch \
+    && git apply libressl.patch \
+    && make \
+        WITH_MEMORY_TRACKING=no \
+        WITH_WEBSOCKETS=yes \
+        WITH_SRV=yes \
+        WITH_TLS_PSK=no \
+        WITH_ADNS=no \
+        WITH_DOCS=no \
+        prefix=/usr \
+    && sed -i -e "s|(INSTALL) -s|(INSTALL)|g" -e 's|--strip-program=${CROSS_COMPILE}${STRIP}||' */Makefile */*/Makefile \
+    && make WITH_DOCS=no prefix=/usr install \
+    && addgroup -S mosquitto \
+    && adduser -S -D -H -h /var/empty -s /sbin/nologin -G mosquitto -g mosquitto mosquitto \
+    && mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log \ 
+    && cp /etc/mosquitto/mosquitto.conf.example /mosquitto/config/mosquitto.conf \
+    && chown -R mosquitto:mosquitto /mosquitto \
+    && apk --purge del .build-deps .fetch-deps \
+    && rm -rf /var/cache/apk/*
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]

--- a/docker/generic/README.md
+++ b/docker/generic/README.md
@@ -1,0 +1,67 @@
+# Eclipse Mosquitto Docker Image
+
+## Mount Points
+
+Three mount points have been created in the image to be used for configuration, persistent storage and logs.
+```
+/mosquitto/config
+/mosquitto/data
+/mosquitto/log
+```
+
+
+## Configuration
+
+When running the image, the default configuration values are used.
+To use a custom configuration file, mount a **local** configuration file to `/mosquitto/config/mosquitto.conf`
+```console
+docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+```
+
+Configuration can be changed to:
+
+* persist data to `/mosquitto/data`
+* log to `/mosquitto/log/mosquitto.log`
+
+i.e. add the following to `mosquitto.conf`:
+```configure
+persistence true
+persistence_location /mosquitto/data/
+
+log_dest file /mosquitto/log/mosquitto.log
+```
+
+**Note**: If a volume is used, the data will persist between containers.
+
+## Build This image is meant to be able to build all released version of
+Mosquitto on top of the latest stable Alpine. The version number should be
+passed as an a build argument, without the leading `v`. For example, to build
+the image for version [v1.4.15] of mosquitto, run the following command:
+
+```console
+docker build --build-arg VERSION=1.4.15 -t eclipse-mosquitto:1.4.15 .
+```
+
+  [v1.4.15]: https://github.com/eclipse/mosquitto/tree/v1.4.15
+
+## Run
+Run a container using the new image:
+```console
+docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log eclipse-mosquitto:1.4.15
+```
+:boom: if the mosquitto configuration (mosquitto.conf) was modified
+to use non-default ports, the docker run command will need to be updated
+to expose the ports that have been configured.
+
+## Implementation Notes
+The version specific Dockerfiles otherwise present in the main `docker`
+directory rely on the existence of ready-made packages as part of the Alpine
+Linux distribution. Instead, this image will clone, branch to the relevant
+version and compile the mosquitto source code. Compilation in the Dockerfile
+linearises the various [strategies] that are otherwise deployed for compiling
+the mosquitto Alpine packages. This include patching the code for running
+against libressl and adapting the Makefiles not to run `strip`. Code patching is
+necessary until [PR#281] has been accepted.
+
+  [strategies]: https://git.alpinelinux.org/cgit/aports/tree/main/mosquitto
+  [PR#281]: https://github.com/eclipse/mosquitto/pull/281

--- a/docker/generic/README.md
+++ b/docker/generic/README.md
@@ -33,35 +33,48 @@ log_dest file /mosquitto/log/mosquitto.log
 
 **Note**: If a volume is used, the data will persist between containers.
 
-## Build This image is meant to be able to build all released version of
+## Build
+This image is meant to be able to build (almost) all released version of
 Mosquitto on top of the latest stable Alpine. The version number should be
-passed as an a build argument, without the leading `v`. For example, to build
-the image for version [v1.4.15] of mosquitto, run the following command:
+passed as the build argument `VERSION` and contain the tag of the version,
+without the leading `v`. For example, to build the image for version [v1.4.15]
+of mosquitto, run the following command:
 
 ```console
 docker build --build-arg VERSION=1.4.15 -t eclipse-mosquitto:1.4.15 .
 ```
 
+A similar build argument called `WS_VERSION` can be used to pinpoint one of the
+existing [releases] of [libwebsockets]. Similarily, this argument should contain
+the version number without the leading `v`.
+
   [v1.4.15]: https://github.com/eclipse/mosquitto/tree/v1.4.15
+  [releases]: https://github.com/warmcat/libwebsockets/releases
+  [libwebsockets]: https://github.com/warmcat/libwebsockets
 
 ## Run
 Run a container using the new image:
 ```console
 docker run -it -p 1883:1883 -p 9001:9001 -v <path-to-configuration-file>:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log eclipse-mosquitto:1.4.15
 ```
-:boom: if the mosquitto configuration (mosquitto.conf) was modified
+:boom: if the mosquitto configuration (`mosquitto.conf`) was modified
 to use non-default ports, the docker run command will need to be updated
 to expose the ports that have been configured.
 
 ## Implementation Notes
-The version specific Dockerfiles otherwise present in the main `docker`
-directory rely on the existence of ready-made packages as part of the Alpine
-Linux distribution. Instead, this image will clone, branch to the relevant
-version and compile the mosquitto source code. Compilation in the Dockerfile
-linearises the various [strategies] that are otherwise deployed for compiling
-the mosquitto Alpine packages. This include patching the code for running
-against libressl and adapting the Makefiles not to run `strip`. Code patching is
-necessary until [PR#281] has been accepted.
+### Dependencies
+In order to be able to compile with most configuration flags turned on, this
+image depends on [openssl] rather than [libressl], which is otherwise the
+preferred SSL implementation on Alpine. Bringing in an openssl dependency means
+having to manually compile [libwebsockets] which also depends on an SSL
+implementation.
 
-  [strategies]: https://git.alpinelinux.org/cgit/aports/tree/main/mosquitto
-  [PR#281]: https://github.com/eclipse/mosquitto/pull/281
+  [openssl]: https://git.alpinelinux.org/cgit/aports/tree/main/openssl
+  [libressl]: https://git.alpinelinux.org/cgit/aports/tree/main/libressl
+### Intentional Manual Patching
+This image manually patches the code for adapting the Makefiles not to run
+`strip`. Manual code patching is necessary as stripping was made optional
+[later] than a number of old releases. A similar technique is used to arrange
+for neither making, nor installing the documentation into the final image.
+
+  [later]: https://github.com/eclipse/mosquitto/commit/d90cd585dd8cc1f9cecd9082d71333e1e638df2d

--- a/docker/generic/docker-entrypoint.sh
+++ b/docker/generic/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/ash
+
+set -e
+exec "$@"
+


### PR DESCRIPTION
This makes it possible to generate Docker images for all releases of mosquitto, using the github tags that are associated to each release. Previous Docker images would rely on the packages that were present as part of the Alpine distribution. This implementation will, instead, compile from source, thus removing the dependency on Alpine (re)packaging of the project.

Generation of releases is by way of Docker support for build arguments. As a result, this Docker image generation implementation would provide the base for squeezing issues #606 #669. In addition, this image also includes the pub and sub clients, thus squeezing #364. Care has been taken to remain compatible with the previous implementations, through keeping the same directory structure for hosting the logs, configuration files, or persistence data.

As commented [here](https://github.com/eclipse/mosquitto/issues/606#issuecomment-357476814) it is possible to let github notify the Docker hub about new tags. This code would then be able to be used for generating the image based on the tag. 

Signed-off-by: Emmanuel Frécon <efrecon@gmail.com>