### PR TITLE
Implemented per-listener acl_files, as per documentation. Fixes eclipse/mosquitto#796.

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -575,25 +575,21 @@ int handle__connect(struct mosquitto_db *db, struct mosquitto *context)
 	}
 
 	/* Associate user with its ACL, assuming we have ACLs loaded. */
-	if(db->acl_list){
-		acl_tail = db->acl_list;
-		while(acl_tail){
-			if(context->username){
-				if(acl_tail->username && !strcmp(context->username, acl_tail->username)){
-					context->acl_list = acl_tail;
-					break;
-				}
-			}else{
-				if(acl_tail->username == NULL){
-					context->acl_list = acl_tail;
-					break;
-				}
-			}
+	acl_tail = db->config->per_listener_settings ? context->listener->acl_list : db->acl_list;
+	char *cuser = context->username;
+	if (cuser) {
+		char *acluser;
+		while (acl_tail) {
+			acluser = acl_tail->username;
+			if (acluser && !strcmp(acluser, cuser))
+				break;
 			acl_tail = acl_tail->next;
 		}
-	}else{
-		context->acl_list = NULL;
+	} else {
+		while (acl_tail && NULL != acl_tail->username)
+			acl_tail = acl_tail->next;
 	}
+	context->acl_list = acl_tail;
 
 	if(will_struct){
 		context->will = will_struct;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -4,12 +4,12 @@ Copyright (c) 2009-2018 Roger Light <roger@atchoo.org>
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 and Eclipse Distribution License v1.0 which accompany this distribution.
- 
+
 The Eclipse Public License is available at
    http://www.eclipse.org/legal/epl-v10.html
 and the Eclipse Distribution License is available at
   http://www.eclipse.org/org/documents/edl-v10.php.
- 
+
 Contributors:
    Roger Light - initial implementation and documentation.
    Tatsuzo Osawa - Add epoll.
@@ -193,6 +193,7 @@ struct mosquitto__security_options {
 	 * should be disabled when these options are set.
 	 */
 	char *password_file;
+	char *acl_file;
 	char *psk_file;
 	struct mosquitto__auth_plugin_config *auth_plugin_configs;
 	int auth_plugin_config_count;
@@ -235,11 +236,12 @@ struct mosquitto__listener {
 	struct mosquitto__security_options security_options;
 	struct mosquitto__unpwd *unpwd;
 	struct mosquitto__unpwd *psk_id;
+	struct mosquitto__acl_user *acl_list;
+	struct mosquitto__acl *acl_patterns;
 };
 
 struct mosquitto__config {
 	char *config_file;
-	char *acl_file;
 	bool allow_duplicate_messages;
 	int autosave_interval;
 	bool autosave_on_changes;


### PR DESCRIPTION
I thought I'd fix the issue I encountered. I hope I worked in a way that is acceptable to you.
I was not entirely sure of the modified function signature of `aclfile__parse(...)` with the double arguments, but declaring a union or putting the acl_list and acl_patterns in yet another struct also felt clunky to me and would've caused even more changes to the codebase.

I have tested this with per-listener acl_files and it seems to work, also across reloads. Not sure what else to test.

If there is anything else I need to do, let me know.