### PR TITLE
return MOSQ_ERR_INVAL if config has invalid boolean value

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -2126,6 +2126,7 @@ static int conf__parse_bool(char **token, const char *name, bool *value, char *s
 			*value = true;
 		}else{
 			log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid %s value (%s).", name, *token);
+			return MOSQ_ERR_INVAL;
 		}
 	}else{
 		log__printf(NULL, MOSQ_LOG_ERR, "Error: Empty %s value in configuration.", name);


### PR DESCRIPTION
`conf__parse_bool` returns `MOSQ_ERR_INVAL` even if boolean value in mosquitto config file is invalid. This causes unexpected behaviour, for example if we run mosquitto with `persistence t` mosquitto prints error in logs but starts successfully without persistence.
```
$ mosquitto -c mosquitto.conf
Error: Invalid persistence value (t).
1538079039: mosquitto version 1.5.1 starting
1538079039: Config loaded from mosquitto.conf.
1538079039: Opening ipv6 listen socket on port 1883.
1538079039: Opening ipv4 listen socket on port 1883.
```
If mosquitto is running with persistence and config is changed, on reload signal mosquitto will print error message, but it will take the default value of persistence and persistence will be disabled.

Signed-off-by: Vinod Kumar <kumar003vinod@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
