### PR TITLE
fix bug where bridge doesn't honor restart_timeout setting

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -422,8 +422,8 @@ int mosquitto_main_loop(struct mosquitto_db *db, mosq_sock_t *listensock, int li
 #else
 						{
 							rc = bridge__connect(db, context);
+							context->bridge->restart_t = 0;
 							if(rc == MOSQ_ERR_SUCCESS){
-								context->bridge->restart_t = 0;
 								if(context->bridge->round_robin == false && context->bridge->cur_address != 0){
 									context->bridge->primary_retry = now + 5;
 								}


### PR DESCRIPTION
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

All tests ran, except for:
08-tls-psk-pub.py
08-tls-psk-bridge.py

Which didn't complete after leaving them running for 15 minutes each.

This fixes https://github.com/eclipse/mosquitto/issues/1019