### PR TITLE
replace unavailable ssl libs in the generic dockerfile with openssl

### DIFF
--- a/docker/generic/Dockerfile
+++ b/docker/generic/Dockerfile
@@ -6,7 +6,7 @@ RUN test -n "${VERSION}"
 
 RUN apk --no-cache add \
       build-base \
-      libressl-dev \
+      openssl-dev \
       c-ares-dev \
       curl \
       util-linux-dev \
@@ -48,8 +48,7 @@ LABEL maintainer="Jonathan Hanson <jonathan@jonathan-hanson.org>" \
 RUN apk --no-cache add \
       busybox \
       ca-certificates \
-      libcrypto1.0 \
-      libssl1.0 \
+      openssl \
       libuuid \
       libwebsockets \
       musl


### PR DESCRIPTION
Signed-off-by: matt <swineherd92@gmail.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ y] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ y] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ na] If you are contributing a new feature, is your work based off the develop branch?
- [ y] If you are contributing a bugfix, is your work based off the fixes branch?
- [ y] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ y] Have you successfully run `make test` with your changes locally?

-----
issue #1711 
