### PR TITLE
No pthread_cancel() on Android

### DIFF
--- a/config.h
+++ b/config.h
@@ -60,4 +60,9 @@
 
 #define UNUSED(A) (void)(A)
 
+/* Android Bionic libpthread implementation doesn't have pthread_cancel */
+#ifndef ANDROID
+#  define HAVE_PTHREAD_CANCEL
+#endif
+
 #endif

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -201,11 +201,13 @@ void mosquitto__destroy(struct mosquitto *mosq)
 	if(!mosq) return;
 
 #ifdef WITH_THREADING
+#  ifdef HAVE_PTHREAD_CANCEL
 	if(mosq->threaded == mosq_ts_self && !pthread_equal(mosq->thread_id, pthread_self())){
 		pthread_cancel(mosq->thread_id);
 		pthread_join(mosq->thread_id, NULL);
 		mosq->threaded = mosq_ts_none;
 	}
+#  endif
 
 	if(mosq->id){
 		/* If mosq->id is not NULL then the client has already been initialised

--- a/lib/thread_mosq.c
+++ b/lib/thread_mosq.c
@@ -27,7 +27,7 @@ void *mosquitto__thread_main(void *obj);
 
 int mosquitto_loop_start(struct mosquitto *mosq)
 {
-#ifdef WITH_THREADING
+#if defined(WITH_THREADING) && defined(HAVE_PTHREAD_CANCEL)
 	if(!mosq || mosq->threaded != mosq_ts_none) return MOSQ_ERR_INVAL;
 
 	mosq->threaded = mosq_ts_self;
@@ -43,7 +43,7 @@ int mosquitto_loop_start(struct mosquitto *mosq)
 
 int mosquitto_loop_stop(struct mosquitto *mosq, bool force)
 {
-#ifdef WITH_THREADING
+#if defined(WITH_THREADING) && defined(HAVE_PTHREAD_CANCEL)
 #  ifndef WITH_BROKER
 	char sockpair_data = 0;
 #  endif


### PR DESCRIPTION
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----

pthread_cancel() is not available on Android

Thus mosquitto_loop_start() and mosquitto_loop_stop()  won't be available there (and mosquitto_connect_async() as a consequence).