### PR TITLE
Fixed QNX compilation. QNX 6.5 supports _XOPEN_SOURCE=600 or less.

### DIFF
--- a/config.h
+++ b/config.h
@@ -6,8 +6,12 @@
 
 #ifdef __APPLE__
 #  define __DARWIN_C_SOURCE
-#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__SYMBIAN32__) || defined(__QNX__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__SYMBIAN32__)
 #  define _XOPEN_SOURCE 700
+#  define __BSD_VISIBLE 1
+#  define HAVE_NETINET_IN_H
+#elif defined(__QNX__)
+#  define _XOPEN_SOURCE 600
 #  define __BSD_VISIBLE 1
 #  define HAVE_NETINET_IN_H
 #else


### PR DESCRIPTION
Signed-off-by: raspopov <raspopov@cherubicsoft.com>

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
