### PR TITLE
Fix and improve interface binding

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -624,23 +624,37 @@ static int net__bind_interface(struct mosquitto__listener *listener, struct addr
 				&& ifa->ifa_addr->sa_family == rp->ai_addr->sa_family){
 
 			if(rp->ai_addr->sa_family == AF_INET){
-				memcpy(&((struct sockaddr_in *)rp->ai_addr)->sin_addr,
-						&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr,
-						sizeof(struct in_addr));
+				if(listener->host &&
+						memcmp(&((struct sockaddr_in *)rp->ai_addr)->sin_addr,
+							&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr,
+							sizeof(struct in_addr))){
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Interface address does not match specified listener host.");
+				}else{
+					memcpy(&((struct sockaddr_in *)rp->ai_addr)->sin_addr,
+							&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr,
+							sizeof(struct in_addr));
 
-				freeifaddrs(ifaddr);
-				return MOSQ_ERR_SUCCESS;
+					freeifaddrs(ifaddr);
+					return MOSQ_ERR_SUCCESS;
+				}
 			}else if(rp->ai_addr->sa_family == AF_INET6){
-				memcpy(&((struct sockaddr_in6 *)rp->ai_addr)->sin6_addr,
-						&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr,
-						 sizeof(struct in6_addr));
-				freeifaddrs(ifaddr);
-				return MOSQ_ERR_SUCCESS;
+				if(listener->host &&
+						memcmp(&((struct sockaddr_in6 *)rp->ai_addr)->sin6_addr,
+							&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr,
+							sizeof(struct in6_addr))){
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Interface address does not match specified listener host.");
+				}else{
+					memcpy(&((struct sockaddr_in6 *)rp->ai_addr)->sin6_addr,
+							&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr,
+							sizeof(struct in6_addr));
+					freeifaddrs(ifaddr);
+					return MOSQ_ERR_SUCCESS;
+				}
 			}
 		}
 	}
 	freeifaddrs(ifaddr);
-	log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Interface %s does not support %s.",
+	log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Interface %s does not support %s configuration.",
 	            listener->bind_interface, rp->ai_addr->sa_family == AF_INET ? "ipv4" : "ipv6");
 	return MOSQ_ERR_NOT_FOUND;
 }


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] (N/A) If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

Hi Mosquitto developers,

While upstepping this component, we noticed a regression in the interface binding of the broker.

More specifically: the commit 886ee6cd0c647e26b7c2a9f9f62cb181df3d5de3 changed the interface binding behavior from using `SO_BINDTODEVICE` to a method using `getifaddrs()`.

##  Overstrict binding
While this approach works fine in most use-cases, it can fail when (1) no host is specified, (2) the specified interface does not support ipv4 (or ipv6) and (3) there are other interfaces that do support the missing sa_family. In this use-case, the call to `getaddrinfo()` will give 2 options to bind to: an ipv4 and an ipv6 version. In the loop, the broker will try to get the address for both families, but it will fail on one of the two, resulting in a failed startup. (It's all or nothing)

Steps to reproduce:
```sh
ip link add eth_dummy type dummy
ip addr add 192.168.111.2/24 dev eth_dummy
# (you can remove the interface with `ip link del eth_dummy`)
printf "listener 31337\nbind_interface eth_dummy\n" > broker.conf
mosquitto -v -c broker.conf
```
will result in:
```
1612816913: mosquitto version 2.0.7 starting                                                 
1612816913: Config loaded from broker.conf.
1612816913: Opening ipv4 listen socket on port 31337.
1612816913: Opening ipv6 listen socket on port 31337.
1612816913: Error: Interface eth_dummy not found.
```
The first commit fixes this issue:
```
1612817207: mosquitto version 2.0.7 starting
1612817207: Config loaded from broker.conf.
1612817207: Opening ipv4 listen socket on port 31337.
1612817207: Opening ipv6 listen socket on port 31337.
1612817207: Warning: Interface eth_dummy does not support ipv6.
1612817207: mosquitto version 2.0.7 running
...
```
## Bind address overwrite
A second issue occurs when specifying both a host to a `listener` config line, and a `bind_interface`:

```
listener 31337 192.168.66.1
bind_interface eth_dummy
```
Because there is no check in the current `net__bind_interface()`, the specified listener address is overwritten by the first valid address returned from `getifaddrs()`. The second commit addresses this issue by checking if the interface address matches the host. If it does, the address is accepted. The function now seems somewhat complex, so you might just want to disallow this configuration combination altogether. The current solution results in mosquitto listening to the intersection between (the listen address/host) and (the interface addresses).

With the same setup as before, but with the changed configuration, the original code gives:
```
1612822113: mosquitto version 2.0.7 starting
1612822113: Config loaded from broker.conf.
1612822113: Opening ipv4 listen socket on port 31337.
1612822113: mosquitto version 2.0.7 running
```
but ultimately on the "wrong" address:
```
~ $ netstat -tlpn | grep mosquit 
tcp        0      0 192.168.111.2:31337     0.0.0.0:*               LISTEN      2824914/src/mosquit 
```

With the fix, mosquitto refuses to launch as no valid listeners could be created:
```
1612822661: mosquitto version 2.0.7 starting
1612822661: Config loaded from broker.conf.
1612822661: Opening ipv4 listen socket on port 31337.
1612822661: Warning: Interface address does not match specified listener host.
1612822661: Warning: Interface eth_dummy does not support ipv4 configuration.
```

## Incomplete binding
For this issue, I don't have an immediate fix. The problem here is that one interface can have multiple IP addresses. One might expect the `bind_interface` config option to bind to each and every one of those, instead of only the first (valid) one returned by `getifaddrs()`. The current code is written with the expectation that there is only one IP address that would match a family. A possible, proper fix would be to first enumerate the addresses from an interface, and only then as a next step create a listener for each of those addresses. It would be nice to reuse the `net__socket_listen_tcp()` call from some `net__socket_listen_tcp_interface()`, but then you need to convert structures back to strings first. I do want to take a throw at implementing it, but I would love to hear your opinion first.

---

If there are any other issues with this MR, please don't hold back. I would be glad to fix them.
