### PR TITLE
Bugfix mem leak in handle unsubscribe

### DIFF
--- a/lib/socks_mosq.c
+++ b/lib/socks_mosq.c
@@ -185,6 +185,7 @@ int socks5__send(struct mosquitto *mosq)
 		}else{
 			slen = strlen(mosq->host);
 			if(slen > UCHAR_MAX){
+				mosquitto__free(packet);
 				return MOSQ_ERR_NOMEM;
 			}
 			packet->packet_length = 7 + slen;

--- a/src/handle_unsubscribe.c
+++ b/src/handle_unsubscribe.c
@@ -66,12 +66,6 @@ int handle__unsubscribe(struct mosquitto_db *db, struct mosquitto *context)
 		}
 	}
 
-	reason_code_max = 10;
-	reason_codes = mosquitto__malloc(reason_code_max);
-	if(!reason_codes){
-		return MOSQ_ERR_NOMEM;
-	}
-
 	while(context->in_packet.pos < context->in_packet.remaining_length){
 		sub = NULL;
 		if(packet__read_string(&context->in_packet, &sub, &slen)){
@@ -99,6 +93,12 @@ int handle__unsubscribe(struct mosquitto_db *db, struct mosquitto *context)
 		mosquitto__free(sub);
 		if(rc) return rc;
 
+		reason_code_max = 10;
+		reason_codes = mosquitto__malloc(reason_code_max);
+		if(!reason_codes){
+			return MOSQ_ERR_NOMEM;
+		}
+
 		reason_codes[reason_code_count] = reason;
 		reason_code_count++;
 		if(reason_code_count == reason_code_max){
@@ -122,4 +122,3 @@ int handle__unsubscribe(struct mosquitto_db *db, struct mosquitto *context)
 	mosquitto__free(reason_codes);
 	return rc;
 }
-


### PR DESCRIPTION
Memory leak in handle_unsubscribe.c

Reason: In line 70, the memory allocation for the pointer "reasons_codes" may 
result to a memory leak due to the many returns (e.g as the one in line 78)
occuring in the program's path until reaching the mosquitto__free at line 122.

Fix: I added a mosquitto__free(reason_codes) statement before each return
statement that could result to a memory leak.

Signed-off-by: Panagiotis Vasilikos panagiotis.vasilikos@alexandra.dk
