### PR TITLE
Add documentation and networking dep to unit files

### DIFF
--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -1,5 +1,8 @@
 [Unit]
 Description=Mosquitto MQTT v3.1/v3.1.1 Broker
+Documentation=man:mosquitto.conf(5) man:mosquitto(8)
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=notify

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -1,5 +1,8 @@
 [Unit]
 Description=Mosquitto MQTT v3.1/v3.1.1 Broker
+Documentation=man:mosquitto.conf(5) man:mosquitto(8)
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf


### PR DESCRIPTION
Updated the unit file examples to add a dependency on the
network-online.target systemd target to prevent mosquitto from
starting without network connectivity.

Added a documentation line to the unit files pointing to mosquitto
manpages.

Signed-off-by: Rich Mattes <richmattes@gmail.com>