### PR TITLE
Add ca-certificates to Docker

### DIFF
--- a/docker/1.4.12/Dockerfile
+++ b/docker/1.4.12/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER David Audet <david.audet@ca.com>
 
 LABEL Description="Eclipse Mosquitto MQTT Broker"
 
-RUN apk --no-cache add mosquitto=1.4.12-r0 && \
+RUN apk --no-cache add mosquitto=1.4.12-r0 ca-certificates && \
     mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
     cp /etc/mosquitto/mosquitto.conf /mosquitto/config && \
     chown -R mosquitto:mosquitto /mosquitto

--- a/docker/1.5/Dockerfile
+++ b/docker/1.5/Dockerfile
@@ -14,7 +14,8 @@ RUN set -x && \
         cmake \
         gnupg \
         libressl-dev \
-        util-linux-dev && \
+        util-linux-dev \
+        ca-certificates && \
     wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
     mkdir -p /build/lws && \
     tar --strip=1 -xf /tmp/lws.tar.gz -C /build/lws && \

--- a/docker/1.6/Dockerfile
+++ b/docker/1.6/Dockerfile
@@ -14,7 +14,8 @@ RUN set -x && \
         cmake \
         gnupg \
         libressl-dev \
-        util-linux-dev && \
+        util-linux-dev \
+        ca-certificates && \
     wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
     mkdir -p /build/lws && \
     tar --strip=1 -xf /tmp/lws.tar.gz -C /build/lws && \

--- a/docker/generic/Dockerfile
+++ b/docker/generic/Dockerfile
@@ -12,7 +12,8 @@ RUN apk --no-cache add \
       util-linux-dev \
       libwebsockets-dev \
       libxslt \
-      python2
+      python2 \
+      ca-certificates
 
 # This build procedure is based on:
 # https://github.com/alpinelinux/aports/blob/master/main/mosquitto/APKBUILD

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -13,7 +13,8 @@ RUN set -x && \
         cmake \
         gnupg \
         libressl-dev \
-        util-linux-dev && \
+        util-linux-dev \
+        ca-certificates && \
     wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
     mkdir -p /build/lws && \
     tar --strip=1 -xf /tmp/lws.tar.gz -C /build/lws && \


### PR DESCRIPTION
to support root certificates

Signed-off-by: Mario Vejlupek <mario@vejlupek.cz>

Without root certificates docker image is unable to use TLS connection without additional setup.

- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
