### PR TITLE
Fixed paranoid VS2017 compilation error of uninitialized variable (was a warning before).

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -377,6 +377,8 @@ int net__try_connect(const char *host, uint16_t port, mosq_sock_t *sock, const c
 	uint32_t val = 1;
 #endif
 
+	ainfo_bind = NULL;
+
 	*sock = INVALID_SOCKET;
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;


### PR DESCRIPTION
Signed-off-by: raspopov <raspopov@cherubicsoft.com>

VS2017 too clever... 😒

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
