### PR TITLE
Fix `mosquitto_pub -l` hang when stdin stream ends. Closes #1448.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -14,6 +14,7 @@ Client library:
 
 Clients:
 - Fix duplicate cfg definition in rr_client. Closes #1453.
+- Fix `mosquitto_pub -l` hang when stdin stream ends. Closes #1448.
 
 
 1.6.7 - 20190925

--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -283,7 +283,8 @@ int pub_shared_loop(struct mosquitto *mosq)
 					/* Not end of stdin, so we've lost our connection and must
 					 * reconnect */
 				}
-			}else if(status == STATUS_WAITING){
+			}
+			if(status == STATUS_WAITING){
 				if(last_mid_sent == last_mid && disconnect_sent == false){
 					mosquitto_disconnect_v5(mosq, 0, cfg.disconnect_props);
 					disconnect_sent = true;


### PR DESCRIPTION
Since 1.6.3 'mosquitto_pub -l' frequently hangs after end of stdin.
This fix allows to run disconnection part of code before leaving loop, so clean mqtt end of session is possible.
Fixes #1448.

Signed-off-by: Marek Wodzinski <majek@w7i.pl>

- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
