### PR TITLE
Ld symbol of the mosquitto_property_copy_all has global bind now.

### DIFF
--- a/lib/linker.version
+++ b/lib/linker.version
@@ -109,6 +109,7 @@ MOSQ_1.6 {
 		mosquitto_property_add_varint;
 		mosquitto_property_check_all;
 		mosquitto_property_check_command;
+		mosquitto_property_copy_all;
 		mosquitto_property_free_all;
 		mosquitto_property_read_binary;
 		mosquitto_property_read_byte;


### PR DESCRIPTION
Signed-off-by: ignacy.ruksza <ignacy.ruksza@ledatel.pl>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
