### PR TITLE
Add missing sys/time.h include on client_shared.h

### DIFF
--- a/client/client_shared.h
+++ b/client/client_shared.h
@@ -18,6 +18,7 @@ Contributors:
 #define CLIENT_CONFIG_H
 
 #include <stdio.h>
+#include <sys/time.h> /* timeval */
 
 /* pub_client.c modes */
 #define MSGMODE_NONE 0


### PR DESCRIPTION
Required by more strict libcs like musl libc.

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
