### PR TITLE
Fixed handling in case of thread creation failure

### DIFF
--- a/lib/cpp/mosquittopp.cpp
+++ b/lib/cpp/mosquittopp.cpp
@@ -220,6 +220,11 @@ int mosquittopp::connect_async(const char *host, int port, int keepalive, const 
 	return mosquitto_connect_bind_async(m_mosq, host, port, keepalive, bind_address);
 }
 
+void mosquittopp::connect_timeout_set(unsigned int connect_timeout)
+{
+	mosquitto_connect_timeout_set(m_mosq, connect_timeout);
+}
+
 int mosquittopp::reconnect()
 {
 	return mosquitto_reconnect(m_mosq);

--- a/lib/cpp/mosquittopp.h
+++ b/lib/cpp/mosquittopp.h
@@ -96,6 +96,7 @@ class mosqpp_EXPORT mosquittopp {
 		int connect_async(const char *host, int port=1883, int keepalive=60);
 		int connect(const char *host, int port, int keepalive, const char *bind_address);
 		int connect_async(const char *host, int port, int keepalive, const char *bind_address);
+		void connect_timeout_set(unsigned int connect_timeout);
 		int reconnect();
 		int reconnect_async();
 		int disconnect();

--- a/lib/linker.version
+++ b/lib/linker.version
@@ -77,6 +77,7 @@ MOSQ_1.4 {
 		mosquitto_pub_topic_check;
 		mosquitto_sub_topic_check;
 		mosquitto_socks5_set;
+		mosquitto_connect_timeout_set;
 } MOSQ_1.3;
 
 MOSQ_1.5 {

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -173,6 +173,7 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_se
 	mosq->in_callback = false;
 	mosq->in_queue_len = 0;
 	mosq->out_queue_len = 0;
+	mosq->connect_timeout = 10000;
 	mosq->reconnect_delay = 1;
 	mosq->reconnect_delay_max = 1;
 	mosq->reconnect_exponential_backoff = false;

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -1305,6 +1305,19 @@ libmosq_EXPORT void mosquitto_unsubscribe_callback_set(struct mosquitto *mosq, v
 libmosq_EXPORT void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on_log)(struct mosquitto *, void *, int, const char *));
 
 /*
+ * Function: mosquitto_connect_timeout_set
+ *
+ * Control the behaviour of the client when it tries to establish
+ * a connection to the broker. The default behaviour if this function
+ * is not used is to wait for at most 10000 ms in non-blocking mode.
+ *
+ * Returns:
+ *	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid.
+ */
+libmosq_EXPORT int mosquitto_connect_timeout_set(struct mosquitto *mosq, unsigned int connect_timeout);
+
+/*
  * Function: mosquitto_reconnect_delay_set
  *
  * Control the behaviour of the client when it has unexpectedly disconnected in

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -275,6 +275,7 @@ struct mosquitto {
 	ares_channel achan;
 #  endif
 #endif
+	unsigned int connect_timeout;
 
 #ifdef WITH_BROKER
 	UT_hash_handle hh_id;

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -26,7 +26,7 @@ Contributors:
 #define _GNU_SOURCE
 #include <netdb.h>
 #include <sys/socket.h>
-#include <unistd.h>
+#include <unistd.h>z
 #else
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/lib/options.c
+++ b/lib/options.c
@@ -71,6 +71,14 @@ int mosquitto_username_pw_set(struct mosquitto *mosq, const char *username, cons
 	return MOSQ_ERR_SUCCESS;
 }
 
+int mosquitto_connect_timeout_set(struct mosquitto *mosq, unsigned int connect_timeout)
+{
+	if(!mosq) return MOSQ_ERR_INVAL;
+
+	mosq->connect_timeout = connect_timeout;
+
+	return MOSQ_ERR_SUCCESS;
+}
 
 int mosquitto_reconnect_delay_set(struct mosquitto *mosq, unsigned int reconnect_delay, unsigned int reconnect_delay_max, bool reconnect_exponential_backoff)
 {

--- a/lib/thread_mosq.c
+++ b/lib/thread_mosq.c
@@ -34,6 +34,7 @@ int mosquitto_loop_start(struct mosquitto *mosq)
 	if(!pthread_create(&mosq->thread_id, NULL, mosquitto__thread_main, mosq)){
 		return MOSQ_ERR_SUCCESS;
 	}else{
+		mosq->threaded = mosq_ts_none;
 		return MOSQ_ERR_ERRNO;
 	}
 #else


### PR DESCRIPTION
* Reset mosq->threaded to mosq_ts_none in case
  pthread_create() fails in mosquitto_loop_start()
  since otherwise all subsequent calls to this
  function fail with MOSQ_ERR_INVAL

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
