### PR TITLE
Use libdir as the install prefix for plugins

### DIFF
--- a/plugins/dynamic-security/Makefile
+++ b/plugins/dynamic-security/Makefile
@@ -77,10 +77,10 @@ test:
 install: all
 ifeq ($(WITH_CJSON),yes)
 ifeq ($(WITH_TLS),yes)
-	$(INSTALL) -d "${DESTDIR}$(prefix)/lib"
-	$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${prefix}/lib/${PLUGIN_NAME}.so"
+	$(INSTALL) -d "${DESTDIR}$(libdir)"
+	$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"
 endif
 endif
 
 uninstall :
-	-rm -f "${DESTDIR}${prefix}/lib/${PLUGIN_NAME}.so"
+	-rm -f "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"

--- a/plugins/message-timestamp/Makefile
+++ b/plugins/message-timestamp/Makefile
@@ -20,8 +20,8 @@ test:
 
 install: ${PLUGIN_NAME}.so
 	# Don't install, these are examples only.
-	#$(INSTALL) -d "${DESTDIR}$(prefix)/lib"
-	#$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${prefix}/lib/${PLUGIN_NAME}.so"
+	#$(INSTALL) -d "${DESTDIR}$(libdir)"
+	#$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"
 
 uninstall :
-	-rm -f "${DESTDIR}${prefix}/lib/${PLUGIN_NAME}.so"
+	-rm -f "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"

--- a/plugins/payload-modification/Makefile
+++ b/plugins/payload-modification/Makefile
@@ -20,8 +20,8 @@ test:
 
 install: ${PLUGIN_NAME}.so
 	# Don't install, these are examples only.
-	#$(INSTALL) -d "${DESTDIR}$(prefix)/lib"
-	#$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${prefix}/lib/${PLUGIN_NAME}.so"
+	#$(INSTALL) -d "${DESTDIR}$(libdir)"
+	#$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"
 
 uninstall :
-	-rm -f "${DESTDIR}${prefix}/lib/${PLUGIN_NAME}.so"
+	-rm -f "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"


### PR DESCRIPTION
Use the libdir variable from config.mk just like lib/ uses to ensure
that the plugins are installed into the same location as the library.
This fixes systems that use lib64 for libraries like most 64 bit
Linux distributions.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [N/A] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
