### PR TITLE
Feature: Add support for publishing multiple buffers concatenated together

### DIFF
--- a/lib/cpp/mosquittopp.cpp
+++ b/lib/cpp/mosquittopp.cpp
@@ -272,6 +272,11 @@ int mosquittopp::publish(int *mid, const char *topic, int payloadlen, const void
 	return mosquitto_publish(m_mosq, mid, topic, payloadlen, payload, qos, retain);
 }
 
+int mosquittopp::publish_bufs(int *mid, const char *topic, const struct buf *buffers, int buffers_cnt, int qos, bool retain)
+{
+	return mosquitto_publish_bufs(m_mosq, mid, topic, buffers, buffers_cnt, qos, retain);
+}
+
 void mosquittopp::reconnect_delay_set(unsigned int reconnect_delay, unsigned int reconnect_delay_max, bool reconnect_exponential_backoff)
 {
 	mosquitto_reconnect_delay_set(m_mosq, reconnect_delay, reconnect_delay_max, reconnect_exponential_backoff);

--- a/lib/cpp/mosquittopp.h
+++ b/lib/cpp/mosquittopp.h
@@ -107,6 +107,7 @@ class mosqpp_EXPORT DEPRECATED mosquittopp {
 		int DEPRECATED reconnect_async();
 		int DEPRECATED disconnect();
 		int DEPRECATED publish(int *mid, const char *topic, int payloadlen=0, const void *payload=NULL, int qos=0, bool retain=false);
+		int DEPRECATED publish_bufs(int *mid, const char *topic, const struct buf *buffers=NULL, int buffers_cnt=0, int qos=0, bool retain=false);
 		int DEPRECATED subscribe(int *mid, const char *sub, int qos=0);
 		int DEPRECATED unsubscribe(int *mid, const char *sub);
 		void DEPRECATED reconnect_delay_set(unsigned int reconnect_delay, unsigned int reconnect_delay_max, bool reconnect_exponential_backoff);

--- a/lib/mosquitto.h
+++ b/lib/mosquitto.h
@@ -134,6 +134,10 @@ struct mosquitto_message{
 };
 
 struct mosquitto;
+struct buf {
+    const void *base;
+    uint32_t len;
+};
 typedef struct mqtt5__property mosquitto_property;
 
 /*
@@ -813,6 +817,99 @@ libmosq_EXPORT int mosquitto_publish_v5(
 		bool retain,
 		const mosquitto_property *properties);
 
+/*
+ * Function: mosquitto_publish_bufs
+ *
+ * Publish a message on a given topic.
+ *
+ * Parameters:
+ * 	mosq -       a valid mosquitto instance.
+ * 	mid -        pointer to an int. If not NULL, the function will set this
+ *               to the message id of this particular message. This can be then
+ *               used with the publish callback to determine when the message
+ *               has been sent.
+ *               Note that although the MQTT protocol doesn't use message ids
+ *               for messages with QoS=0, libmosquitto assigns them message ids
+ *               so they can be tracked with this parameter.
+ *  topic -      null terminated string of the topic to publish to.
+ *  buffers -    an array of buf instances, where each instance consists of a 
+ *               pointer to the data and the length of the data (in bytes). 
+ *               Sum of lengths should be between 0 to 268,435,455.
+ *  buffers_cnt -number of buffers to send. Should be >= 0.
+ * 	qos -        integer value 0, 1 or 2 indicating the Quality of Service to be
+ *               used for the message.  only 0 is supported.
+ * 	retain -     set to true to make the message retained.
+ *
+ * Returns:
+ * 	MOSQ_ERR_SUCCESS -      on success.
+ * 	MOSQ_ERR_INVAL -        if the input parameters were invalid.
+ * 	MOSQ_ERR_NOMEM -        if an out of memory condition occurred.
+ * 	MOSQ_ERR_NO_CONN -      if the client isn't connected to a broker.
+ *	MOSQ_ERR_PROTOCOL -     if there is a protocol error communicating with the
+ *                          broker.
+ * 	MOSQ_ERR_PAYLOAD_SIZE - if payloadlen is too large.
+ *
+ * See Also:
+ *	<mosquitto_max_inflight_messages_set>
+ */
+libmosq_EXPORT int mosquitto_publish_bufs(struct mosquitto *mosq, int *mid, const char *topic, const struct buf *buffers, int buffers_cnt, int qos, bool retain);
+
+/*
+ * Function: mosquitto_publish_bufs_v5
+ *
+ * Publish a message on a given topic, with attached MQTT properties.
+ *
+ * Use e.g. <mosquitto_property_add_string> and similar to create a list of
+ * properties, then attach them to this publish. Properties need freeing with
+ * <mosquitto_property_free_all>.
+ *
+ * Requires the mosquitto instance to be connected with MQTT 5.
+ *
+ * Parameters:
+ * 	mosq -       a valid mosquitto instance.
+ * 	mid -        pointer to an int. If not NULL, the function will set this
+ *               to the message id of this particular message. This can be then
+ *               used with the publish callback to determine when the message
+ *               has been sent.
+ *               Note that although the MQTT protocol doesn't use message ids
+ *               for messages with QoS=0, libmosquitto assigns them message ids
+ *               so they can be tracked with this parameter.
+ *  topic -      null terminated string of the topic to publish to.
+ *               268,435,455.
+ *  buffers -    an array of buf instances, where each instance consists of a 
+ *               pointer to the data and the length of the data (in bytes). 
+ *               Sum of lengths should be between 0 to 268,435,455.
+ *  buffers_cnt -number of buffers to send. Should be >= 0.
+ * 	qos -        integer value 0, 1 or 2 indicating the Quality of Service to be
+ *               used for the message.
+ * 	retain -     set to true to make the message retained.
+ * 	properties - a valid mosquitto_property list, or NULL.
+ *
+ * Returns:
+ * 	MOSQ_ERR_SUCCESS -        on success.
+ * 	MOSQ_ERR_INVAL -          if the input parameters were invalid.
+ * 	MOSQ_ERR_NOMEM -          if an out of memory condition occurred.
+ * 	MOSQ_ERR_NO_CONN -        if the client isn't connected to a broker.
+ *	MOSQ_ERR_PROTOCOL -       if there is a protocol error communicating with the
+ *                            broker.
+ * 	MOSQ_ERR_PAYLOAD_SIZE -   if payloadlen is too large.
+ * 	MOSQ_ERR_MALFORMED_UTF8 - if the topic is not valid UTF-8
+ *	MOSQ_ERR_DUPLICATE_PROPERTY - if a property is duplicated where it is forbidden.
+ *	MOSQ_ERR_PROTOCOL - if any property is invalid for use with PUBLISH.
+ *	MOSQ_ERR_QOS_NOT_SUPPORTED - if the QoS is greater than that supported by
+ *	                             the broker.
+ *	MOSQ_ERR_OVERSIZE_PACKET - if the resulting packet would be larger than
+ *	                           supported by the broker.
+ */
+libmosq_EXPORT int mosquitto_publish_bufs_v5(
+		struct mosquitto *mosq,
+		int *mid,
+		const char *topic,
+		const struct buf *buffers,
+        int buffers_cnt,
+		int qos,
+		bool retain,
+		const mosquitto_property *properties);
 
 /*
  * Function: mosquitto_subscribe

--- a/lib/packet_datatypes.c
+++ b/lib/packet_datatypes.c
@@ -87,6 +87,13 @@ void packet__write_bytes(struct mosquitto__packet *packet, const void *bytes, ui
 	packet->pos += count;
 }
 
+void packet__write_buffers(struct mosquitto__packet *packet, const struct buf *buffers, int buffers_cnt)
+{
+  int i;
+  for(i=0; i<buffers_cnt; i++){
+    packet__write_bytes(packet, buffers[i].base, buffers[i].len);
+  }
+}
 
 int packet__read_binary(struct mosquitto__packet *packet, uint8_t **data, int *length)
 {

--- a/lib/packet_mosq.h
+++ b/lib/packet_mosq.h
@@ -38,6 +38,7 @@ int packet__read_uint16(struct mosquitto__packet *packet, uint16_t *word);
 int packet__read_uint32(struct mosquitto__packet *packet, uint32_t *word);
 int packet__read_varint(struct mosquitto__packet *packet, int32_t *word, int8_t *bytes);
 
+void packet__write_buffers(struct mosquitto__packet *packet, const struct buf *buffers, int buffers_cnt);
 void packet__write_byte(struct mosquitto__packet *packet, uint8_t byte);
 void packet__write_bytes(struct mosquitto__packet *packet, const void *bytes, uint32_t count);
 void packet__write_string(struct mosquitto__packet *packet, const char *str, uint16_t length);

--- a/lib/send_mosq.h
+++ b/lib/send_mosq.h
@@ -22,6 +22,7 @@ Contributors:
 int send__simple_command(struct mosquitto *mosq, uint8_t command);
 int send__command_with_mid(struct mosquitto *mosq, uint8_t command, uint16_t mid, bool dup, uint8_t reason_code, const mosquitto_property *properties);
 int send__real_publish(struct mosquitto *mosq, uint16_t mid, const char *topic, uint32_t payloadlen, const void *payload, int qos, bool retain, bool dup, const mosquitto_property *cmsg_props, const mosquitto_property *store_props, uint32_t expiry_interval);
+int send__real_publish_bufs(struct mosquitto *mosq, uint16_t mid, const char *topic, uint32_t payloadlen, const struct buf *buffers, int buffers_cnt, int qos, bool retain, bool dup, const mosquitto_property *cmsg_props, const mosquitto_property *store_props, uint32_t expiry_interval);
 
 int send__connect(struct mosquitto *mosq, uint16_t keepalive, bool clean_session, const mosquitto_property *properties);
 int send__disconnect(struct mosquitto *mosq, uint8_t reason_code, const mosquitto_property *properties);
@@ -30,6 +31,7 @@ int send__pingresp(struct mosquitto *mosq);
 int send__puback(struct mosquitto *mosq, uint16_t mid, uint8_t reason_code);
 int send__pubcomp(struct mosquitto *mosq, uint16_t mid);
 int send__publish(struct mosquitto *mosq, uint16_t mid, const char *topic, uint32_t payloadlen, const void *payload, int qos, bool retain, bool dup, const mosquitto_property *cmsg_props, const mosquitto_property *store_props, uint32_t expiry_interval);
+int send__publish_bufs(struct mosquitto *mosq, uint16_t mid, const char *topic, uint32_t payloadlen, const struct buf *buffers, int buffers_cnt, int qos, bool retain, bool dup, const mosquitto_property *cmsg_props, const mosquitto_property *store_props, uint32_t expiry_interval);
 int send__pubrec(struct mosquitto *mosq, uint16_t mid, uint8_t reason_code);
 int send__pubrel(struct mosquitto *mosq, uint16_t mid);
 int send__subscribe(struct mosquitto *mosq, int *mid, int topic_count, char *const *const topic, int topic_qos, const mosquitto_property *properties);

--- a/test/lib/03-publish_bufs-c2b-qos1-disconnect.py
+++ b/test/lib/03-publish_bufs-c2b-qos1-disconnect.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# Test whether a client sends a correct PUBLISH_BUFS to a topic with QoS 1, then responds correctly to a disconnect.
+
+from mosq_test_helper import *
+
+port = mosq_test.get_lib_port()
+
+rc = 1
+keepalive = 60
+connect_packet = mosq_test.gen_connect("publish_bufs-qos1-test", keepalive=keepalive)
+connack_packet = mosq_test.gen_connack(rc=0)
+
+disconnect_packet = mosq_test.gen_disconnect()
+
+mid = 1
+publish_packet = mosq_test.gen_publish("pub/qos1/test", qos=1, mid=mid, payload="message1msg2")
+publish_packet_dup = mosq_test.gen_publish("pub/qos1/test", qos=1, mid=mid, payload="message1msg2", dup=True)
+puback_packet = mosq_test.gen_puback(mid)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.settimeout(10)
+sock.bind(('', port))
+sock.listen(5)
+
+client_args = sys.argv[1:]
+env = dict(os.environ)
+env['LD_LIBRARY_PATH'] = '../../lib:../../lib/cpp'
+try:
+    pp = env['PYTHONPATH']
+except KeyError:
+    pp = ''
+env['PYTHONPATH'] = '../../lib/python:'+pp
+
+client = mosq_test.start_client(filename=sys.argv[1].replace('/', '-'), cmd=client_args, env=env, port=port)
+
+try:
+    (conn, address) = sock.accept()
+    conn.settimeout(15)
+
+    if mosq_test.expect_packet(conn, "connect", connect_packet):
+        conn.send(connack_packet)
+
+        if mosq_test.expect_packet(conn, "publish", publish_packet):
+            # Disconnect client. It should reconnect.
+            conn.close()
+
+            (conn, address) = sock.accept()
+            conn.settimeout(15)
+
+            if mosq_test.expect_packet(conn, "connect", connect_packet):
+                conn.send(connack_packet)
+
+                if mosq_test.expect_packet(conn, "retried publish", publish_packet_dup):
+                    conn.send(puback_packet)
+
+                    if mosq_test.expect_packet(conn, "disconnect", disconnect_packet):
+                        rc = 0
+
+    conn.close()
+finally:
+    client.terminate()
+    client.wait()
+    sock.close()
+
+exit(rc)

--- a/test/lib/03-publish_bufs-qos0-no-payload.py
+++ b/test/lib/03-publish_bufs-qos0-no-payload.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Test whether a client sends a correct PUBLISH_BUFS to a topic with QoS 0 and no payload.
+
+# The client should connect to port 1888 with keepalive=60, clean session set,
+# and client id publish_bufs-qos0-test-np
+# The test will send a CONNACK message to the client with rc=0. Upon receiving
+# the CONNACK and verifying that rc=0, the client should send a PUBLISH_BUFS message
+# to topic "pub/qos0/no-payload/test" with zero length payload and QoS=0. If
+# rc!=0, the client should exit with an error.
+# After sending the PUBLISH_BUFS message, the client should send a DISCONNECT message.
+
+from mosq_test_helper import *
+
+port = mosq_test.get_lib_port()
+
+rc = 1
+keepalive = 60
+connect_packet = mosq_test.gen_connect("publish_bufs-qos0-test-np", keepalive=keepalive)
+connack_packet = mosq_test.gen_connack(rc=0)
+
+publish_packet = mosq_test.gen_publish("pub/qos0/no-payload/test", qos=0)
+
+disconnect_packet = mosq_test.gen_disconnect()
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.settimeout(10)
+sock.bind(('', port))
+sock.listen(5)
+
+client_args = sys.argv[1:]
+env = dict(os.environ)
+env['LD_LIBRARY_PATH'] = '../../lib:../../lib/cpp'
+try:
+    pp = env['PYTHONPATH']
+except KeyError:
+    pp = ''
+env['PYTHONPATH'] = '../../lib/python:'+pp
+client = mosq_test.start_client(filename=sys.argv[1].replace('/', '-'), cmd=client_args, env=env, port=port)
+
+try:
+    (conn, address) = sock.accept()
+    conn.settimeout(10)
+
+    if mosq_test.expect_packet(conn, "connect", connect_packet):
+        conn.send(connack_packet)
+
+        if mosq_test.expect_packet(conn, "publish", publish_packet):
+            if mosq_test.expect_packet(conn, "disconnect", disconnect_packet):
+                rc = 0
+
+    conn.close()
+finally:
+    client.terminate()
+    client.wait()
+    sock.close()
+
+exit(rc)

--- a/test/lib/03-publish_bufs-qos0.py
+++ b/test/lib/03-publish_bufs-qos0.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Test whether a client sends a correct PUBLISH_BUFS to a topic with QoS 0.
+
+# The client should connect to port 1888 with keepalive=60, clean session set,
+# and client id publish_bufs-qos0-test 
+# The test will send a CONNACK message to the client with rc=0. Upon receiving
+# the CONNACK and verifying that rc=0, the client should send a PUBLISV message
+# to topic "pub/qos0/test" with a vector {"message1", "msg2", "last_message" and QoS=0. 
+# If rc!=0, the client should exit with an error.
+# After sending the PUBLISH_BUFS message, the client should send a DISCONNECT message.
+
+from mosq_test_helper import *
+
+port = mosq_test.get_lib_port()
+
+rc = 1
+keepalive = 60
+connect_packet = mosq_test.gen_connect("publish_bufs-qos0-test", keepalive=keepalive)
+connack_packet = mosq_test.gen_connack(rc=0)
+
+publish_packet = mosq_test.gen_publish("pub/qos0/test", qos=0, payload="message1msg2last_message");
+
+disconnect_packet = mosq_test.gen_disconnect()
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.settimeout(10)
+sock.bind(('', port))
+sock.listen(5)
+
+client_args = sys.argv[1:]
+env = dict(os.environ)
+env['LD_LIBRARY_PATH'] = '../../lib:../../lib/cpp'
+try:
+    pp = env['PYTHONPATH']
+except KeyError:
+    pp = ''
+env['PYTHONPATH'] = '../../lib/python:'+pp
+client = mosq_test.start_client(filename=sys.argv[1].replace('/', '-'), cmd=client_args, env=env, port=port)
+
+try:
+    (conn, address) = sock.accept()
+    conn.settimeout(10)
+
+    if mosq_test.expect_packet(conn, "connect", connect_packet):
+        conn.send(connack_packet)
+
+        if mosq_test.expect_packet(conn, "publish", publish_packet):
+            if mosq_test.expect_packet(conn, "disconnect", disconnect_packet):
+                rc = 0
+
+    conn.close()
+finally:
+    client.terminate()
+    client.wait()
+    if rc:
+        (stdo, stde) = client.communicate()
+        print(stde)
+    sock.close()
+
+exit(rc)

--- a/test/lib/Makefile
+++ b/test/lib/Makefile
@@ -54,6 +54,9 @@ c : test-compile
 	./03-publish-c2b-qos2.py $@/03-publish-c2b-qos2.test
 	./03-publish-qos0-no-payload.py $@/03-publish-qos0-no-payload.test
 	./03-publish-qos0.py $@/03-publish-qos0.test
+	./03-publish_bufs-c2b-qos1-disconnect.py $@/03-publish_bufs-c2b-qos1-disconnect.test
+	./03-publish_bufs-qos0-no-payload.py $@/03-publish_bufs-qos0-no-payload.test
+	./03-publish_bufs-qos0.py $@/03-publish_bufs-qos0.test
 	./03-request-response-correlation.py $@/03-request-response-correlation.test
 	./03-request-response.py $@/03-request-response.test
 	./04-retain-qos0.py $@/04-retain-qos0.test

--- a/test/lib/c/03-publish_bufs-c2b-qos1-disconnect.c
+++ b/test/lib/c/03-publish_bufs-c2b-qos1-disconnect.c
@@ -1,0 +1,63 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mosquitto.h>
+
+static int run = -1;
+static int first_connection = 1;
+
+void on_connect(struct mosquitto *mosq, void *obj, int rc)
+{
+	if(rc){
+		exit(1);
+	}else{
+		if(first_connection == 1){
+            const struct buf buffers[] = {
+                {"message1", (uint32_t) strlen("message1")},
+                {"msg2", (uint32_t) strlen("msg2")}
+            };
+			mosquitto_publish_bufs(mosq, NULL, "pub/qos1/test", buffers, 2, 1, false);
+			first_connection = 0;
+		}
+	}
+}
+
+void on_publish(struct mosquitto *mosq, void *obj, int mid)
+{
+	mosquitto_disconnect(mosq);
+}
+
+void on_disconnect(struct mosquitto *mosq, void *obj, int rc)
+{
+	if(rc){
+		mosquitto_reconnect(mosq);
+	}else{
+		run = 0;
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct mosquitto *mosq;
+
+	int port = atoi(argv[1]);
+
+	mosquitto_lib_init();
+
+	mosq = mosquitto_new("publish_bufs-qos1-test", true, NULL);
+	mosquitto_connect_callback_set(mosq, on_connect);
+	mosquitto_disconnect_callback_set(mosq, on_disconnect);
+	mosquitto_publish_callback_set(mosq, on_publish);
+	mosquitto_message_retry_set(mosq, 3);
+
+	rc = mosquitto_connect(mosq, "localhost", port, 60);
+
+	while(run == -1){
+		mosquitto_loop(mosq, 300, 1);
+	}
+
+	mosquitto_lib_cleanup();
+	return run;
+}

--- a/test/lib/c/03-publish_bufs-qos0-no-payload.c
+++ b/test/lib/c/03-publish_bufs-qos0-no-payload.c
@@ -1,0 +1,58 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mosquitto.h>
+
+static int run = -1;
+static int sent_mid = -1;
+
+void on_connect(struct mosquitto *mosq, void *obj, int rc)
+{
+	if(rc){
+		exit(1);
+	}else{
+		mosquitto_publish_bufs(mosq, &sent_mid, "pub/qos0/no-payload/test", NULL, 0, 0, false);
+		//Caution, this throws error: mosquitto_publish_bufs(mosq, &sent_mid, "pub/qos0/no-payload/test", NULL, 1, 0, false);
+        /* Note: This also publishes a packet with no-payload
+        const struct buf dummy[] = {
+            {NULL, 0},
+            {NULL, 0}
+        };
+		mosquitto_publish_bufs(mosq, &sent_mid, "pub/qos0/no-payload/test", dummy, 2, 0, false);
+        */
+	}
+}
+
+void on_publish(struct mosquitto *mosq, void *obj, int mid)
+{
+	if(mid == sent_mid){
+        mosquitto_disconnect(mosq);
+        run = 0;
+	}else{
+		exit(1);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct mosquitto *mosq;
+
+	int port = atoi(argv[1]);
+
+	mosquitto_lib_init();
+
+	mosq = mosquitto_new("publish_bufs-qos0-test-np", true, NULL);
+	mosquitto_connect_callback_set(mosq, on_connect);
+	mosquitto_publish_callback_set(mosq, on_publish);
+
+	rc = mosquitto_connect(mosq, "localhost", port, 60);
+
+	while(run == -1){
+		mosquitto_loop(mosq, -1, 1);
+	}
+
+	mosquitto_lib_cleanup();
+	return run;
+}

--- a/test/lib/c/03-publish_bufs-qos0.c
+++ b/test/lib/c/03-publish_bufs-qos0.c
@@ -1,0 +1,56 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mosquitto.h>
+
+static int run = -1;
+static int sent_mid = -1;
+
+void on_connect(struct mosquitto *mosq, void *obj, int rc)
+{
+	if(rc){
+		exit(1);
+	}else{
+        const struct buf buffers[] = {
+            {"message1", (uint32_t) strlen("message1")},
+            {"msg2", (uint32_t) strlen("msg2")},
+            {"last_message", (uint32_t) strlen("last_message")},
+        };
+		mosquitto_publish_bufs(mosq, &sent_mid, "pub/qos0/test", buffers, 3, 0, false);
+	}
+}
+
+void on_publish(struct mosquitto *mosq, void *obj, int mid)
+{
+	if(mid == sent_mid){
+		mosquitto_disconnect(mosq);
+		run = 0;
+	}else{
+		exit(1);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	int rc;
+	struct mosquitto *mosq;
+
+	int port = atoi(argv[1]);
+
+	mosquitto_lib_init();
+
+	mosq = mosquitto_new("publish_bufs-qos0-test", true, NULL);
+	mosquitto_connect_callback_set(mosq, on_connect);
+	mosquitto_publish_callback_set(mosq, on_publish);
+
+	rc = mosquitto_connect(mosq, "localhost", port, 60);
+
+	while(run == -1){
+		rc = mosquitto_loop(mosq, -1, 1);
+	}
+
+	mosquitto_destroy(mosq);
+	mosquitto_lib_cleanup();
+	return run;
+}

--- a/test/lib/c/Makefile
+++ b/test/lib/c/Makefile
@@ -35,6 +35,9 @@ SRC = \
 	03-publish-c2b-qos2-maximum-qos-1.c \
 	03-publish-b2c-qos1.c \
 	03-publish-b2c-qos2.c \
+	03-publish_bufs-c2b-qos1-disconnect.c \
+	03-publish_bufs-qos0-no-payload.c \
+	03-publish_bufs-qos0.c \
 	03-request-response-1.c \
 	03-request-response-2.c \
 	03-request-response-correlation-1.c \

--- a/test/lib/cpp/03-publish_bufs-c2b-qos1-disconnect.cpp
+++ b/test/lib/cpp/03-publish_bufs-c2b-qos1-disconnect.cpp
@@ -1,0 +1,75 @@
+#include <cstdlib>
+#include <cstring>
+
+#include <mosquittopp.h>
+
+static int run = -1;
+static int first_connection = 1;
+
+class mosquittopp_test : public mosqpp::mosquittopp
+{
+	public:
+		mosquittopp_test(const char *id);
+
+		void on_connect(int rc);
+		void on_disconnect(int rc);
+		void on_publish(int mid);
+};
+
+mosquittopp_test::mosquittopp_test(const char *id) : mosqpp::mosquittopp(id)
+{
+}
+
+void mosquittopp_test::on_connect(int rc)
+{
+	if(rc){
+		exit(1);
+	}else{
+		if(first_connection == 1){
+            const struct buf buffers[] = {
+                {"message1", (uint32_t) strlen("message1")},
+                {"msg2", (uint32_t) strlen("msg2")}
+            };
+			publish_bufs(NULL, "pub/qos1/test", buffers, 2, 1, false);
+			first_connection = 0;
+		}
+	}
+}
+
+void mosquittopp_test::on_disconnect(int rc)
+{
+	if(rc){
+		reconnect();
+	}else{
+		run = 0;
+	}
+}
+
+void mosquittopp_test::on_publish(int mid)
+{
+	disconnect();
+}
+
+int main(int argc, char *argv[])
+{
+	struct mosquittopp_test *mosq;
+
+	int port = atoi(argv[1]);
+
+	mosqpp::lib_init();
+
+	mosq = new mosquittopp_test("publish_bufs-qos1-test");
+	mosq->message_retry_set(3);
+
+	mosq->connect("localhost", port, 60);
+
+	while(run == -1){
+		mosq->loop();
+	}
+
+	delete mosq;
+	mosqpp::lib_cleanup();
+
+	return run;
+}
+

--- a/test/lib/cpp/03-publish_bufs-qos0-no-payload.cpp
+++ b/test/lib/cpp/03-publish_bufs-qos0-no-payload.cpp
@@ -1,0 +1,59 @@
+#include <cstring>
+
+#include <mosquittopp.h>
+
+static int run = -1;
+static int sent_mid = -1;
+
+class mosquittopp_test : public mosqpp::mosquittopp
+{
+	public:
+		mosquittopp_test(const char *id);
+
+		void on_connect(int rc);
+		void on_publish(int mid);
+};
+
+mosquittopp_test::mosquittopp_test(const char *id) : mosqpp::mosquittopp(id)
+{
+}
+
+void mosquittopp_test::on_connect(int rc)
+{
+	if(rc){
+		exit(1);
+	}else{
+		publish_bufs(&sent_mid, "pub/qos0/no-payload/test", NULL, 0, 0, false);
+	}
+}
+
+void mosquittopp_test::on_publish(int mid)
+{
+	if(sent_mid == mid){
+        disconnect();
+	}else{
+		exit(1);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	struct mosquittopp_test *mosq;
+
+	int port = atoi(argv[1]);
+
+	mosqpp::lib_init();
+
+	mosq = new mosquittopp_test("publish_bufs-qos0-test-np");
+
+	mosq->connect("localhost", port, 60);
+
+	while(run == -1){
+		mosq->loop();
+	}
+
+	delete mosq;
+	mosqpp::lib_cleanup();
+
+	return run;
+}

--- a/test/lib/cpp/03-publish_bufs-qos0.cpp
+++ b/test/lib/cpp/03-publish_bufs-qos0.cpp
@@ -1,0 +1,64 @@
+#include <cstring>
+
+#include <mosquittopp.h>
+
+static int run = -1;
+static int sent_mid = -1;
+
+class mosquittopp_test : public mosqpp::mosquittopp
+{
+	public:
+		mosquittopp_test(const char *id);
+
+		void on_connect(int rc);
+		void on_publish(int mid);
+};
+
+mosquittopp_test::mosquittopp_test(const char *id) : mosqpp::mosquittopp(id)
+{
+}
+
+void mosquittopp_test::on_connect(int rc)
+{
+	if(rc){
+		exit(1);
+	}else{
+        const struct buf buffers[] = {
+            {"message1", (uint32_t) strlen("message1")},
+            {"msg2", (uint32_t) strlen("msg2")},
+            {"last_message", (uint32_t) strlen("last_message")},
+        };
+		publish_bufs(&sent_mid, "pub/qos0/test", buffers, 3, 0, false);
+	}
+}
+
+void mosquittopp_test::on_publish(int mid)
+{
+	if(sent_mid == mid){
+		disconnect();
+	}else{
+		exit(1);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	struct mosquittopp_test *mosq;
+
+	int port = atoi(argv[1]);
+
+	mosqpp::lib_init();
+
+	mosq = new mosquittopp_test("publish_bufs-qos0-test");
+
+	mosq->connect("localhost", port, 60);
+
+	while(run == -1){
+		mosq->loop();
+	}
+
+	delete mosq;
+	mosqpp::lib_cleanup();
+
+	return run;
+}

--- a/test/lib/cpp/Makefile
+++ b/test/lib/cpp/Makefile
@@ -56,6 +56,15 @@ all : 01 02 03 04 08 09
 03-publish-b2c-qos2.test : 03-publish-b2c-qos2.cpp
 	$(CXX) $< -o $@ $(CFLAGS) $(LIBS)
 
+03-publish_bufs-c2b-qos1-disconnect.test : 03-publish_bufs-c2b-qos1-disconnect.cpp
+	$(CXX) $< -o $@ $(CFLAGS) $(LIBS)
+
+03-publish_bufs-qos0-no-payload.test : 03-publish_bufs-qos0-no-payload.cpp
+	$(CXX) $< -o $@ $(CFLAGS) $(LIBS)
+
+03-publish_bufs-qos0.test : 03-publish_bufs-qos0.cpp
+	$(CXX) $< -o $@ $(CFLAGS) $(LIBS)
+
 04-retain-qos0.test : 04-retain-qos0.cpp
 	$(CXX) $< -o $@ $(CFLAGS) $(LIBS)
 
@@ -81,7 +90,7 @@ all : 01 02 03 04 08 09
 
 02 : 02-subscribe-qos0.test 02-subscribe-qos1.test 02-subscribe-qos2.test 02-unsubscribe.test
 
-03 : 03-publish-qos0.test 03-publish-qos0-no-payload.test 03-publish-c2b-qos1-disconnect.test 03-publish-c2b-qos2.test 03-publish-c2b-qos2-disconnect.test 03-publish-b2c-qos1.test 03-publish-b2c-qos2.test
+03 : 03-publish-qos0.test 03-publish-qos0-no-payload.test 03-publish-c2b-qos1-disconnect.test 03-publish-c2b-qos2.test 03-publish-c2b-qos2-disconnect.test 03-publish-b2c-qos1.test 03-publish-b2c-qos2.test 03-publish_bufs-qos0.test 03-publish_bufs-qos0-no-payload.test 03-publish_bufs-c2b-qos1-disconnect.test
 
 04 : 04-retain-qos0.test
 

--- a/test/lib/test.py
+++ b/test/lib/test.py
@@ -37,6 +37,9 @@ tests = [
     (1, ['./03-publish-c2b-qos2.py', 'c/03-publish-c2b-qos2.test']),
     (1, ['./03-publish-qos0-no-payload.py', 'c/03-publish-qos0-no-payload.test']),
     (1, ['./03-publish-qos0.py', 'c/03-publish-qos0.test']),
+    (1, ['./03-publish_bufs-c2b-qos1-disconnect.py', 'c/03-publish_bufs-c2b-qos1-disconnect.test']),
+    (1, ['./03-publish_bufs-qos0-no-payload.py', 'c/03-publish_bufs-qos0-no-payload.test']),
+    (1, ['./03-publish_bufs-qos0.py', 'c/03-publish_bufs-qos0.test']),
     (1, ['./03-request-response-correlation.py', 'c/03-request-response-correlation.test']),
     (1, ['./03-request-response.py', 'c/03-request-response.test']),
 
@@ -73,6 +76,9 @@ tests = [
     (1, ['./03-publish-c2b-qos2.py', 'cpp/03-publish-c2b-qos2.test']),
     (1, ['./03-publish-qos0-no-payload.py', 'cpp/03-publish-qos0-no-payload.test']),
     (1, ['./03-publish-qos0.py', 'cpp/03-publish-qos0.test']),
+    (1, ['./03-publish_bufs-c2b-qos1-disconnect.py', 'cpp/03-publish_bufs-c2b-qos1-disconnect.test']),
+    (1, ['./03-publish_bufs-qos0-no-payload.py', 'cpp/03-publish_bufs-qos0-no-payload.test']),
+    (1, ['./03-publish_bufs-qos0.py', 'cpp/03-publish_bufs-qos0.test']),
 
     (1, ['./04-retain-qos0.py', 'cpp/04-retain-qos0.test']),
 


### PR DESCRIPTION
As discussed in my previous [PR](https://github.com/eclipse/mosquitto/pull/1683) (which I broke accidentally while force-pushing an unintended commit and subsequently closed this PR)

Motivation: If you want to make a single publish to consist of multiple buffers concatenated together, then instead of concatenating the buffers on the user's end and then passing it to `mosquitto_publish` they can call use `mosquitto_publish_bufs`, this will reduce `memcpy` calls on the user's end. 
Example - If the user has 10 buffers each 20 bytes big, then the user will save cost (in terms of both, time and memory) of doing `memcpy` for a total of 200 bytes.

Signature of the function: `int mosquitto_publish_bufs(mosq, mid, topic, buffers, buffers_cnt, qos, retain)`, where `buffers` is an array of struct `buf`, where
```
struct buf {
   const void *base;
   uint32_t len;
};
```
^Taking into  account [the feedback](https://github.com/eclipse/mosquitto/pull/1683#issuecomment-631438763) provided on the last PR.

The difference in implementations for users will look like following:

With publish_bufs: 
```
buffer_count = sensor_count + 2;
buffers = malloc(buffer_count * sizeof(struct buf));
buffer[0]->iov_base = header;
buffer[0]->iov_len = strlen(header);
for(i=0; i<sensor_count; i++){
    buffer[i+1]->base = sensor[i];
    buffer[i+1]->len = strlen(sensor[i]);
}
for(i=0;i<4;i++){
	buffers[i].base = message[i];
	buffers[i].len = strlen(message[i]);
}
mosquitto_publish_bufs(..., buffers, buffer_count, ...);
free(buffers);
```

Without publish_bufs: 
```
payload_len = strlen(header)+strlen(footer);
for(i=0; i<sensor_count, i++){
	payload_len += strlen(sensor[i]);
}
payload = malloc(payloadlen + 1);
memcpy(payload, header, strlen(header));
offset += strlen(header);
for(i=0; i<sensor_count; i++){
	len = strlen(sensor[i]);
	memcpy(&payload[offset], sensor[i], len);
	offset += len;
}
memcpy(&payload[offset], footer, strlen(footer));
mosquitto_publish(..., payload_len, payload, ...);
free(payload);
```

- I have defined a new `struct buf` instead of using `struct iovec` (present in  <sys/uio.h>) because of the feedback provided [here](https://www.eclipse.org/lists/mosquitto-dev/msg02359.html) of keeping the mosquitto API as consistent as possible across platforms.
- The implementation makes `mosquitto_publish` a special case of `mosquitto_publish_bufs` to reduce code-duplication. I can make the two separate in-case the maintainer prefers so.
- The three new tests added (03-publish_bufs-qos0, 03-publish_bufs-qos0-no-payload, 03-publish_bufs-c2b-qos1-disconnect) extend the code-coverage to the new functionality added (primarily when `buffers_cnt != 1`) and the currently present (03-publish-*) tests still pass confirming that `mosquitto_publish_bufs` works fine when `buffers_cnt == 1`.

-----
- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?