### PR TITLE
mosquitto.service: mosquitto starts even if the network is offline

### DIFF
--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mosquitto MQTT v3.1/v3.1.1 Broker
 Documentation=man:mosquitto.conf(5) man:mosquitto(8)
-After=network-online.target
-Wants=network-online.target
+After=network.target
+Wants=network.target
 
 [Service]
 Type=notify

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mosquitto MQTT v3.1/v3.1.1 Broker
 Documentation=man:mosquitto.conf(5) man:mosquitto(8)
-After=network-online.target
-Wants=network-online.target
+After=network.target
+Wants=network.target
 
 [Service]
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf


### PR DESCRIPTION
This patch changes the behavior of how mosquitto is starting using
systemd.

Currently it is starting only when the network is online, meaning that the
network is configured to a routable IP address.

With this patch, mosquitto is starting when the network is offline, does
not need to be configured. This is needed because the MQTT broker might
be used as an internal message bus which does not need the network to be
online.

Signed-off-by: Stavros Vagionitis <stavros.vagionitis@jci.com>

- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
