### PR TITLE
FIX #1080

### DIFF
--- a/lib/util_mosq.c
+++ b/lib/util_mosq.c
@@ -421,7 +421,7 @@ FILE *mosquitto__fopen(const char *path, const char *mode, bool restrict_read)
 
 			hfile = CreateFile(buf, GENERIC_READ | GENERIC_WRITE, 0,
 				&sec,
-				CREATE_NEW,
+				CREATE_ALWAYS,
 				FILE_ATTRIBUTE_NORMAL,
 				NULL);
 


### PR DESCRIPTION
Fix proposal for : Broker can't restart with log file on Windows #1080
