### PR TITLE
Fixed Segmentation Fault / NULLptr dereference

### DIFF
--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -662,6 +662,10 @@ int client_config_line_proc(struct mosq_config *cfg, int pub_or_sub, int argc, c
 					return 1;
 				}
 				topic = strchr(url, '/');
+				if(!topic){
+					fprintf(stderr, "Error: invalid URL for -L argument specified.\n\n");
+					return 1;
+				}
 				*topic++ = 0;
 
 				if(cfg_add_topic(cfg, pub_or_sub, topic, "-L topic"))


### PR DESCRIPTION
Signed-off-by: Till Zimmermann <tzimmermann@uni-osnabrueck.de>

This fixes a Segmentation Fault in the client tools I encountered recently when supplying a malformed URL to the `-L`-Flag (missing trailing `/`) (cf. #1248).

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
