### PR TITLE
Handle stale stored messages with conflicting message ID.

### DIFF
--- a/src/handle_publish.c
+++ b/src/handle_publish.c
@@ -285,6 +285,13 @@ int handle__publish(struct mosquitto *context)
 	if(msg->qos > 0){
 		db__message_store_find(context, msg->source_mid, &stored);
 	}
+
+	if (stored && (stored->qos != msg->qos || stored->payloadlen != msg->payloadlen || strcmp(stored->topic, msg->topic) || memcmp(stored->payload, msg->payload, msg->payloadlen))){
+		log__printf(NULL, MOSQ_LOG_WARNING, "Reused message ID from %s detected. Clearing from storage.", context->id);
+		db__message_remove_incoming(context, stored->mid);
+		stored = NULL;
+	}
+
 	if(!stored){
 		if(msg->qos == 0
 				|| db__ready_for_flight(&context->msgs_in, msg->qos)


### PR DESCRIPTION
We're running several Mosquitto instances with bridges between them. At one point one of the bridges stopped working - the connection is dropped and retried every few seconds, but never comes back up). Upon further investigation, we concluded that the following had happened:

1. Broker1 sends a QoS2 message to Broker2.
2. At some point during the PUBREC/PUBREL/PUBCOMP exchange, Broker1 was stopped, and persistent storage was cleared.
3. Broker2 now sits on a stored copy of the message.
4. Broker1 reconnects and proceeds to send messages.
5. Broker1 later sends a QoS1 message with the same ID as in step 1
6. Broker2 finds the message ID in storage and proceeds to reply with a PUBREC, since the stored copy is QoS2.
7. Broker1 receives the PUBREC, but expects a PUBACK and closes the connection due to a protocol error.
8. Broker1 reconnects and goes back to step 5.

The connection never recovers unless the persistent storage on Broker2 is cleaned up.

The issue was later verified on a test setup with a modified client that skips the PUBREL/PUBCOMP.

This PR attempts to detect this situation by comparing the received message with the stored message with the same ID and clears the stored message if they are deemed to be different (by comparing QoS, topic and payload).
