### PR TITLE
ignore inline comments while parsing optional config params

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -765,6 +765,9 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 						return MOSQ_ERR_INVAL;
 					}
 					while((token = strtok_r(NULL, " ", &saveptr))){
+						if (token[0] == '#'){
+							break;
+						}
 						cur_bridge->address_count++;
 						cur_bridge->addresses = mosquitto__realloc(cur_bridge->addresses, sizeof(struct bridge_address)*cur_bridge->address_count);
 						if(!cur_bridge->addresses){
@@ -1326,7 +1329,10 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 						cur_listener->security_options.allow_anonymous = -1;
 						cur_listener->protocol = mp_mqtt;
 						cur_listener->port = tmp_int;
-						token = strtok_r(NULL, "", &saveptr);
+						token = strtok_r(NULL, " ", &saveptr);
+						if (token != NULL && token[0] == '#'){
+							token = NULL;
+						}
 						mosquitto__free(cur_listener->host);
 						if(token){
 							cur_listener->host = mosquitto__strdup(token);
@@ -1870,6 +1876,9 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 						}
 						token = strtok_r(NULL, " ", &saveptr);
 						if(token){
+							if (token[0] == '#'){
+								strtok_r(NULL, "", &saveptr);
+							}
 							cur_topic->qos = atoi(token);
 							if(cur_topic->qos < 0 || cur_topic->qos > 2){
 								log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge QoS level '%s'.", token);
@@ -1879,8 +1888,11 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 							token = strtok_r(NULL, " ", &saveptr);
 							if(token){
 								cur_bridge->topic_remapping = true;
-								if(!strcmp(token, "\"\"")){
+								if(!strcmp(token, "\"\"") || token[0] == '#'){
 									cur_topic->local_prefix = NULL;
+									if (token[0] == '#'){
+										strtok_r(NULL, "", &saveptr);
+									}
 								}else{
 									if(mosquitto_pub_topic_check(token) != MOSQ_ERR_SUCCESS){
 										log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge topic local prefix '%s'.", token);
@@ -1895,7 +1907,7 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 
 								token = strtok_r(NULL, " ", &saveptr);
 								if(token){
-									if(!strcmp(token, "\"\"")){
+									if(!strcmp(token, "\"\"") || token[0] == '#'){
 										cur_topic->remote_prefix = NULL;
 									}else{
 										if(mosquitto_pub_topic_check(token) != MOSQ_ERR_SUCCESS){


### PR DESCRIPTION
This is a fix I am proposing for #1075 . The inline comment does not work for configuration parameters which have optional values. like `listener port [bind address/host]`.
In such cases currently we read inline comment as optional parameter value. This patch just ignores the inline comments and default value of optional params is used.
In this patch I have considered `listener`, `address` and `topic` as these have optional parameters in configuration file (I hope I did not miss any).

Other approach could be to display proper error message, but for other configuration keys where we do not have optional parameters we end up ignoring inline comments, because we do not parse the line once we get the required values, so this will make it consistent across the whole config.

This will not work if we have optional parameter which can start from `#`, but in this case we do not have such optional parameter.

Signed-off-by: Vinod Kumar <kumar003vinod@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
