### PR TITLE
src: ASN1_STRING_data is deprecated in OpenSSL 1.1

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -457,7 +457,11 @@ int handle__connect(struct mosquitto_db *db, struct mosquitto *context)
 						rc = 1;
 						goto handle_connect_error;
 					}
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 					context->username = mosquitto__strdup((char *) ASN1_STRING_data(name_asn1));
+#else
+					context->username = mosquitto__strdup((char *) ASN1_STRING_get0_data(name_asn1));
+#endif
 					if(!context->username){
 						send__connack(context, 0, CONNACK_REFUSED_SERVER_UNAVAILABLE);
 						rc = MOSQ_ERR_NOMEM;


### PR DESCRIPTION
ASN1_STRING_get0_data replaces ASN1_STRING_data in OpenSSL 1.1 therefore
add an #ifdef for backwards compatibility.

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
