### PR TITLE
Feature/add deny option for acl

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -107,14 +107,16 @@
 						listed will have access. Topic access is added with
 						lines of the format:</para>
 
-					<para><code>topic [read|write|readwrite] &lt;topic&gt;</code></para>
+					<para><code>topic [read|write|readwrite|deny] &lt;topic&gt;</code></para>
 
-					<para>The access type is controlled using "read", "write" or
-						"readwrite". This parameter is optional (unless
+					<para>The access type is controlled using "read", "write",
+						"readwrite" or "deny". This parameter is optional (unless
 						&lt;topic&gt; includes a space character) - if not
 						given then the access is read/write.  &lt;topic&gt; can
 						contain the + or # wildcards as in
-						subscriptions.</para>
+						subscriptions. The "deny" option can used to explicity
+						deny access to a topic that would otherwise be granted
+						by a broader read/write/readwrite statement.</para>
 
 					<para>The first set of topics are applied to anonymous
 						clients, assuming <option>allow_anonymous</option> is
@@ -131,7 +133,7 @@
 						substitution within the topic. The form is the same as
 						for the topic keyword, but using pattern as the
 						keyword.</para>
-					<para><code>pattern [read|write|readwrite] &lt;topic&gt;</code></para>
+					<para><code>pattern [read|write|readwrite|deny] &lt;topic&gt;</code></para>
 
 					<para>The patterns available for substition are:</para>
 					<itemizedlist mark="circle">

--- a/test/broker/09-acl-access-variants.py
+++ b/test/broker/09-acl-access-variants.py
@@ -13,12 +13,15 @@ def write_config(filename, port, per_listener):
 def write_acl(filename, global_en, user_en, pattern_en):
     with open(filename, 'w') as f:
         if global_en:
-            f.write('topic readwrite topic/global\n')
+            f.write('topic readwrite topic/global/#\n')
+            f.write('topic deny      topic/global/except\n')
         if user_en:
             f.write('user username\n')
-            f.write('topic readwrite topic/username\n')
+            f.write('topic readwrite topic/username/#\n')
+            f.write('topic deny      topic/username/except\n')
         if pattern_en:
-            f.write('pattern readwrite pattern/%u\n')
+            f.write('pattern readwrite pattern/%u/#\n')
+            f.write('pattern deny      pattern/%u/except\n')
 
 
 
@@ -73,12 +76,15 @@ def acl_test(port, per_listener, global_en, user_en, pattern_en):
     if global_en:
         single_test(port, per_listener, username=None,       topic="topic/global", expect_deny=False)
         single_test(port, per_listener, username="username", topic="topic/global", expect_deny=True)
+        single_test(port, per_listener, username=None,       topic="topic/global/except", expect_deny=True)
     if user_en:
         single_test(port, per_listener, username=None,       topic="topic/username", expect_deny=True)
         single_test(port, per_listener, username="username", topic="topic/username", expect_deny=False)
+        single_test(port, per_listener, username="username", topic="topic/username/except", expect_deny=True)
     if pattern_en:
         single_test(port, per_listener, username=None,       topic="pattern/username", expect_deny=True)
         single_test(port, per_listener, username="username", topic="pattern/username", expect_deny=False)
+        single_test(port, per_listener, username="username", topic="pattern/username/except", expect_deny=True)
 
 def do_test(port, per_listener):
     try:


### PR DESCRIPTION
This features adds an option to the acl_file to allow a user to be explicitly denied access to a topic that might otherwise be granted from a broader topic. 
For example in an acl file:
```
user bob
topic readwrite api/#
topic deny api/sensitive/#
```
The user `bob` would be granted read/write access to all topics matching `api/#` with the exception of topics matching `api/sensitive/#`.
This allows us to configure mosquitto (no extra plugins) more easily without the need for extensive whitelists like this:
```
user bob
topic readwrite api/fun/#
topic readwrite api/stuff/#
topic readwrite api/hello/#
topic readwrite api/so/#
topic readwrite api/many/#
topic readwrite api/topics/#
...
```

Because tests aren't passing on `develop` branch currently, I also made these changes off `master` to test.

I hope the purpose of these changes was made clear.

Brandt

---
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
-----
