### PR TITLE
Small mosquitto_acl_check parameters test update

### DIFF
--- a/src/security.c
+++ b/src/security.c
@@ -629,7 +629,7 @@ int mosquitto_acl_check(struct mosquitto_db *db, struct mosquitto *context, cons
 	struct mosquitto__security_options *opts;
 	struct mosquitto_acl_msg msg;
 
-	if(!context->id){
+	if(!db || !context || !context->id || !topic){
 		return MOSQ_ERR_ACL_DENIED;
 	}
 


### PR DESCRIPTION
I don't understand why test (!context->id), 
I've preserved this test (compatibility)  but add the previous test (!context) and add the others pointers used inside the function.

Signed-off-by: Carlos San Esteban <carlos.sanesteban@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
