### PR TITLE
Remove redundant initialization in clients

### DIFF
--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -443,7 +443,6 @@ int main(int argc, char *argv[])
 
 	if(pub_shared_init()) return 1;
 
-	memset(&cfg, 0, sizeof(struct mosq_config));
 	rc = client_config_load(&cfg, CLIENT_PUB, argc, argv);
 	if(rc){
 		if(rc == 2){

--- a/client/rr_client.c
+++ b/client/rr_client.c
@@ -252,8 +252,6 @@ int main(int argc, char *argv[])
 #ifndef WIN32
 		struct sigaction sigact;
 #endif
-	
-	memset(&cfg, 0, sizeof(struct mosq_config));
 
 	mosquitto_lib_init();
 

--- a/client/sub_client.c
+++ b/client/sub_client.c
@@ -278,8 +278,6 @@ int main(int argc, char *argv[])
 #ifndef WIN32
 		struct sigaction sigact;
 #endif
-	
-	memset(&cfg, 0, sizeof(struct mosq_config));
 
 	mosquitto_lib_init();
 


### PR DESCRIPTION
the `memset(&cfg, 0, sizeof(struct mosq_config));` already exsits in
`client_config_load()`'s `init_config()`. So calling it in main function
is totally unnecessary.

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
