### PR TITLE
feat: Remove unecessary if statement

### DIFF
--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -1427,11 +1427,11 @@ static int mosquitto__parse_socks_url(struct mosq_config *cfg, char *url)
 
 	return 0;
 cleanup:
-	if(username_or_host) free(username_or_host);
-	if(username) free(username);
-	if(password) free(password);
-	if(host) free(host);
-	if(port) free(port);
+	free(username_or_host);
+	free(username);
+	free(password);
+	free(host);
+	free(port);
 	return 1;
 }
 #endif


### PR DESCRIPTION
free() would take no action if the arguement is a NULL pointer.
Therefore, the if statement is totally unnecessary.
See ISO-IEC 9899

Signed-off-by: YangHau <vulxj0j8j8@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
