### PR TITLE
Change systemd dependency to network.target

### DIFF
--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mosquitto MQTT v3.1/v3.1.1 Broker
 Documentation=man:mosquitto.conf(5) man:mosquitto(8)
-After=network-online.target
-Wants=network-online.target
+After=network.target
+Wants=network.target
 
 [Service]
 Type=notify

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mosquitto MQTT v3.1/v3.1.1 Broker
 Documentation=man:mosquitto.conf(5) man:mosquitto(8)
-After=network-online.target
-Wants=network-online.target
+After=network.target
+Wants=network.target
 
 [Service]
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf


### PR DESCRIPTION
According to systemd "Running Services After the Network is up"
documentation [1], "network-online.target should not be pulled in
too liberally". Mosquitto can work perfectly well in local context
before network being online, hence network.target should be more
appropriate than network-online.target.

[1] https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

---
In our use case the network cable may even be unplugged and mosquitto
is used locally.

- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.

-----
