### PR TITLE
Fix bridge reconnect

### DIFF
--- a/src/mux_epoll.c
+++ b/src/mux_epoll.c
@@ -157,6 +157,7 @@ int mux_epoll__add_in(struct mosquitto_db *db, struct mosquitto *context)
 	if (epoll_ctl(db->epollfd, EPOLL_CTL_ADD, context->sock, &ev) == -1) {
 		log__printf(NULL, MOSQ_LOG_ERR, "Error in epoll accepting: %s", strerror(errno));
 	}
+	context->events = EPOLLIN;
 	return MOSQ_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
In the mux_epoll__add_in function, no context->events was set. Previously this was set to match the ev.events (EPOLLIN). Adding this back in, keeps the code consistent to before it was refactored to split out epoll and poll functions, as well as being consistent with the other mux_epoll__ functions.

If this is not set, the connection is never fully established when the broker comes back up.

Fixes #1680.

Signed-off-by: Simon Tate <simon.tate@bt.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
No - it is a bug fix to the develop branch itself. The bug is not there on the fixes branch.
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
No - but they failed for me on develop too. Is this expected?

-----
