### PR TITLE
Fix missing AF_INET definition

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 
 extern struct mosquitto_db int_db;


### PR DESCRIPTION
Without this, mosquitto doesn't build on FreeBSD with websockets enabled

Signed-off-by: Steven Lawrance <stl@koffein.net>