### PR TITLE
Fix FormatMessage warnings for Windows.

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -86,7 +86,7 @@ static void net__print_error(int log, const char *format_str)
 
 #ifdef WIN32
 	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-			NULL, WSAGetLastError(), LANG_NEUTRAL, &buf, 0, NULL);
+			NULL, WSAGetLastError(), LANG_NEUTRAL, (LPTSTR)&buf, 0, NULL);
 
 	log__printf(NULL, log, format_str, buf);
 	LocalFree(buf);

--- a/src/security.c
+++ b/src/security.c
@@ -33,7 +33,7 @@ void LIB_ERROR(void)
 #ifdef WIN32
 	char *buf;
 	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
-			NULL, GetLastError(), LANG_NEUTRAL, &buf, 0, NULL);
+			NULL, GetLastError(), LANG_NEUTRAL, (LPTSTR)&buf, 0, NULL);
 	log__printf(NULL, MOSQ_LOG_ERR, "Load error: %s", buf);
 	LocalFree(buf);
 #else

--- a/src/service.c
+++ b/src/service.c
@@ -32,7 +32,7 @@ static void print_error(void)
 	char *buf;
 
 	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-		NULL, GetLastError(), LANG_NEUTRAL, &buf, 0, NULL);
+		NULL, GetLastError(), LANG_NEUTRAL, (LPTSTR)&buf, 0, NULL);
 
 	fprintf(stderr, "Error: %s\n", buf);
 	LocalFree(buf);


### PR DESCRIPTION
From the FormatMessage() Win32 API documentation: "The lpBuffer
parameter is a pointer to an LPTSTR; you must cast the pointer
to an LPTSTR (for example, (LPTSTR)&lpBuffer)."

https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage#parameters

This commit fixes warnings like these:
warning C4047: 'function': 'LPSTR' differs in levels of indirection from 'char **'
warning C4024: 'FormatMessageA': different types for formal and actual parameter 5

Signed-off-by: Sigmund Vik <sigmund_vik@yahoo.com>

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
