### PR TITLE
Fix sys_tree macro stubs with no arguments.

### DIFF
--- a/src/sys_tree.h
+++ b/src/sys_tree.h
@@ -54,10 +54,10 @@ extern unsigned int g_connection_count;
 #define G_MSGS_SENT_INC(A)
 #define G_PUB_MSGS_RECEIVED_INC(A)
 #define G_PUB_MSGS_SENT_INC(A)
-#define G_MSGS_DROPPED_INC(A)
-#define G_CLIENTS_EXPIRED_INC(A)
-#define G_SOCKET_CONNECTIONS_INC(A)
-#define G_CONNECTION_COUNT_INC(A)
+#define G_MSGS_DROPPED_INC()
+#define G_CLIENTS_EXPIRED_INC()
+#define G_SOCKET_CONNECTIONS_INC()
+#define G_CONNECTION_COUNT_INC()
 
 #endif
 


### PR DESCRIPTION
This fixes Visual Studio compiler warnings like this one:
"warning C4003: not enough arguments for function-like
macro invocation 'G_MSGS_DROPPED_INC'"

Signed-off-by: Sigmund Vik <sigmund_vik@yahoo.com>

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
