### PR TITLE
Fixed compilation error on Win32 UNICODE platform.

### DIFF
--- a/lib/misc_mosq.c
+++ b/lib/misc_mosq.c
@@ -40,14 +40,14 @@ FILE *mosquitto__fopen(const char *path, const char *mode, bool restrict_read)
 #ifdef WIN32
 	char buf[4096];
 	int rc;
-	rc = ExpandEnvironmentStrings(path, buf, 4096);
+	rc = ExpandEnvironmentStringsA(path, buf, 4096);
 	if(rc == 0 || rc > 4096){
 		return NULL;
 	}else{
 		if (restrict_read) {
 			HANDLE hfile;
 			SECURITY_ATTRIBUTES sec;
-			EXPLICIT_ACCESS ea;
+			EXPLICIT_ACCESS_A ea;
 			PACL pacl = NULL;
 			char username[UNLEN + 1];
 			int ulen = UNLEN;
@@ -68,12 +68,12 @@ FILE *mosquitto__fopen(const char *path, const char *mode, bool restrict_read)
 					return NULL;
 			}
 
-			GetUserName(username, &ulen);
+			GetUserNameA(username, &ulen);
 			if (!InitializeSecurityDescriptor(&sd, SECURITY_DESCRIPTOR_REVISION)) {
 				return NULL;
 			}
-			BuildExplicitAccessWithName(&ea, username, GENERIC_ALL, SET_ACCESS, NO_INHERITANCE);
-			if (SetEntriesInAcl(1, &ea, NULL, &pacl) != ERROR_SUCCESS) {
+			BuildExplicitAccessWithNameA(&ea, username, GENERIC_ALL, SET_ACCESS, NO_INHERITANCE);
+			if (SetEntriesInAclA(1, &ea, NULL, &pacl) != ERROR_SUCCESS) {
 				return NULL;
 			}
 			if (!SetSecurityDescriptorDacl(&sd, TRUE, pacl, FALSE)) {
@@ -85,7 +85,7 @@ FILE *mosquitto__fopen(const char *path, const char *mode, bool restrict_read)
 			sec.bInheritHandle = FALSE;
 			sec.lpSecurityDescriptor = &sd;
 
-			hfile = CreateFile(buf, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ,
+			hfile = CreateFileA(buf, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ,
 				&sec,
 				dwCreationDisposition,
 				FILE_ATTRIBUTE_NORMAL,


### PR DESCRIPTION
Signed-off-by: raspopov <raspopov@cherubicsoft.com>

I suggest to use a direct ANSI version of Win32 API with current data type i.e. "char". Optionally add TODO to upgrade it to UNICODE at some time...

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
