### PR TITLE
Fixing a memory leak when another broker connects. Closes #2057

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -285,6 +285,7 @@ void do_disconnect(struct mosquitto *context, int reason)
 #endif
 
 	if(context->state == mosq_cs_disconnected){
+		context__cleanup(context, true);
 		return;
 	}
 #ifdef WITH_WEBSOCKETS


### PR DESCRIPTION
Due to unfamiliarity with your code, I am not sure if using context__cleanup in the place I suggested is correct, but in my tests it solves the problem.