### PR TITLE
Fix plugin psk_key_get for v4

### DIFF
--- a/src/security.c
+++ b/src/security.c
@@ -752,7 +752,7 @@ int mosquitto_psk_key_get(struct mosquitto_db *db, struct mosquitto *context, co
 	}
 
 	for(i=0; i<opts->auth_plugin_config_count; i++){
-		if(opts->auth_plugin_configs[i].plugin.version == 3
+		if(opts->auth_plugin_configs[i].plugin.version == 4
 				&& opts->auth_plugin_configs[i].plugin.psk_key_get_v4){
 
 			rc = opts->auth_plugin_configs[i].plugin.psk_key_get_v4(


### PR DESCRIPTION
If you've had authentication plugin version 4 the broker would never call `mosquitto_auth_psk_key_get` because there was an incorrect version check. 

Signed-off-by: Matevz Mihalic <matevz.mihalic@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
