### PR TITLE
Check SSL_DATA_PENDING in mosquitto_loop_read()

### DIFF
--- a/lib/loop.c
+++ b/lib/loop.c
@@ -147,12 +147,10 @@ int mosquitto_loop(struct mosquitto *mosq, int timeout, int max_packets)
 	}else{
 		if(mosq->sock != INVALID_SOCKET){
 			if(FD_ISSET(mosq->sock, &readfds)){
-				do{
-					rc = mosquitto_loop_read(mosq, max_packets);
-					if(rc || mosq->sock == INVALID_SOCKET){
-						return rc;
-					}
-				}while(SSL_DATA_PENDING(mosq));
+				rc = mosquitto_loop_read(mosq, max_packets);
+				if(rc || mosq->sock == INVALID_SOCKET){
+					return rc;
+				}
 			}
 			if(mosq->sockpairR != INVALID_SOCKET && FD_ISSET(mosq->sockpairR, &readfds)){
 #ifndef WIN32
@@ -364,7 +362,7 @@ int mosquitto_loop_read(struct mosquitto *mosq, int max_packets)
 	/* Queue len here tells us how many messages are awaiting processing and
 	 * have QoS > 0. We should try to deal with that many in this loop in order
 	 * to keep up. */
-	for(i=0; i<max_packets; i++){
+	for(i=0; i<max_packets || SSL_DATA_PENDING(mosq); i++){
 #ifdef WITH_SOCKS
 		if(mosq->socks5_host){
 			rc = socks5__read(mosq);


### PR DESCRIPTION
Hi,
``mosquitto_loop_read()`` sometimes doesn't read all the packets when I use it with TLS and an external loop. This PR fixes this issue.

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
