### PR TITLE
fix signal handler on win32

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -105,7 +105,7 @@ void handle_sigusr2(int signal)
 DWORD WINAPI SigThreadProc(void* data)
 {
 	TCHAR evt_name[MAX_PATH];
-	static HANDLE evt[4];
+	static HANDLE evt[3];
 	int pid = GetCurrentProcessId();
 
 	sprintf_s(evt_name, MAX_PATH, "mosq%d_shutdown", pid);


### PR DESCRIPTION
The signal handler thread on win32 did listen to 4 HANDLEs,
of which only 3 were initialized.
The result was 1 thread eating 100% cpu.
This commit reduces the HANDLE array storage.

Signed-off-by: Kurt Van Dijck <dev.kurt@vandijck-laurijssen.be>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
