### PR TITLE
1.deal with pubrel, ignore the ret of msg remove, 2.delete the same m…

### DIFF
--- a/lib/handle_pubrel.c
+++ b/lib/handle_pubrel.c
@@ -102,7 +102,8 @@ int handle__pubrel(struct mosquitto_db *db, struct mosquitto *mosq)
 
 	rc = message__remove(mosq, mid, mosq_md_in, &message, 2);
 	if(rc){
-		return rc;
+		// return rc;
+		/* Apparently this is "normal" behaviour, so we don't need to issue a warning */
 	}else{
 		/* Only pass the message on if we have removed it from the queue - this
 		 * prevents multiple callbacks for the same message. */


### PR DESCRIPTION
- in function handle__pubrel(), ingore the return value of message__remove() . when deal with the   pubrel, received unexpected rel is apparently normal behaviour, if returned the rc, the loop may exit.
- in function message__queue(), add the check for same mid. if found the same mid, delete it. in some test scenarios, the server may reset, but client not reset , it may keep the older message, and the the next time connect to the server, it will received the same mid message.and then when get message from the queue, it will get unexpected message.


- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?


-----
