### PR TITLE
100% CPU usage in case the client doesn't send data - bug fix

### DIFF
--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -216,7 +216,9 @@ int packet__write(struct mosquitto *mosq)
 	if(mosq->sock == INVALID_SOCKET) return MOSQ_ERR_NO_CONN;
 
 #ifdef WITH_BROKER
-	mux__add_out(mosq);
+	if (mosq->current_out_packet) {
+	   mux__add_out(mosq);
+	}
 #endif
 
 	pthread_mutex_lock(&mosq->current_out_packet_mutex);


### PR DESCRIPTION
Hi.
It is very easy to make Mosquitto use 100% of the CPU. Just run the command:
openssl s_client -connect mosquitt-server: 8883

I ran a look at the server code today and found the cause of the problem.
Until a timeout occurs, the server will continue to execute the main loop without pausing. This is because epoll_wait gets the EPOLLOUT event all the time. Below are two diagrams showing the CPU consumption with and without the fix.

Unfixed (100% CPU):
[mosquitto-cpuprof-TooHigh.pdf](https://github.com/eclipse/mosquitto/files/5881791/mosquitto-cpuprof-TooHigh.pdf)

with the fix (0.7% CPU):
[mosquitto-cpuprof-Normal.pdf](https://github.com/eclipse/mosquitto/files/5881792/mosquitto-cpuprof-Normal.pdf)

@ralight should check if my patch does not restore the problem that his commit solved
https://github.com/eclipse/mosquitto/commit/fabdfcc060432f07595b4a10d4f4fb3d075c64dc