### PR TITLE
Fix: Compile without OpenSSL / TLS

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -268,14 +268,18 @@ int mosquitto_opts_set(struct mosquitto *mosq, enum mosq_opt_t option, void *val
 			}
 			break;
 		case MOSQ_OPT_SSL_CTX:
+#if defined(WITH_TLS)
 			mosq->ssl_ctx = (SSL_CTX *)value;
 			if(mosq->ssl_ctx){
-#if defined(WITH_TLS) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 				SSL_CTX_up_ref(mosq->ssl_ctx);
 #else
 				CRYPTO_add(&(mosq->ssl_ctx)->references, 1, CRYPTO_LOCK_SSL_CTX);
 #endif
 			}
+#else
+			return MOSQ_ERR_NOT_SUPPORTED;
+#endif
 			break;
 		case MOSQ_OPT_SSL_CTX_WITH_DEFAULTS:
 #if defined(WITH_TLS) && OPENSSL_VERSION_NUMBER >= 0x10100000L


### PR DESCRIPTION
Identical to (Fix: Compile without OpenSSL / TLS. #807 and #808).
Re-tested without the ip-validation step failed.
Last chance !
Signed-off-by: Tifaifai Maupiti <tifaifai.maupiti@gmail.com>