### PR TITLE
Add broker ready message.

### DIFF
--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -364,6 +364,7 @@ int main(int argc, char *argv[])
 	}
 #endif
 
+	log__printf(NULL, MOSQ_LOG_INFO, "mosquitto version %s running", VERSION);
 #ifdef WITH_SYSTEMD
 	sd_notify(0, "READY=1");
 #endif


### PR DESCRIPTION
Before this commit there was no good way to detect that the
Mosquitto broker was done with its startup phase on systems
without systemd.

On such systems it was tricky to e.g. start the broker from
a test where ports are dynamically assigned and one have to
deal with potential port conflicts.  Without a way to know
that the broker is done with its startup phase, there was no
way to know if the broker was able to acquire the port (for
both IPv4 and IPv6) without waiting for some unknown period
of time (when many tests are run in parallel a single process
might be starved for resources).

With this new broker ready message it is easy for the parent
process to monitor the broker output and figure out when the
port was successfully acquired.

Signed-off-by: Sigmund Vik <sigmund_vik@yahoo.com>

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
