### PR TITLE
remove cjson stranded reference when building WITH_CJSON=no

### DIFF
--- a/client/sub_client_output.c
+++ b/client/sub_client_output.c
@@ -313,7 +313,6 @@ static int json_print(const struct mosquitto_message *message, const mosquitto_p
 	snprintf(&buf[strlen("2020-05-06T21:48:00.")], 9, "%06d", ns/1000);
 	buf[strlen("2020-05-06T21:48:00.000000")] = 'Z';
 
-	tmp = cJSON_CreateStringReference(buf);
 	printf("{\"tst\":\"%s\",\"topic\":\"%s\",\"qos\":%d,\"retain\":%d,\"payloadlen\":%d,", buf, message->topic, message->qos, message->retain, message->payloadlen);
 	if(message->qos > 0){
 		printf("\"mid\":%d,", message->mid);


### PR DESCRIPTION
Changes made a couple of weeks ago broke WITH_CJSON=no builds. This patch fixes that issue on develop (the fixes branch is out of sync with develop, at least for this file).

 The fixes branch seems to be out of sync, so I created the pull request to develop. Please advice if rework is needed, and how to proceed.

-----

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?
