### PR TITLE
Install pkg-config files also for non-CMake builds

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -57,6 +57,9 @@ ifeq ($(WITH_STATIC_LIBRARIES),yes)
 endif
 	$(INSTALL) -d "${DESTDIR}${prefix}/include/"
 	$(INSTALL) mosquitto.h "${DESTDIR}${prefix}/include/mosquitto.h"
+	$(INSTALL) -d "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/pkgconfig"
+	$(INSTALL) -m644 ../libmosquitto.pc.in "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/pkgconfig/libmosquitto.pc"
+	sed -i -e "s#@CMAKE_INSTALL_PREFIX@#$(prefix)#" -e "s#@VERSION@#$(VERSION)#" "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/pkgconfig/libmosquitto.pc"
 	$(MAKE) -C cpp install
 
 uninstall :

--- a/lib/cpp/Makefile
+++ b/lib/cpp/Makefile
@@ -24,7 +24,10 @@ ifeq ($(WITH_STATIC_LIBRARIES),yes)
 endif
 	$(INSTALL) -d "${DESTDIR}${prefix}/include/"
 	$(INSTALL) mosquittopp.h "${DESTDIR}${prefix}/include/mosquittopp.h"
-	
+	$(INSTALL) -d "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/pkgconfig"
+	$(INSTALL) -m644 ../../libmosquittopp.pc.in "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/pkgconfig/libmosquittopp.pc"
+	sed -i -e "s#@CMAKE_INSTALL_PREFIX@#$(prefix)#" -e "s#@VERSION@#$(VERSION)#" "${DESTDIR}$(prefix)/lib${LIB_SUFFIX}/pkgconfig/libmosquittopp.pc"
+
 uninstall :
 	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so.${SOVERSION}"
 	-rm -f "${DESTDIR}${prefix}/lib${LIB_SUFFIX}/libmosquittopp.so"


### PR DESCRIPTION
At the moment, pkg-config hint files are only installed when CMake is
used as build system. However, it is very convenient for programs using
libmosquitto to have these files always in place, so let's add it
here, too.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>

-----

From my point of view, this is a fix - YMMV, so I could rebase to develop if desired...