### PR TITLE
lazy init SSL for libmosquitto

### DIFF
--- a/lib/net_mosq.h
+++ b/lib/net_mosq.h
@@ -55,6 +55,10 @@ struct mosquitto_db;
 int net__init(void);
 void net__cleanup(void);
 
+#ifdef WITH_TLS
+void net__init_tls(void);
+#endif
+
 int net__socket_connect(struct mosquitto *mosq, const char *host, uint16_t port, const char *bind_address, bool blocking);
 #ifdef WITH_BROKER
 int net__socket_close(struct mosquitto_db *db, struct mosquitto *mosq);

--- a/src/net.c
+++ b/src/net.c
@@ -72,6 +72,9 @@ void net__broker_init(void)
 {
 	spare_sock = socket(AF_INET, SOCK_STREAM, 0);
 	net__init();
+#ifdef WITH_TLS
+	net__init_tls();
+#endif
 }
 
 


### PR DESCRIPTION
Signed-off-by: Abilio Marques <abiliojr@gmail.com>

Currently, when using a WITH_TLS compiled version of the mosquitto library, it will automatically initialize openssl as mosquitto_lib_init gets called. This causes > 120 Kb of RAM to be allocated, even if not needed (e.g., connecting to local broker, via TCP or UNIX sockets).

This patch allows for SSL to be initialized when it's needed. Broker functionality remains unchanged.

-------------------------------------------------------------------------------------------------------------

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
