### PR TITLE
brige: fix backoff not working properly when remote broker rejects connection

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -313,10 +313,8 @@ int bridge__connect_step3(struct mosquitto *context)
 
 	rc = send__connect(context, context->keepalive, context->clean_start, NULL);
 	if(rc == MOSQ_ERR_SUCCESS){
-		bridge__backoff_reset(context);
 		return MOSQ_ERR_SUCCESS;
 	}else if(rc == MOSQ_ERR_ERRNO && errno == ENOTCONN){
-		bridge__backoff_reset(context);
 		return MOSQ_ERR_SUCCESS;
 	}else{
 		if(rc == MOSQ_ERR_TLS){
@@ -454,10 +452,8 @@ int bridge__connect(struct mosquitto *context)
 
 	rc2 = send__connect(context, context->keepalive, context->clean_start, NULL);
 	if(rc2 == MOSQ_ERR_SUCCESS){
-		bridge__backoff_reset(context);
 		return rc;
 	}else if(rc2 == MOSQ_ERR_ERRNO && errno == ENOTCONN){
-		bridge__backoff_reset(context);
 		return MOSQ_ERR_SUCCESS;
 	}else{
 		if(rc2 == MOSQ_ERR_TLS){
@@ -561,6 +557,8 @@ int bridge__on_connect(struct mosquitto *context)
 					qos, 0);
 		}
 	}
+
+	bridge__backoff_reset(context);
 
 	return MOSQ_ERR_SUCCESS;
 }


### PR DESCRIPTION
Current decorrelated jitter backoff mechanism for bridged connections  only applies for connectivity (network) issues. It fails to provide any kind of backoff in cases where the remote broker rejects the connection. This happens because the backoff timer gets prematurely reset before the actual CONNACK gets processed.

This PR fixes that

-----

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
