### PR TITLE
fix: replace sleep with (p)select in loop_forever

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -78,20 +78,6 @@ static int mosquitto__connect_init(struct mosquitto *mosq, const char *host, int
 	mosq->msgs_in.inflight_quota = mosq->msgs_in.inflight_maximum;
 	mosq->msgs_out.inflight_quota = mosq->msgs_out.inflight_maximum;
 
-	if(mosq->sockpairR != INVALID_SOCKET){
-		COMPAT_CLOSE(mosq->sockpairR);
-		mosq->sockpairR = INVALID_SOCKET;
-	}
-	if(mosq->sockpairW != INVALID_SOCKET){
-		COMPAT_CLOSE(mosq->sockpairW);
-		mosq->sockpairW = INVALID_SOCKET;
-	}
-
-	if(net__socketpair(&mosq->sockpairR, &mosq->sockpairW)){
-		log__printf(mosq, MOSQ_LOG_WARNING,
-				"Warning: Unable to open socket pair, outgoing publish commands may be delayed.");
-	}
-
 	return MOSQ_ERR_SUCCESS;
 }
 

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -92,8 +92,10 @@ struct mosquitto *mosquitto_new(const char *id, bool clean_start, void *userdata
 	mosq = (struct mosquitto *)mosquitto__calloc(1, sizeof(struct mosquitto));
 	if(mosq){
 		mosq->sock = INVALID_SOCKET;
-		mosq->sockpairR = INVALID_SOCKET;
-		mosq->sockpairW = INVALID_SOCKET;
+		if(net__socketpair(&mosq->sockpairR, &mosq->sockpairW)){
+			log__printf(mosq, MOSQ_LOG_WARNING,
+					"Warning: Unable to open socket pair, outgoing publish commands may be delayed.");
+		}
 #ifdef WITH_THREADING
 		mosq->thread_id = pthread_self();
 #endif
@@ -131,8 +133,10 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_st
 	}
 	mosq->protocol = mosq_p_mqtt311;
 	mosq->sock = INVALID_SOCKET;
-	mosq->sockpairR = INVALID_SOCKET;
-	mosq->sockpairW = INVALID_SOCKET;
+	if(net__socketpair(&mosq->sockpairR, &mosq->sockpairW)){
+		log__printf(mosq, MOSQ_LOG_WARNING,
+				"Warning: Unable to open socket pair, outgoing publish commands may be delayed.");
+	}
 	mosq->keepalive = 60;
 	mosq->clean_start = clean_start;
 	if(id){

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -1079,6 +1079,9 @@ int net__socketpair(mosq_sock_t *pairR, mosq_sock_t *pairW)
 #else
 	int sv[2];
 
+	*pairR = INVALID_SOCKET;
+	*pairW = INVALID_SOCKET;
+
 	if(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1){
 		return MOSQ_ERR_ERRNO;
 	}


### PR DESCRIPTION
sleep was blocking loop_stop(force=false) since it
was uniteruptible

Signed-off-by: Christian Schneider <cschneider@radiodata.biz>

- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
 --> How?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----