### PR TITLE
Handle stale stored messages with conflicting message IDs.

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -918,7 +918,6 @@ int db__message_remove_incoming(struct mosquitto* context, uint16_t mid)
 	}
 }
 
-
 int db__message_release_incoming(struct mosquitto *context, uint16_t mid)
 {
 	struct mosquitto_client_msg *tail, *tmp;

--- a/src/handle_publish.c
+++ b/src/handle_publish.c
@@ -285,6 +285,13 @@ int handle__publish(struct mosquitto *context)
 	if(msg->qos > 0){
 		db__message_store_find(context, msg->source_mid, &stored);
 	}
+
+	if (stored && (stored->qos != msg->qos || stored->payloadlen != msg->payloadlen || strcmp(stored->topic, msg->topic) || memcmp(stored->payload, msg->payload, msg->payloadlen))){
+		log__printf(NULL, MOSQ_LOG_WARNING, "Reused message ID from %s detected. Clearing from storage.", context->id);
+		db__message_remove_incoming(context, stored->mid);
+		stored = NULL;
+	}
+
 	if(!stored){
 		if(msg->qos == 0
 				|| db__ready_for_flight(&context->msgs_in, msg->qos)

--- a/src/handle_publish.c
+++ b/src/handle_publish.c
@@ -286,9 +286,9 @@ int handle__publish(struct mosquitto *context)
 		db__message_store_find(context, msg->source_mid, &stored);
 	}
 
-	if (stored && (stored->qos != msg->qos || stored->payloadlen != msg->payloadlen || strcmp(stored->topic, msg->topic) || memcmp(stored->payload, msg->payload, msg->payloadlen))){
-		log__printf(NULL, MOSQ_LOG_WARNING, "Reused message ID from %s detected. Clearing from storage.", context->id);
-		db__message_remove_incoming(context, stored->mid);
+	if (stored && msg->source_mid != 0 && (stored->qos != msg->qos || stored->payloadlen != msg->payloadlen || strcmp(stored->topic, msg->topic) || memcmp(stored->payload, msg->payload, msg->payloadlen) )){
+		log__printf(NULL, MOSQ_LOG_WARNING, "Reused message ID %u from %s detected. Clearing from storage.", msg->source_mid, context->id);
+		db__message_remove_incoming(context, msg->source_mid);
 		stored = NULL;
 	}
 

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -639,6 +639,7 @@ int persist__restore(void);
 int db__message_count(int *count);
 int db__message_delete_outgoing(struct mosquitto *context, uint16_t mid, enum mosquitto_msg_state expect_state, int qos);
 int db__message_insert(struct mosquitto *context, uint16_t mid, enum mosquitto_msg_direction dir, uint8_t qos, bool retain, struct mosquitto_msg_store *stored, mosquitto_property *properties, bool update);
+int db__message_remove_incoming(struct mosquitto* context, uint16_t mid);
 int db__message_release_incoming(struct mosquitto *context, uint16_t mid);
 int db__message_update_outgoing(struct mosquitto *context, uint16_t mid, enum mosquitto_msg_state state, int qos);
 void db__message_dequeue_first(struct mosquitto *context, struct mosquitto_msg_data *msg_data);


### PR DESCRIPTION
Signed-off-by: Vidar Madsen <vidarino@gmail.com>

We're running several Mosquitto instances with bridges between them. At one point one of the bridges stopped working - it disconnected and reconnected repeatedly, never getting messages through, Upon further investigation, we concluded that the following had happened:

1. Broker1 sends a QoS2 message to Broker2.
2. At some point during the PUBREC/PUBREL/PUBCOMP exchange, Broker1 was restarted, and persistent storage was cleared.
3. Broker2 now sits on a stored copy of the message.
4. Broker1 reconnects and proceeds to send messages.
5. Broker1 later sends a QoS1 message with the same ID as in step 1
6. Broker2 finds the old QoS2 message ID in storage and proceeds to reply with a PUBREC.
7. Broker1 receives the PUBREC, but expects a PUBACK and closes the connection due to protocol error.
8. Broker1 reconnects and goes back to step 5.
9. The bridge is now down indefinitely.

We verified this chain of events on a separate test setup, using a modified client that purposefully leaves out the PUBREL/PUBCOMP part. Mosquitto responds with PUBREC on QoS1 messages if it receives a QoS1 message with the same ID as the stored message.

Obviously it's the client's fault for reusing message IDs, but it should be detected and handled in a more graceful manner.

This PR detects mismatches between stored messages and incoming messages and drops the stored message on a mismatch, since it's obviously obsolete.