### PR TITLE
Prolongate timeout on PUBLISH only when not already waiting for PINGRESP

### DIFF
--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -373,7 +373,9 @@ int packet__write(struct mosquitto *mosq)
 		mosquitto__free(packet);
 
 		pthread_mutex_lock(&mosq->msgtime_mutex);
-		mosq->next_msg_out = mosquitto_time() + mosq->keepalive;
+		if (!mosq->ping_t) {
+			mosq->next_msg_out = mosquitto_time() + mosq->keepalive;
+		}
 		pthread_mutex_unlock(&mosq->msgtime_mutex);
 	}
 	pthread_mutex_unlock(&mosq->current_out_packet_mutex);


### PR DESCRIPTION
When a PINGREQ has been sent the PINGRESP is expected within
next keepalive interval and the select timeout is set accordingly.
Sending PUBLISH on the socket may still be possible at this time
although the connection is no longer working. Normally the next
timeout is set to PUBLISH time + another keepalive interval,
but in case the PINGRESP has not arrived yet, it should be kept
to detect a connection problem as soon as possible.

Change-Id: I9c9cd62a228d2f3edb0aba513cd454845bd654d8
Signed-off-by: Sarah Nieswand <Sarah.Nieswand@partner.bmw.de>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
