### PR TITLE
Fixed handling in case of thread creation failure

### DIFF
--- a/lib/thread_mosq.c
+++ b/lib/thread_mosq.c
@@ -34,6 +34,7 @@ int mosquitto_loop_start(struct mosquitto *mosq)
 	if(!pthread_create(&mosq->thread_id, NULL, mosquitto__thread_main, mosq)){
 		return MOSQ_ERR_SUCCESS;
 	}else{
+		mosq->threaded = mosq_ts_none;
 		return MOSQ_ERR_ERRNO;
 	}
 #else


### PR DESCRIPTION
* Reset mosq->threaded to mosq_ts_none in case
  pthread_create() fails in mosquitto_loop_start()
  since otherwise all subsequent calls to this
  function fail with MOSQ_ERR_INVAL

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
