### PR TITLE
Ssl fixes for ENGINE and UI includes

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -50,6 +50,7 @@ Contributors:
 #include <openssl/conf.h>
 #include <openssl/engine.h>
 #include <openssl/err.h>
+#include <openssl/ui.h>
 #include <tls_mosq.h>
 #endif
 

--- a/lib/options.c
+++ b/lib/options.c
@@ -255,6 +255,7 @@ int mosquitto_string_option(struct mosquitto *mosq, enum mosq_opt_t option, cons
 	switch(option){
 		case MOSQ_OPT_TLS_ENGINE:
 #ifdef WITH_TLS
+#    if !defined(OPENSSL_NO_ENGINE)
 			eng = ENGINE_by_id(value);
 			if(!eng){
 				return MOSQ_ERR_INVAL;
@@ -265,6 +266,7 @@ int mosquitto_string_option(struct mosquitto *mosq, enum mosq_opt_t option, cons
 				return MOSQ_ERR_NOMEM;
 			}
 			return MOSQ_ERR_SUCCESS;
+#endif
 #else
 			return MOSQ_ERR_NOT_SUPPORTED;
 #endif


### PR DESCRIPTION
Not sure if the ui.h include is part of engine support or not, but it needs to be included for the openwrt buildroot at least.

The ENGINE=no support is just something quick to get me to compile again.  I may have not taken the preferred paths of warning that things might not be available.

I'm _completely_ ok with simply requiring ENGINE support.  OpenWrt is defaulting to engine ON now, I've only extended the patching as support for building without engine support was already in the codebase.


- [n/a ] If you are contributing a new feature, is your work based off the develop branch?
- [no (fixes branch isn't uptodate) ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
