### PR TITLE
Added support for SSL keylogging.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -239,6 +239,7 @@ void config__init(struct mosquitto_db *db, struct mosquitto__config *config)
 	config__init_reload(db, config);
 
 	config->daemon = false;
+	config->keylog = false;
 	memset(&config->default_listener, 0, sizeof(struct mosquitto__listener));
 	config->default_listener.max_connections = -1;
 	config->default_listener.protocol = mp_mqtt;
@@ -357,10 +358,11 @@ static void print_usage(void)
 {
 	printf("mosquitto version %s\n\n", VERSION);
 	printf("mosquitto is an MQTT v5.0/v3.1.1/v3.1 broker.\n\n");
-	printf("Usage: mosquitto [-c config_file] [-d] [-h] [-p port]\n\n");
+	printf("Usage: mosquitto [-c config_file] [-d] [-h] [-p port] [-k]\n\n");
 	printf(" -c : specify the broker config file.\n");
 	printf(" -d : put the broker into the background after starting.\n");
 	printf(" -h : display this help.\n");
+	printf(" -k : log SSL keys to logfile.\n");
 	printf(" -p : start the broker listening on the specified port.\n");
 	printf("      Not recommended in conjunction with the -c option.\n");
 	printf(" -v : verbose mode - enable all logging types. This overrides\n");
@@ -391,6 +393,8 @@ int config__parse_args(struct mosquitto_db *db, struct mosquitto__config *config
 		}else if(!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")){
 			print_usage();
 			return MOSQ_ERR_INVAL;
+		}else if(!strcmp(argv[i], "-k")){
+			config->keylog = true;
 		}else if(!strcmp(argv[i], "-p") || !strcmp(argv[i], "--port")){
 			if(i<argc-1){
 				port_tmp = atoi(argv[i+1]);

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -278,6 +278,7 @@ struct mosquitto__config {
 	char *clientid_prefixes;
 	bool connection_messages;
 	bool daemon;
+	bool keylog;
 	struct mosquitto__listener default_listener;
 	struct mosquitto__listener *listeners;
 	int listener_count;


### PR DESCRIPTION
This feature adds the `-k` option, which installs a callback function to log SSL key material to the logfile.

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ X ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ X ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [  ] Have you successfully run `make test` with your changes locally?

-----

Couldn't run `make test` due to CUnit dependencies. Already committed and pushed so `commit -s` wasn't available, but if there is a way to add this after the fact, I will do so.