### PR TITLE
Systemd service changes for updated pid path

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -869,7 +869,7 @@ log_timestamp_format %Y-%m-%dT%H:%M:%S
 					<para>If mosquitto is being automatically started by an
 						init script it will usually be required to write a pid
 						file. This should then be configured as e.g.
-						/var/run/mosquitto.pid</para>
+						/var/run/mosquitto/mosquitto.pid</para>
 					<para>Not reloaded on reload signal.</para>
 				</listitem>
 			</varlistentry>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -145,7 +145,7 @@
 
 # Write process id to a file. Default is a blank string which means
 # a pid file shouldn't be written.
-# This should be set to /var/run/mosquitto.pid if mosquitto is
+# This should be set to /var/run/mosquitto/mosquitto.pid if mosquitto is
 # being run automatically on boot with an init script and
 # start-stop-daemon or similar.
 #pid_file

--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -12,6 +12,8 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
 ExecStartPre=/bin/chown mosquitto: /var/log/mosquitto
+ExecStartPre=/bin/mkdir -m 740 -p /var/run/mosquitto
+ExecStartPre=/bin/chown mosquitto: /var/run/mosquitto
 
 [Install]
 WantedBy=multi-user.target

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -10,6 +10,8 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
 ExecStartPre=/bin/chown mosquitto: /var/log/mosquitto
+ExecStartPre=/bin/mkdir -m 740 -p /var/run/mosquitto
+ExecStartPre=/bin/chown mosquitto: /var/run/mosquitto
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix Issue #1950  Systemd services would not start due to attempt to create pid file in directory that does not exist.  Script updated to create directory with correct privs.

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
