### PR TITLE
add a maximum limit to the output queue 

### DIFF
--- a/lib/linker.version
+++ b/lib/linker.version
@@ -90,4 +90,5 @@ MOSQ_1.5 {
 		mosquitto_sub_topic_check2;
 		mosquitto_topic_matches_sub2;
 		mosquitto_connect_with_flags_callback_set;
+		mosquitto_max_pub_queue_messages_set;
 } MOSQ_1.4;

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -173,6 +173,7 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_se
 	mosq->in_callback = false;
 	mosq->in_queue_len = 0;
 	mosq->out_queue_len = 0;
+	mosq->max_out_queue_len = 0;
 	mosq->reconnect_delay = 1;
 	mosq->reconnect_delay_max = 1;
 	mosq->reconnect_exponential_backoff = false;

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -84,7 +84,8 @@ enum mosq_err_t {
 	MOSQ_ERR_EAI = 15,
 	MOSQ_ERR_PROXY = 16,
 	MOSQ_ERR_PLUGIN_DEFER = 17,
-	MOSQ_ERR_MALFORMED_UTF8 = 18
+	MOSQ_ERR_MALFORMED_UTF8 = 18,
+	MOSQ_ERR_QUEUE_LIMIT = 19
 };
 
 /* Error values */
@@ -1351,6 +1352,9 @@ libmosq_EXPORT int mosquitto_reconnect_delay_set(struct mosquitto *mosq, unsigne
  * higher than the maximum in flight messages on the broker may lead to
  * delays in the messages being acknowledged.
  *
+ * The real number of inflight messages published at one time can't be higer than the max_messages allowed in the queue
+ * (see mosquitto_max_pub_queue_messages_set)
+ *
  * Set to 0 for no maximum.
  *
  * Parameters:
@@ -1363,6 +1367,26 @@ libmosq_EXPORT int mosquitto_reconnect_delay_set(struct mosquitto *mosq, unsigne
  * 	MOSQ_ERR_INVAL -   if the input parameters were invalid.
  */
 libmosq_EXPORT int mosquitto_max_inflight_messages_set(struct mosquitto *mosq, unsigned int max_inflight_messages);
+
+/*
+ * Function: mosquitto_max_pub_queue_messages_set
+ *
+ * Set the number of QoS 1 and 2 messages published that can be queued
+ *
+ * The inflight messages at one time can't be higer than this number, even if max_inflight_messages whas defined otherwise
+ *
+ *
+ * Set to 0 for no maximum.
+ *
+ * Parameters:
+ *  mosq -                  a valid mosquitto instance.
+ *  max_queued_messages - the maximum number of outgoing queued messages
+ *
+ * Returns:
+ *	MOSQ_ERR_SUCCESS - on success.
+ *	MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ */
+libmosq_EXPORT int mosquitto_max_pub_queue_messages_set(struct mosquitto *mosq, unsigned int max_queued_messages);
 
 /*
  * Function: mosquitto_message_retry_set

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -259,6 +259,7 @@ struct mosquitto {
 	int port;
 	int in_queue_len;
 	int out_queue_len;
+	int max_out_queue_len;
 	char *bind_address;
 	unsigned int reconnect_delay;
 	unsigned int reconnect_delay_max;


### PR DESCRIPTION
Currently the output queue is not limited, only the number of inflight messages are.
This change add a control in the queue grow, to prevent it from growing unontrollably when the connection to the brooker is lost.

A 0 value means "unlimited"
Default value is 0, for retro-compatibility with older code

When the limit is reached, the packages are dropped and mosquitto_publish returns a new error code, MOSQ_ERR_QUEUE_LIMIT

Signed-off-by: chus alvarez <chus.alvarez@fon.com>