### PR TITLE
Let auth plugin handle if no username matched

### DIFF
--- a/src/security_default.c
+++ b/src/security_default.c
@@ -882,7 +882,7 @@ int mosquitto_unpwd_check_default(struct mosquitto_db *db, struct mosquitto *con
 		}
 	}
 
-	return MOSQ_ERR_AUTH;
+	return MOSQ_ERR_PLUGIN_DEFER;
 }
 
 static int unpwd__cleanup(struct mosquitto__unpwd **root, bool reload)


### PR DESCRIPTION
mosquitto_unpwd_check_default() should return MOSQ_ERR_PLUGIN_DEFER instead MOSQ_ERR_AUTH
if no username matched so that auth plugin can handle it.

According to docs:
"If password_file, or acl_file are used in the config file alongsize auth_plugin,
the plugin checks will run after the build in checks."

Fixes #1215

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
