### PR TITLE
Fixed threaded enum lost in merges

### DIFF
--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -141,7 +141,7 @@ int packet__queue(struct mosquitto *mosq, struct mosquitto__packet *packet)
 #endif
 	}
 
-	if(mosq->in_callback == false && mosq->threaded == false){
+	if(mosq->in_callback == false && mosq->threaded == mosq_ts_none){
 		return packet__write(mosq);
 	}else{
 		return MOSQ_ERR_SUCCESS;


### PR DESCRIPTION
Change was part of the original commit e8185ddaa74234c2c37aa529e711cddfc7cede91
"[166] Don't cancel external threads."
and then lost during code reorganizing and subsequent merge,
commits 970ba58da63b2790607585edcc364b7ada614e3b 81cb7ab547b37edcdf9e22e2ab93cbe260bb924b

Signed-off-by: Maksym Ruchko <mruchko@advantech-bb.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?
- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
