### PR TITLE
Do not break loop in case of MOSQ_ERR_TLS errors

### DIFF
--- a/lib/loop.c
+++ b/lib/loop.c
@@ -219,7 +219,6 @@ int mosquitto_loop_forever(struct mosquitto *mosq, int timeout, int max_packets)
 			case MOSQ_ERR_PROTOCOL:
 			case MOSQ_ERR_INVAL:
 			case MOSQ_ERR_NOT_FOUND:
-			case MOSQ_ERR_TLS:
 			case MOSQ_ERR_PAYLOAD_SIZE:
 			case MOSQ_ERR_NOT_SUPPORTED:
 			case MOSQ_ERR_AUTH:
@@ -228,6 +227,7 @@ int mosquitto_loop_forever(struct mosquitto *mosq, int timeout, int max_packets)
 			case MOSQ_ERR_EAI:
 			case MOSQ_ERR_PROXY:
 				return rc;
+			case MOSQ_ERR_TLS:
 			case MOSQ_ERR_ERRNO:
 				break;
 		}


### PR DESCRIPTION
TLS errors can be caused by bad local clock settings which might
get adjusted later, causing a reconnect to succeed.

Change-Id: Id156908a8b2363fd19821893c7fe41ae21bdbc14

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
