### PR TITLE
print error message when listener bind address is not valid

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -407,7 +407,11 @@ int net__socket_listen(struct mosquitto__listener *listener)
 	hints.ai_flags = AI_PASSIVE;
 	hints.ai_socktype = SOCK_STREAM;
 
-	if(getaddrinfo(listener->host, service, &hints, &ainfo)) return INVALID_SOCKET;
+	rc = getaddrinfo(listener->host, service, &hints, &ainfo);
+	if (rc){
+		log__printf(NULL, MOSQ_LOG_ERR, "Error creating listener: %s.", gai_strerror(rc));
+		return INVALID_SOCKET;
+	}
 
 	listener->sock_count = 0;
 	listener->socks = NULL;


### PR DESCRIPTION
If the listener host is an invalid value (`getaddrinfo` fails), print error message.

Signed-off-by: Vinod Kumar <kumar003vinod@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
