### PR TITLE
Fix enclosing include brackets in cmake

### DIFF
--- a/apps/mosquitto_ctrl/CMakeLists.txt
+++ b/apps/mosquitto_ctrl/CMakeLists.txt
@@ -3,7 +3,7 @@ if (WITH_TLS AND CJSON_FOUND)
 	include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/include
 			${mosquitto_SOURCE_DIR}/lib ${mosquitto_SOURCE_DIR}/src
 			${OPENSSL_INCLUDE_DIR} ${STDBOOL_H_PATH} ${STDINT_H_PATH}
-			${CJSON_INCLUDE_DIRS}) ${mosquitto_SOURCE_DIR}/apps/mosquitto_passwd
+			${CJSON_INCLUDE_DIRS} ${mosquitto_SOURCE_DIR}/apps/mosquitto_passwd)
 
 	add_executable(mosquitto_ctrl
 		mosquitto_ctrl.c mosquitto_ctrl.h


### PR DESCRIPTION
Fix enclosing include brackets in cmake
    
Signed-off-by: Franz Auernigg <f.auernigg@commend.com>

Thank you for contributing your time to the Mosquitto project!

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?