### PR TITLE
Remove AI_ADDRCONFIG flag from getaddrinfo() call.

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -311,7 +311,7 @@ int net__try_connect(struct mosquitto *mosq, const char *host, uint16_t port, mo
 	*sock = INVALID_SOCKET;
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = PF_UNSPEC;
-	hints.ai_flags = AI_ADDRCONFIG;
+	hints.ai_flags = 0;
 	hints.ai_socktype = SOCK_STREAM;
 
 	s = getaddrinfo(host, NULL, &hints, &ainfo);


### PR DESCRIPTION
This avoids issues with systems where there are no interfaces configured (except loopback).  See #869.