### PR TITLE
Remove useless if statement

### DIFF
--- a/src/db_dump/db_dump.c
+++ b/src/db_dump/db_dump.c
@@ -100,42 +100,28 @@ struct msg_store_chunk *msgs_by_id = NULL;
 static void
 free__db_sub(struct db_sub *sub)
 {
-	if (sub->client_id) {
-		free(sub->client_id);
-	}
-	if (sub->topic) {
-		free(sub->topic);
-	}
+	free(sub->client_id);
+	free(sub->topic);
 }
 
 static void
 free__db_client(struct db_client *client)
 {
-	if (client->client_id) {
-		free(client->client_id);
-	}
+	free(client->client_id);
 }
 
 static void
 free__db_client_msg(struct db_client_msg *msg)
 {
-	if (msg->client_id) {
-		free(msg->client_id);
-	}
+	free(msg->client_id);
 }
 
 static void
 free__db_msg(struct db_msg *msg)
 {
-	if (msg->source_id) {
-		free(msg->source_id);
-	}
-	if (msg->topic) {
-		free(msg->topic);
-	}
-	if (msg->payload) {
-		free(msg->payload);
-	}
+	free(msg->source_id);
+	free(msg->topic);
+	free(msg->payload);
 }
 
 static void


### PR DESCRIPTION
If statement for detecting if a pointer is NULL is totally unnecessary.
As what it did in #1365 

Signed-off-by: YangHau <vulxj0j8j8@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
