### PR TITLE
Retrieve websocket client address from X-Real-IP/X-Forwarded-For headers

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -846,6 +846,17 @@
 							Defaults to 0.</para>
 					</listitem>
 				</varlistentry>
+				<varlistentry>
+					<term><option>websockets_log_forwarded_for</option> <replaceable>level</replaceable></term>
+					<listitem>
+						<para>Change the websockets logging to read the ip from the
+							X-Real-IP/X-Forwarded-For headers if present. This is
+							usefull if mosquitto is running behind a proxy and
+							you want the client IP to show up in the log. If it
+							isn't running behind a proxy there is a risk of ip
+							address spoofing.</para>
+					</listitem>
+				</varlistentry>
 			</variablelist>
 		</refsect2>
 		<refsect2>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -520,6 +520,12 @@
 # be enabled.
 #websockets_log_level 0
 
+# Change the websockets logging to read the ip from the X-Real-IP/X-Forwarded-For
+# headers if present. This is usefull if mosquitto is running behind a proxy and
+# you want the client IP to show up in the log.
+# If it isn't running behind a proxy there is a risk of ip address spoofing.
+#websockets_log_forwarded_for false
+
 # If set to true, client connection and disconnection messages will be included
 # in the log.
 #connection_messages true

--- a/src/conf.c
+++ b/src/conf.c
@@ -571,6 +571,7 @@ void config__copy(struct mosquitto__config *src, struct mosquitto__config *dest)
 
 #ifdef WITH_WEBSOCKETS
 	dest->websockets_log_level = src->websockets_log_level;
+	dest->websockets_log_forwarded_for = src->websockets_log_forwarded_for;
 #endif
 }
 
@@ -2012,6 +2013,12 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 				}else if(!strcmp(token, "websockets_log_level")){
 #ifdef WITH_WEBSOCKETS
 					if(conf__parse_int(&token, "websockets_log_level", &config->websockets_log_level, saveptr)) return MOSQ_ERR_INVAL;
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Websockets support not available.");
+#endif
+				}else if(!strcmp(token, "websockets_log_forwarded_for")){
+#ifdef WITH_WEBSOCKETS
+					if(conf__parse_bool(&token, "websockets_log_forwarded_for", &config->websockets_log_forwarded_for, saveptr)) return MOSQ_ERR_INVAL;
 #else
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Websockets support not available.");
 #endif

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -274,6 +274,7 @@ struct mosquitto__config {
 	char *user;
 #ifdef WITH_WEBSOCKETS
 	int websockets_log_level;
+	bool websockets_log_forwarded_for;
 	bool have_websockets_listener;
 #endif
 #ifdef WITH_BRIDGE

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -153,11 +153,16 @@ static struct libwebsocket_protocols protocols[] = {
 	}
 };
 
-static void easy_address(int sock, struct mosquitto *mosq)
+static void easy_address(struct libwebsocket *wsi, struct mosquitto *mosq)
 {
 	char address[1024];
 
-	if(!net__socket_get_address(sock, address, 1024)){
+	if (lws_hdr_copy(wsi, address, 1023, WSI_TOKEN_HTTP_X_REAL_IP) > 0 ||
+#if (LWS_LIBRARY_VERSION_MAJOR > 2) || (LWS_LIBRARY_VERSION_MAJOR == 2 && LWS_LIBRARY_VERSION_MINOR >= 2)
+		lws_hdr_copy(wsi, address, 1023, WSI_TOKEN_HTTP_X_FORWARDED_FOR) > 0 ||
+#endif
+		!net__socket_get_address(libwebsocket_get_socket_fd(wsi), address, 1024)
+	) {
 		mosq->address = mosquitto__strdup(address);
 	}
 }
@@ -221,7 +226,7 @@ static int callback_mqtt(struct libwebsocket_context *context,
 			}else{
 				return -1;
 			}
-			easy_address(libwebsocket_get_socket_fd(wsi), mosq);
+			easy_address(wsi, mosq);
 			if(!mosq->address){
 				/* getpeername and inet_ntop failed and not a bridge */
 				mosquitto__free(mosq);


### PR DESCRIPTION
Using the patch that robymus provided as a base in Issue #339, I went ahead and added a config variable as was suggested in the issue.

It works pretty well, but at least on my system with libwebsockets-3.0.1 there is a small formatting issue: lws_hdr_copy() includes the colon and the space of the header, so the IP looks like ": 127.0.0.1" in the log. I am unsure if this is a bug in lws or intentional, so I didn'T know how to proceed and just left it as it was.