### PR TITLE
Fix for set(CMAKE_MACOSX_RPATH 1) on Darwin systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ set (VERSION 1.6.12)
 
 add_definitions (-DCMAKE -DVERSION=\"${VERSION}\")
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	set(CMAKE_MACOSX_RPATH 1)
+endif()
+
 if (WIN32)
 	add_definitions("-D_CRT_SECURE_NO_WARNINGS")
 	add_definitions("-D_CRT_NONSTDC_NO_DEPRECATE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,15 +9,14 @@ set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 project(mosquitto)
 
 cmake_minimum_required(VERSION 2.8)
-# Only for version 3 and up. cmake_policy(SET CMP0042 NEW)
+if (CMAKE_MAJOR_VERSION GREATER_EQUAL 3)
+    # set MACOSX_RPATH ON by default, see https://cmake.org/cmake/help/v3.0/policy/CMP0042.html
+    cmake_policy(SET CMP0042 NEW)
+endif()
 
 set (VERSION 1.6.12)
 
 add_definitions (-DCMAKE -DVERSION=\"${VERSION}\")
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	set(CMAKE_MACOSX_RPATH 1)
-endif()
 
 if (WIN32)
 	add_definitions("-D_CRT_SECURE_NO_WARNINGS")


### PR DESCRIPTION
Signed-off-by: Tony Bright <krakjn@gmail.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
