### PR TITLE
do not include pthread when compiling without threading support

### DIFF
--- a/lib/thread_mosq.c
+++ b/lib/thread_mosq.c
@@ -20,10 +20,12 @@ Contributors:
 #include <time.h>
 #endif
 
+#if defined(WITH_THREADING)
 #if defined(__linux__) || defined(__NetBSD__)
 #  include <pthread.h>
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #  include <pthread_np.h>
+#endif
 #endif
 
 #include "mosquitto_internal.h"


### PR DESCRIPTION
This fixes the following error, when compiling for systems without
pthread support, and when passing WITH_THREADING=no to make:

    thread_mosq.c:24:12: fatal error: pthread.h: No such file or directory
     #  include <pthread.h>
                 ^~~~~~~~~~~
    compilation terminated.