### PR TITLE
Fix password input when MAX_BUFFER_LEN is not 1024 in mosquitto_passwd.c

### DIFF
--- a/src/mosquitto_passwd.c
+++ b/src/mosquitto_passwd.c
@@ -339,13 +339,15 @@ int gets_quiet(char *s, int len)
 #endif
 }
 
-int get_password(char *password, int len)
+int get_password(char *password, size_t len)
 {
 	char pw1[MAX_BUFFER_LEN], pw2[MAX_BUFFER_LEN];
+	size_t minLen;
+	minLen = len < MAX_BUFFER_LEN ? len : MAX_BUFFER_LEN;
 
 	printf("Password: ");
 	fflush(stdout);
-	if(gets_quiet(pw1, MAX_BUFFER_LEN)){
+	if(gets_quiet(pw1, minLen)){
 		fprintf(stderr, "Error: Empty password.\n");
 		return 1;
 	}
@@ -353,7 +355,7 @@ int get_password(char *password, int len)
 
 	printf("Reenter password: ");
 	fflush(stdout);
-	if(gets_quiet(pw2, MAX_BUFFER_LEN)){
+	if(gets_quiet(pw2, minLen)){
 		fprintf(stderr, "Error: Empty password.\n");
 		return 1;
 	}
@@ -364,7 +366,7 @@ int get_password(char *password, int len)
 		return 1;
 	}
 
-	strncpy(password, pw1, len);
+	strncpy(password, pw1, minLen);
 	return 0;
 }
 
@@ -526,7 +528,7 @@ int main(int argc, char *argv[])
 #endif
 
 	if(create_new){
-		rc = get_password(password, 1024);
+		rc = get_password(password, MAX_BUFFER_LEN);
 		if(rc){
 			free(password_file);
 			return rc;
@@ -581,7 +583,7 @@ int main(int argc, char *argv[])
 				/* Update password for individual user */
 				rc = update_pwuser(fptr, ftmp, username, password_cmd);
 			}else{
-				rc = get_password(password, 1024);
+				rc = get_password(password, MAX_BUFFER_LEN);
 				if(rc){
 					fclose(fptr);
 					fclose(ftmp);


### PR DESCRIPTION
This handles some inconsistencies in mosquitto_passwd.c . The MAX_BUFFER_LEN was not used at all places, which could result in a buffer overflow in case of MAX_BUFFER_LEN != 1024 here:
https://github.com/eclipse/mosquitto/blob/995f90dbafa82c7fd3d24f7174d094f11c2d6c85/src/mosquitto_passwd.c#L529

Also `strncpy` does not garantee to produce a Null-terminated string in destination, if src is longer than the third parameter `len`:
https://github.com/eclipse/mosquitto/blob/995f90dbafa82c7fd3d24f7174d094f11c2d6c85/src/mosquitto_passwd.c#L367

Due to the special case that MAX_BUFFER_LEN is set to 1024, this is not a critical bug, but now it should be safe to change MAX_BUFFER_LEN if necessary.

As I do not have a working OpenSSL-Setup, I'm unable to test it myself. But I hope the CI will do it.

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
