### PR TITLE
Add missing header for QNX

### DIFF
--- a/lib/socks_mosq.c
+++ b/lib/socks_mosq.c
@@ -23,6 +23,7 @@ Contributors:
 #  include <ws2tcpip.h>
 #elif __QNX__
 #  include <sys/socket.h>
+#  include <arpa/inet.h>
 #  include <netinet/in.h>
 #else
 #  include <arpa/inet.h>


### PR DESCRIPTION
<arpa/inet.h> header is required to compile this source. Without it, WARNING is generated.

mosquitto/lib/socks_mosq.c: In function 'socks5__send':
mosquitto/lib/socks_mosq.c:156:22: warning: implicit declaration of function 'inet_pton' [-Wimplicit-function-declaration]
   ipv4_pton_result = inet_pton(AF_INET, mosq->host, &addr_ipv4);

Signed-off-by: ChangJoon Lee <changjoon.lee@lge.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [Y] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [Y] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [Y] Have you added an explanation of what your changes do and why you'd like us to include them?
- [Y] Have you successfully run `make test` with your changes locally?

-----
