### PR TITLE
Fix linux build of mosquitto_ctrl

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -182,6 +182,7 @@ ifeq ($(UNAME),Linux)
 	BROKER_LDADD:=$(BROKER_LDADD) -lrt
 	BROKER_LDFLAGS:=$(BROKER_LDFLAGS) -Wl,--dynamic-list=linker.syms
 	LIB_LIBADD:=$(LIB_LIBADD) -lrt
+	APP_CFLAGS+=-fPIC
 endif
 
 ifeq ($(WITH_SHARED_LIBRARIES),yes)


### PR DESCRIPTION
Fix linux build of mosquitto_ctrl

Append fPIC option to APP_CFLAGS of linux build


Thank you for contributing your time to the Mosquitto project!

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?