### PR TITLE
add option for controlling build of client tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 include config.mk
 
-DIRS=lib apps client plugins src
+DIRS=lib apps plugins src
+ifeq ($(WITH_CLIENT_TOOLS),yes)
+DIRS+=client
+endif
 DOCDIRS=man
 DISTDIRS=man
 DISTFILES= \

--- a/config.mk
+++ b/config.mk
@@ -118,6 +118,9 @@ WITH_JEMALLOC:=no
 # probably of no particular interest to end users.
 WITH_XTREPORT=no
 
+# Comment out to disable the client tools mosquitto_sub and mosquitto_pub.
+WITH_CLIENT_TOOLS:=yes
+
 # =============================================================================
 # End of user configuration
 # =============================================================================


### PR DESCRIPTION
Sometimes it is not desired to build the tools mosquitto_pub and
mosquitto_sub. This option makes it possible to disable building
these tools.

Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
