### PR TITLE
add missing paramters to internal mosquitto_acl_check

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -202,7 +202,8 @@ void context__cleanup(struct mosquitto_db *db, struct mosquitto *context, bool d
 void context__send_will(struct mosquitto_db *db, struct mosquitto *ctxt)
 {
 	if(ctxt->state != mosq_cs_disconnecting && ctxt->will){
-		if(mosquitto_acl_check(db, ctxt, ctxt->will->topic, MOSQ_ACL_WRITE) == MOSQ_ERR_SUCCESS){
+		if(mosquitto_acl_check(db, ctxt, ctxt->will->topic, ctxt->will->payloadlen, ctxt->will->payload,
+							   ctxt->will->qos, ctxt->will->retain, MOSQ_ACL_WRITE) == MOSQ_ERR_SUCCESS){
 			/* Unexpected disconnect, queue the client will. */
 			db__messages_easy_queue(db, ctxt, ctxt->will->topic, ctxt->will->qos, ctxt->will->payloadlen, ctxt->will->payload, ctxt->will->retain);
 		}

--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -83,7 +83,9 @@ void connection_check_acl(struct mosquitto_db *db, struct mosquitto *context, st
 	msg_prev = NULL;
 	while(msg_tail){
 		if(msg_tail->direction == mosq_md_out){
-			if(mosquitto_acl_check(db, context, msg_tail->store->topic, MOSQ_ACL_READ) != MOSQ_ERR_SUCCESS){
+			if(mosquitto_acl_check(db, context, msg_tail->store->topic,
+								   msg_tail->store->payloadlen, UHPA_ACCESS(msg_tail->store->payload, msg_tail->store->payloadlen),
+								   msg_tail->store->qos, msg_tail->store->retain, MOSQ_ACL_READ) != MOSQ_ERR_SUCCESS){
 				db__msg_store_deref(db, &msg_tail->store);
 				if(msg_prev){
 					msg_prev->next = msg_tail->next;

--- a/src/handle_publish.c
+++ b/src/handle_publish.c
@@ -168,7 +168,7 @@ int handle__publish(struct mosquitto_db *db, struct mosquitto *context)
 	}
 
 	/* Check for topic access */
-	rc = mosquitto_acl_check(db, context, topic, MOSQ_ACL_WRITE);
+	rc = mosquitto_acl_check(db, context, topic, payloadlen, UHPA_ACCESS(payload, payloadlen), qos, retain, MOSQ_ACL_WRITE);
 	if(rc == MOSQ_ERR_ACL_DENIED){
 		log__printf(NULL, MOSQ_LOG_DEBUG, "Denied PUBLISH from %s (d%d, q%d, r%d, m%d, '%s', ... (%ld bytes))", context->id, dup, qos, retain, mid, topic, (long)payloadlen);
 		goto process_bad_message;

--- a/src/handle_subscribe.c
+++ b/src/handle_subscribe.c
@@ -112,7 +112,7 @@ int handle__subscribe(struct mosquitto_db *db, struct mosquitto *context)
 			log__printf(NULL, MOSQ_LOG_DEBUG, "\t%s (QoS %d)", sub, qos);
 
 			if(context->protocol == mosq_p_mqtt311){
-				rc = mosquitto_acl_check(db, context, sub, MOSQ_ACL_SUBSCRIBE);
+				rc = mosquitto_acl_check(db, context, sub, 0, NULL, qos, false, MOSQ_ACL_SUBSCRIBE);
 				switch(rc){
 					case MOSQ_ERR_SUCCESS:
 						break;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -605,7 +605,7 @@ int mosquitto_security_module_cleanup(struct mosquitto_db *db);
 int mosquitto_security_init(struct mosquitto_db *db, bool reload);
 int mosquitto_security_apply(struct mosquitto_db *db);
 int mosquitto_security_cleanup(struct mosquitto_db *db, bool reload);
-int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, const char *topic, int access);
+int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, const char *topic, long payloadlen, void* payload, int qos, bool retain, int access);
 int mosquitto_unpwd_check(struct mosquitto_db *db, struct mosquitto *context, const char *username, const char *password);
 int mosquitto_psk_key_get(struct mosquitto_db *db, struct mosquitto *context, const char *hint, const char *identity, char *key, int max_key_len);
 

--- a/src/security.c
+++ b/src/security.c
@@ -413,13 +413,10 @@ int mosquitto_security_cleanup(struct mosquitto_db *db, bool reload)
 
 
 //int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, const char *topic, int access)
-static int acl__check_single(struct mosquitto__auth_plugin_config *auth_plugin, struct mosquitto *context, const char *topic, int access)
+static int acl__check_single(struct mosquitto__auth_plugin_config *auth_plugin, struct mosquitto *context, struct mosquitto_acl_msg *msg, int access)
 {
-	struct mosquitto_acl_msg msg;
 	const char *username;
-
-	memset(&msg, 0, sizeof(msg));
-	msg.topic = topic;
+	const char *topic = msg->topic;
 
 	username = mosquitto_client_username(context);
 	if(auth_plugin->deny_special_chars == true){
@@ -440,7 +437,7 @@ static int acl__check_single(struct mosquitto__auth_plugin_config *auth_plugin, 
 	}
 
 	if(auth_plugin->plugin.version == 3){
-		return auth_plugin->plugin.acl_check_v3(auth_plugin->plugin.user_data, access, context, &msg);
+		return auth_plugin->plugin.acl_check_v3(auth_plugin->plugin.user_data, access, context, msg);
 	}else if(auth_plugin->plugin.version == 2){
 		if(access == MOSQ_ACL_SUBSCRIBE){
 			return MOSQ_ERR_SUCCESS;
@@ -452,11 +449,12 @@ static int acl__check_single(struct mosquitto__auth_plugin_config *auth_plugin, 
 }
 
 
-int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, const char *topic, int access)
+int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, const char *topic, long payloadlen, void* payload, int qos, bool retain, int access)
 {
 	int rc;
 	int i;
 	struct mosquitto__security_options *opts;
+	struct mosquitto_acl_msg msg;
 
 	if(!context->id){
 		return MOSQ_ERR_ACL_DENIED;
@@ -477,8 +475,15 @@ int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, cons
 		opts = &db->config->security_options;
 	}
 
+	memset(&msg, 0, sizeof(msg));
+	msg.topic = topic;
+	msg.payloadlen = payloadlen;
+	msg.payload = payload;
+	msg.qos = qos;
+	msg.retain = retain;
+
 	for(i=0; i<opts->auth_plugin_config_count; i++){
-		rc = acl__check_single(&opts->auth_plugin_configs[i], context, topic, access);
+		rc = acl__check_single(&opts->auth_plugin_configs[i], context, &msg, access);
 		if(rc != MOSQ_ERR_PLUGIN_DEFER){
 			return rc;
 		}

--- a/src/subs.c
+++ b/src/subs.c
@@ -102,7 +102,7 @@ static int subs__process(struct mosquitto_db *db, struct mosquitto__subhier *hie
 			continue;
 		}
 		/* Check for ACL topic access. */
-		rc2 = mosquitto_acl_check(db, leaf->context, topic, MOSQ_ACL_READ);
+		rc2 = mosquitto_acl_check(db, leaf->context, topic, stored->payloadlen, UHPA_ACCESS(stored->payload, stored->payloadlen), stored->qos, stored->retain, MOSQ_ACL_READ);
 		if(rc2 == MOSQ_ERR_ACL_DENIED){
 			leaf = leaf->next;
 			continue;
@@ -649,7 +649,8 @@ static int retain__process(struct mosquitto_db *db, struct mosquitto_msg_store *
 	int qos;
 	uint16_t mid;
 
-	rc = mosquitto_acl_check(db, context, retained->topic, MOSQ_ACL_READ);
+	rc = mosquitto_acl_check(db, context, retained->topic, retained->payloadlen, UHPA_ACCESS(retained->payload, retained->payloadlen),
+			retained->qos, retained->retain, MOSQ_ACL_READ);
 	if(rc == MOSQ_ERR_ACL_DENIED){
 		return MOSQ_ERR_SUCCESS;
 	}else if(rc != MOSQ_ERR_SUCCESS){


### PR DESCRIPTION
All fields in mosquitto_acl_msg wasn't filled before call to plugin.  
I'm not sure if there is another way this should be fixed, but i thought that i'd just add the missing struct fields through parameters to the mosquitto_acl_check call.
