### PR TITLE
apps: mosquitto_ctrl: don't hard set paths

### DIFF
--- a/apps/mosquitto_ctrl/Makefile
+++ b/apps/mosquitto_ctrl/Makefile
@@ -8,8 +8,7 @@ else
 LIBMOSQ:=../../lib/libmosquitto.a
 endif
 
-LOCAL_CPPFLAGS:=-I/usr/include/cjson -I/usr/local/include/cjson -I../mosquitto_passwd
-LOCAL_LDFLAGS:=-L/usr/local/lib
+LOCAL_CPPFLAGS:=-I../mosquitto_passwd
 
 OBJS=	mosquitto_ctrl.o \
 		client.o \


### PR DESCRIPTION
In a cross compile environment, these paths will be added elsewhere, and
in a local environment, they should already be covered by the system
compiler.  Simply drop them.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
  no, 2.0 isn't in fixes yet?
- [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----

Changes required for OpenWrt packaging at least