### PR TITLE
Update SSL_xxx() relalte operation.

### DIFF
--- a/lib/loop.c
+++ b/lib/loop.c
@@ -358,6 +358,13 @@ int mosquitto_loop_write(struct mosquitto *mosq, int max_packets)
 	int i;
 	if(max_packets < 1) return MOSQ_ERR_INVAL;
 
+#ifdef WITH_TLS
+	if(mosq->want_connect){
+		mosq->want_write = false;
+		return net__socket_connect_tls(mosq);
+	}
+#endif
+
 	pthread_mutex_lock(&mosq->msgs_out.mutex);
 	max_packets = mosq->msgs_out.queue_len;
 	pthread_mutex_unlock(&mosq->msgs_out.mutex);

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -56,10 +56,10 @@ Contributors:
 
 #include "mosquitto.h"
 #include "time_mosq.h"
+#ifdef __linux__
+#  include <netdb.h>
+#endif
 #ifdef WITH_BROKER
-#  ifdef __linux__
-#    include <netdb.h>
-#  endif
 #  include "uthash.h"
 struct mosquitto_client_msg;
 #endif


### PR DESCRIPTION
1. Update SSL_connect() SSL_read() SSL_write() error handle(according to openssl manual).

Per openssl manual: 
SSL_read() & SSL_write():
  SSL_shutdown must not called if SSL_get_error get SSL_ERROR_SYSCALL or SSL_ERROR_SSL.

SSL_connect():
  Only SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE from SSL_get_error means retry later, other error indicate fatal error and should not retry. 

2. Check connection state before SSL_connect() for non-blocking connecting(to avoid infinity readable or writable notify from external IO mutex detect).

non-blocking connect() will return EINPROGRESS or EWOULDBLOCK or EAGAIN, and connect result could be check when socket become writable. Add connect status check operation after socket if ready for write. If connection error got, we cleanup SSL and close socket, to avoid infinity writable/readable notification from external IO MUX module(e.g. libevent).

Signed-off-by: Michael Liu <michael.liu.point@gmail.com>

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
