### PR TITLE
Fix IPv6 socket for Windows.

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -588,11 +588,7 @@ int net__socket_listen(struct mosquitto__listener *listener)
 	struct addrinfo *ainfo, *rp;
 	char service[10];
 	int rc;
-#ifndef WIN32
 	int ss_opt = 1;
-#else
-	char ss_opt = 1;
-#endif
 #ifdef SO_BINDTODEVICE
 	struct ifreq ifr;
 #endif
@@ -646,8 +642,14 @@ int net__socket_listen(struct mosquitto__listener *listener)
 		setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &ss_opt, sizeof(ss_opt));
 #endif
 #ifdef IPV6_V6ONLY
-		ss_opt = 1;
-		setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &ss_opt, sizeof(ss_opt));
+		if(rp->ai_family == AF_INET6){
+#ifndef WIN32
+			ss_opt = 1;
+#else
+			ss_opt = 0;
+#endif
+			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &ss_opt, sizeof(ss_opt));
+		}
 #endif
 
 		if(net__socket_nonblock(&sock)){


### PR DESCRIPTION
The IPV6_V6ONLY call to setsockopt() in net__socket_listen()
contained two mistakes for Windows.

The first mistake was that the type of "ss_opt" was wrong.
From the setsockopt() Win32 API documentation: "The optlen
parameter should be equal to sizeof(int) for Boolean options."
https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-setsockopt#remarks

The second mistake was that the IPV6_V6ONLY flag must be flipped
on Windows, see for instance how Boost.Asio does this:
https://github.com/boostorg/asio/blob/2d27fc712387c54b7eb45347fc4669be29a38d9e/include/boost/asio/detail/impl/socket_ops.ipp#L1806

This commit also changes the code to only set the IPV6_V6ONLY
flag for IPv6 (similarly to how Boost.Asio does it), because
that seems more correct.

Before this commit, starting the Mosquitto broker when the IPv6 port
already was in use would produce an output like this (and the broker
would be running):

1594385168: mosquitto version 1.6.9 starting
1594385168: Using default config.
1594385168: Opening ipv6 listen socket on port 31001.
1594385168: Opening ipv4 listen socket on port 31001.

With this commit, starting the Mosquitto broker when the IPv6 port
already is in use makes the broker correctly terminate with an exit
code of 1 and this output:

1594385193: mosquitto version 1.6.9 starting
1594385193: Using default config.
1594385193: Opening ipv6 listen socket on port 31001.
1594385193: Error: Only one usage of each socket address (protocol/network address/port) is normally permitted.

Signed-off-by: Sigmund Vik <sigmund_vik@yahoo.com>

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

(Just like before this commit, I need to apply a [hack](https://github.com/eclipse/mosquitto/issues/1659#issuecomment-653629126) to `test/lib/02-subscribe-qos1.py` in order to make all tests pass on my Ubuntu 18.04 machine.)