### PR TITLE
correct mosquitto.h return code documentation

### DIFF
--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -202,7 +202,8 @@ libmosq_EXPORT int mosquitto_lib_version(int *major, int *minor, int *revision);
  * This function is *not* thread safe.
  *
  * Returns:
- * 	MOSQ_ERR_SUCCESS - always
+ * 	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_UNKNOWN - on Windows, if sockets couldn't be initialized.
  *
  * See Also:
  * 	<mosquitto_lib_cleanup>, <mosquitto_lib_version>


### PR DESCRIPTION
We currently erroneously claim that mosquitto_lib_init cannot fail,
while it can fail on Windows, if WSAStartup fails in net__init. Correct
this.

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
"make test" is failing on my machine, but it fails identically on the fixes branch (on `./02-subscribe-qos1.py`). As this changes only documentation, I highly doubt that's the issue.
Test failure:
```
./02-subscribe-qos1.py c/02-subscribe-qos1-async2.test
connect_async failed: Connection refused
Traceback (most recent call last):
  File "./02-subscribe-qos1.py", line 47, in <module>
    (conn, address) = sock.accept()
  File "/usr/lib/python3.8/socket.py", line 292, in accept
    fd, addr = self._accept()
socket.timeout: timed out
make[2]: *** [Makefile:36: c] Error 1
make[2]: Leaving directory '/home/martin/ws/mosquitto/test/lib'
make[1]: *** [Makefile:11: test] Error 2
make[1]: Leaving directory '/home/martin/ws/mosquitto/test'
make: *** [Makefile:75: test] Error 2
```

-----
