### PR TITLE
Bridge Enhancement: Improve back-off mechanism

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -1235,11 +1235,14 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
-				<term><option>restart_timeout</option> <replaceable>value</replaceable></term>
+				<term><option>restart_timeout</option> <replaceable>constant | base cap</replaceable></term>
 				<listitem>
 					<para>Set the amount of time a bridge using the automatic
-						start type will wait until attempting to reconnect.
-						Defaults to 30 seconds.</para>
+						start type will wait until attempting to reconnect.</para>
+					<para>It can restart on a <replaceable>constant</replaceable> period, or apply a backoff
+						mechanism using “Decorrelated Jitter”, with <replaceable>base</replaceable> and
+						<replaceable>cap</replaceable> values.</para>
+					<para>Defaults to 30 seconds.</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -773,7 +773,10 @@
 #start_type automatic
 
 # Set the amount of time a bridge using the automatic start type will wait
-# until attempting to reconnect.  Defaults to 30 seconds.
+# until attempting to reconnect.
+# It can restart on a constant period, or apply a backoff mechanism using
+# “Decorrelated Jitter”, with base and cap values.
+# Defaults to 30 seconds.
 #restart_timeout 30
 
 # Set the amount of time a bridge using the lazy start type must be idle before

--- a/src/conf.c
+++ b/src/conf.c
@@ -1721,10 +1721,24 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge configuration.");
 						return MOSQ_ERR_INVAL;
 					}
-					if(conf__parse_int(&token, "restart_timeout", &cur_bridge->restart_timeout, saveptr)) return MOSQ_ERR_INVAL;
+					token = strtok_r(NULL, " ", &saveptr);
+					if(!token){
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Empty restart_timeout value in configuration.");
+						return MOSQ_ERR_INVAL;
+					}
+					cur_bridge->restart_timeout = atoi(token);
 					if(cur_bridge->restart_timeout < 1){
 						log__printf(NULL, MOSQ_LOG_NOTICE, "restart_timeout interval too low, using 1 second.");
 						cur_bridge->restart_timeout = 1;
+					}
+					token = strtok_r(NULL, " ", &saveptr);
+					if(token){
+						cur_bridge->backoff_base = cur_bridge->restart_timeout;
+						cur_bridge->backoff_cap = atoi(token);
+						if(cur_bridge->backoff_cap < cur_bridge->backoff_base){
+							log__printf(NULL, MOSQ_LOG_ERR, "Error: backoff cap is lower than the base.");
+							return MOSQ_ERR_INVAL;
+						}
 					}
 #else
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge support not available.");

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -451,6 +451,8 @@ struct mosquitto__bridge{
 	enum mosquitto_bridge_start_type start_type;
 	int idle_timeout;
 	int restart_timeout;
+	int backoff_base;
+	int backoff_cap;
 	int threshold;
 	bool lazy_reconnect;
 	bool attempt_unsubscribe;


### PR DESCRIPTION
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

This pull request covers [issue 1035](https://github.com/eclipse/mosquitto/issues/1035).
To make it work as expected using ADNS, [pull request 1029](https://github.com/eclipse/mosquitto/pull/1029) fixes an issue where effectively 1 minute (by default) gets added to the calculated time, by waiting an aditional `keepalive_interval`

-----
