### PR TITLE
Recent version libwebsockets

### DIFF
--- a/compiling.txt
+++ b/compiling.txt
@@ -1,12 +1,11 @@
 The following packages can be used to add features to mosquitto. All of them
 are optional.
 
-<<<<<<< HEAD
 * openssl (version 1.0.0 or greater if TLS-PSK support is needed)
 * c-ares (for DNS-SRV support, disabled by default)
 * libuuid (from util-linux, can be disabled)
 * tcp-wrappers (optional, package name libwrap0-dev)
-* libwebsockets (optional, disabled by default, version 1.3 and above)
+* libwebsockets (optional, disabled by default, version 1.6 and above)
 * On Windows, a pthreads library is required if threading support is to be
   included.
 

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -225,12 +225,7 @@ struct mosquitto {
 	int sub_count;
 	int pollfd_index;
 #  ifdef WITH_WEBSOCKETS
-#    if defined(LWS_LIBRARY_VERSION_NUMBER)
 	struct lws *wsi;
-#    else
-	struct libwebsocket_context *ws_context;
-	struct libwebsocket *wsi;
-#    endif
 #  endif
 	bool ws_want_write;
 #else

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -162,7 +162,7 @@ int net__socket_close(struct mosquitto *mosq)
 		if(mosq->state != mosq_cs_disconnecting){
 			mosq->state = mosq_cs_disconnect_ws;
 		}
-		lws_callback_on_writable(mosq->ws_context, mosq->wsi);
+		lws_callback_on_writable(mosq->ws_context);
 	}else
 #endif
 	{

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -162,7 +162,7 @@ int net__socket_close(struct mosquitto *mosq)
 		if(mosq->state != mosq_cs_disconnecting){
 			mosq->state = mosq_cs_disconnect_ws;
 		}
-		libwebsocket_callback_on_writable(mosq->ws_context, mosq->wsi);
+		lws_callback_on_writable(mosq->ws_context, mosq->wsi);
 	}else
 #endif
 	{

--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -118,8 +118,8 @@ int packet__queue(struct mosquitto *mosq, struct mosquitto__packet *packet)
 #ifdef WITH_BROKER
 #  ifdef WITH_WEBSOCKETS
 	if(mosq->wsi){
-		libwebsocket_callback_on_writable(mosq->ws_context, mosq->wsi);
-		return MOSQ_ERR_SUCCESS;
+		lws_callback_on_writable(mosq->ws_context, mosq->wsi);
+		return 0;
 	}else{
 		return packet__write(mosq);
 	}

--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -118,7 +118,7 @@ int packet__queue(struct mosquitto *mosq, struct mosquitto__packet *packet)
 #ifdef WITH_BROKER
 #  ifdef WITH_WEBSOCKETS
 	if(mosq->wsi){
-		lws_callback_on_writable(mosq->ws_context, mosq->wsi);
+		lws_callback_on_writable(mosq->ws_context);
 		return 0;
 	}else{
 		return packet__write(mosq);

--- a/src/loop.c
+++ b/src/loop.c
@@ -553,7 +553,7 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 			 * will soon, so for now websockets clients are second class
 			 * citizens. */
 			if(db->config->listeners[i].ws_context){
-				libwebsocket_service(db->config->listeners[i].ws_context, 0);
+				lws_service(db->config->listeners[i].ws_context, 0);
 			}
 		}
 		if(db->config->have_websockets_listener){
@@ -587,7 +587,7 @@ void do_disconnect(struct mosquitto_db *db, struct mosquitto *context)
 			context->state = mosq_cs_disconnect_ws;
 		}
 		if(context->wsi){
-			libwebsocket_callback_on_writable(context->ws_context, context->wsi);
+			lws_callback_on_writable(context->ws_context, context->wsi);
 		}
 		if(context->sock != INVALID_SOCKET){
 			HASH_DELETE(hh_sock, db->contexts_by_sock, context);

--- a/src/loop.c
+++ b/src/loop.c
@@ -587,7 +587,7 @@ void do_disconnect(struct mosquitto_db *db, struct mosquitto *context)
 			context->state = mosq_cs_disconnect_ws;
 		}
 		if(context->wsi){
-			lws_callback_on_writable(context->ws_context, context->wsi);
+			lws_callback_on_writable(context->ws_context);
 		}
 		if(context->sock != INVALID_SOCKET){
 			HASH_DELETE(hh_sock, db->contexts_by_sock, context);

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -372,7 +372,7 @@ int main(int argc, char *argv[])
 #ifdef WITH_WEBSOCKETS
 	for(i=0; i<int_db.config->listener_count; i++){
 		if(int_db.config->listeners[i].ws_context){
-			libwebsocket_context_destroy(int_db.config->listeners[i].ws_context);
+			lws_context_destroy(int_db.config->listeners[i].ws_context);
 		}
 		mosquitto__free(int_db.config->listeners[i].ws_protocol);
 	}

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -23,22 +23,6 @@ Contributors:
 
 #ifdef WITH_WEBSOCKETS
 #  include <libwebsockets.h>
-
-#  if defined(LWS_LIBRARY_VERSION_NUMBER)
-#    define libwebsocket_callback_on_writable(A, B) lws_callback_on_writable((B))
-#    define libwebsocket_service(A, B) lws_service((A), (B))
-#    define libwebsocket_create_context(A) lws_create_context((A))
-#    define libwebsocket_context_destroy(A) lws_context_destroy((A))
-#    define libwebsocket_write(A, B, C, D) lws_write((A), (B), (C), (D))
-#    define libwebsocket_get_socket_fd(A) lws_get_socket_fd((A))
-#    define libwebsockets_return_http_status(A, B, C, D) lws_return_http_status((B), (C), (D))
-#    define libwebsockets_get_protocol(A) lws_get_protocol((A))
-
-#    define libwebsocket_context lws_context
-#    define libwebsocket_protocols lws_protocols
-#    define libwebsocket_callback_reasons lws_callback_reasons
-#    define libwebsocket lws
-#  endif
 #endif
 
 #include "mosquitto_internal.h"
@@ -231,9 +215,9 @@ struct mosquitto__listener {
 	char *tls_version;
 #endif
 #ifdef WITH_WEBSOCKETS
-	struct libwebsocket_context *ws_context;
+	struct lws_context *ws_context;
 	char *http_dir;
-	struct libwebsocket_protocols *ws_protocol;
+	struct lws_protocols *ws_protocol;
 #endif
 	struct mosquitto__security_options security_options;
 	struct mosquitto__unpwd *unpwd;
@@ -631,11 +615,7 @@ DWORD WINAPI SigThreadProc(void* data);
  * Websockets related functions
  * ============================================================ */
 #ifdef WITH_WEBSOCKETS
-#  if defined(LWS_LIBRARY_VERSION_NUMBER)
 struct lws_context *mosq_websockets_init(struct mosquitto__listener *listener, int log_level);
-#  else
-struct libwebsocket_context *mosq_websockets_init(struct mosquitto__listener *listener, int log_level);
-#  endif
 #endif
 void do_disconnect(struct mosquitto_db *db, struct mosquitto *context);
 

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -297,7 +297,7 @@ static int callback_mqtt(
 				return -1;
 			}
 			if(mosq->current_out_packet){
-				lws_callback_on_writable(mosq->ws_context, mosq->wsi);
+				lws_callback_on_writable(mosq->ws_context);
 			}
 			break;
 
@@ -380,7 +380,7 @@ static int callback_mqtt(
 					if(mosq->state != mosq_cs_disconnecting){
 						mosq->state = mosq_cs_disconnect_ws;
 					}
-					lws_callback_on_writable(mosq->ws_context, mosq->wsi);
+					lws_callback_on_writable(mosq->ws_context);
 				} else if (rc) {
 					do_disconnect(db, mosq);
 					return -1;
@@ -551,7 +551,7 @@ static int callback_http(
 				u->fptr = NULL;
 				return -1;
 			}
-			lws_callback_on_writable(context, wsi);
+			lws_callback_on_writable(wsi);
 			break;
 
 		case LWS_CALLBACK_HTTP_BODY:
@@ -590,7 +590,7 @@ static int callback_http(
 						}
 					}
 				}while(u->fptr && !lws_send_pipe_choked(wsi));
-				lws_callback_on_writable(context, wsi);
+				lws_callback_on_writable(wsi);
 			}else{
 				return -1;
 			}


### PR DESCRIPTION
Hi,
In relation with 'Undefined reference libwebsocket_context_destroy' #826, 
i propose you to upgrade the minimum version of libwebsockets of 1.3 to 1.6

For example, the last update on 1.5-stable is 21 Jan 2016 and on 1.6-stable is 22 Apr 2016.

The v2.4-stable branch is always active and the last release (3.0-stable) is 5 May 2018.

C-U

