### PR TITLE
mosquitto_pub: exit if server becomes unreachable and QOS > 0

### DIFF
--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -256,8 +256,8 @@ int pub_stdin_line_loop(struct mosquitto *mosq)
 					rc = my_publish(mosq, &mid_sent, cfg.topic, buf_len_actual-1, line_buf, cfg.qos, cfg.retain);
 					pos = 0;
 					if(rc){
-						err_printf(&cfg, "Error: Publish returned %d, disconnecting.\n", rc);
-						mosquitto_disconnect_v5(mosq, MQTT_RC_DISCONNECT_WITH_WILL_MSG, cfg.disconnect_props);
+						err_printf(&cfg, "Error: Publish returned %d.\n", rc);
+						if(cfg.qos>0) return rc;
 					}
 					break;
 				}else{
@@ -275,8 +275,8 @@ int pub_stdin_line_loop(struct mosquitto *mosq)
 			if(pos != 0){
 				rc = my_publish(mosq, &mid_sent, cfg.topic, buf_len_actual, line_buf, cfg.qos, cfg.retain);
 				if(rc){
-					err_printf(&cfg, "Error: Publish returned %d, disconnecting.\n", rc);
-					mosquitto_disconnect_v5(mosq, MQTT_RC_DISCONNECT_WITH_WILL_MSG, cfg.disconnect_props);
+					err_printf(&cfg, "Error: Publish returned %d.\n", rc);
+					if(cfg.qos>0) return rc;
 				}
 			}
 			if(feof(stdin)){

--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -180,7 +180,8 @@ void my_connect_callback(struct mosquitto *mosq, void *obj, int result, int flag
 			}else{
 				err_printf(&cfg, "Connection error: %s\n", mosquitto_connack_string(result));
 			}
-			mosquitto_disconnect_v5(mosq, 0, cfg.disconnect_props);
+			// let the loop know that this is an unrecoverable connection
+			status = STATUS_NOHOPE;
 		}
 	}
 }
@@ -244,6 +245,10 @@ int pub_stdin_line_loop(struct mosquitto *mosq)
 			ts.tv_nsec = 100000000;
 			nanosleep(&ts, NULL);
 #endif
+		}
+
+		if(status == STATUS_NOHOPE){
+			return MOSQ_ERR_CONN_REFUSED;
 		}
 
 		if(status == STATUS_CONNACK_RECVD){

--- a/client/pub_shared.h
+++ b/client/pub_shared.h
@@ -21,6 +21,7 @@ Contributors:
 #define STATUS_WAITING 2
 #define STATUS_DISCONNECTING 3
 #define STATUS_DISCONNECTED 4
+#define STATUS_NOHOPE 5
 
 extern int mid_sent;
 extern struct mosq_config cfg;


### PR DESCRIPTION
Fixes eclipse/mosquitto#1899

In stdin line mode, mosquitto_pub will continue running and accepting
input even if/when/after publishing fails.  This condition is reached
when it first successfully establishes a connection and the server later
is unreachable.

Exiting with a non-zero exit code allows for much easier health
monitoring when used in a long-running pipe.

Signed-off-by: Dan White <dan.white@valpo.edu>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
