### PR TITLE
_GNU_SOURCE needed for EAI_INPROGRESS

### DIFF
--- a/config.h
+++ b/config.h
@@ -39,4 +39,6 @@
 #  define _POSIX_C_SOURCE 200809L
 #endif
 
+#define _GNU_SOURCE
+
 #endif


### PR DESCRIPTION
Define of _GNU_SOURCE is needed to be able to use EAI_INPROGRESS in
loop.c.

This patch fixes a build error

loop.c:334:17: error: ‘EAI_INPROGRESS’ undeclared (first use in this function)
        if(rc == EAI_INPROGRESS){

occuring with a glibc-2.27-based buildroot toolchain for sparc64

Target: sparc64-buildroot-linux-gnu
[...]
gcc version 6.4.0 (Buildroot 2018.05)

Source of the toolchain:
http://autobuild.buildroot.org/toolchains/tarballs/br-sparc64-full-2018.05.tar.bz2

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X]  Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
