### PR TITLE
Fix cmake not building correctly when WITH_CJSON=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,12 +99,14 @@ if (WITH_DLT)
 	add_definitions("-DWITH_DLT")
 endif (WITH_DLT)
 
-FIND_PACKAGE(cJSON)
-if (CJSON_FOUND)
-	message(STATUS ${CJSON_FOUND})
-else (CJSON_FOUND)
-	message(STATUS "Optional dependency cJSON not found. Some features will be disabled.")
-endif(CJSON_FOUND)
+if (WITH_CJSON)
+    FIND_PACKAGE(cJSON)
+    if (CJSON_FOUND)
+	    message(STATUS ${CJSON_FOUND})
+    else (CJSON_FOUND)
+	    message(STATUS "Optional dependency cJSON not found. Some features will be disabled.")
+    endif(CJSON_FOUND)
+endif()
 
 # ========================================
 # Include projects


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?
**It fails before and after my fix, I don't have cJson installed.**
-----

Fix cmake not building correctly when WITH_CJSON=OFF. 
In the main CMakeLists.txt, the cJson discovery process is executed regardless if WITH_CJSON is ON or OFF, this MR fixes that.

This fixes #2026