### PR TITLE
Don't clear SSL context when TLS connection is closed.

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -145,10 +145,6 @@ int net__socket_close(struct mosquitto *mosq)
 			SSL_free(mosq->ssl);
 			mosq->ssl = NULL;
 		}
-		if(mosq->ssl_ctx){
-			SSL_CTX_free(mosq->ssl_ctx);
-			mosq->ssl_ctx = NULL;
-		}
 	}
 #endif
 


### PR DESCRIPTION
Previous behaviour would clear the external SSL_CTX provided by
MOSQ_OPT_SSL_CTX. This required the user to reset the SSL_CTX every
disconnect, and trust that they were not leaking references.

Recreating the SSL context for every connection is not necessary, and the
SSL context is freed in mosquitto_destroy, which is sufficient.

Signed-off-by: Matthias Stone <matthias@bellstone.ca>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
