### PR TITLE
Fix issue with CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_policy(SET CMP0042 NEW)
 project(mosquitto)
 set (VERSION 2.0.2)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 
 add_definitions (-DCMAKE -DVERSION=\"${VERSION}\")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,10 @@
 # To configure the build options either use the CMake gui, or run the command
 # line utility including the "-i" option.
 
-project(mosquitto)
-
 cmake_minimum_required(VERSION 3.0)
 cmake_policy(SET CMP0042 NEW)
 
+project(mosquitto)
 set (VERSION 2.0.2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@
 # To configure the build options either use the CMake gui, or run the command
 # line utility including the "-i" option.
 
-set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-
 project(mosquitto)
 
 cmake_minimum_required(VERSION 3.0)


### PR DESCRIPTION
Fix appending to CMAKE_MODULE_PATH when a path already exists.  
Remove setting CMAKE_LEGACY_CYGWIN_WIN32 which is not needed anymore since CMake 3.0 is required.  
Set `project` after `cmake_minimum_required` as described in the documentation.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
