### PR TITLE
Base 1.6 Docker image on alpine:3.10

### DIFF
--- a/docker/1.6/Dockerfile
+++ b/docker/1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 LABEL maintainer="Roger Light <roger@atchoo.org>" \
     description="Eclipse Mosquitto MQTT Broker"
@@ -13,7 +13,7 @@ RUN set -x && \
         build-base \
         cmake \
         gnupg \
-        libressl-dev \
+        openssl-dev \
         util-linux-dev && \
     wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
     mkdir -p /build/lws && \


### PR DESCRIPTION
From version 3.9+ alpine uses OpenSSL as default SSL library again. This allows to use RFC6066 MFLN (Maximum Fragment Length Negotiation) which makes it a lot easier for IoT devices with constrained resources to handle TLS.

- [N/A] If you are contributing a new feature, is your work based off the develop branch?
- [N/A] If you are contributing a bugfix, is your work based off the fixes branch?
- [Y] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you successfully run `make test` with your changes locally?
- [Y] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [Y] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
