### PR TITLE
ASN1_STRING_data --> ASN1_STRING_get0_data

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -456,7 +456,7 @@ int handle__connect(struct mosquitto_db *db, struct mosquitto *context)
 						rc = 1;
 						goto handle_connect_error;
 					}
-					context->username = mosquitto__strdup((char *) ASN1_STRING_data(name_asn1));
+					context->username = mosquitto__strdup((char *) ASN1_STRING_get0_data(name_asn1));
 					if(!context->username){
 						send__connack(context, 0, CONNACK_REFUSED_SERVER_UNAVAILABLE);
 						rc = MOSQ_ERR_NOMEM;


### PR DESCRIPTION
ASN1_STRING_data() is similar to ASN1_STRING_get0_data() except the returned value is not constant. This function is deprecated: applications should use ASN1_STRING_get0_data() instead.

See https://www.openssl.org/docs/man1.1.0/crypto/ASN1_STRING_data.html

- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
