### PR TITLE
add client properties to plugins

### DIFF
--- a/include/mosquitto_broker.h
+++ b/include/mosquitto_broker.h
@@ -151,6 +151,9 @@ struct mosquitto_evt_message {
 	uint8_t reason_code;
 	bool retain;
 	void *future2[4];
+	char *client_address;
+	char *client_id;
+	char *client_username;
 };
 
 

--- a/plugins/add-user-properties/CMakeLists.txt
+++ b/plugins/add-user-properties/CMakeLists.txt
@@ -1,0 +1,11 @@
+include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/include
+			${STDBOOL_H_PATH} ${STDINT_H_PATH})
+
+add_library(mosquitto_message_timestamp SHARED mosquitto_message_timestamp.c)
+set_target_properties(mosquitto_message_timestamp PROPERTIES
+	POSITION_INDEPENDENT_CODE 1
+)
+set_target_properties(mosquitto_message_timestamp PROPERTIES PREFIX "")
+
+# Don't install, these are example plugins only.
+#install(TARGETS mosquitto_message_timestamp RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/plugins/add-user-properties/Makefile
+++ b/plugins/add-user-properties/Makefile
@@ -1,0 +1,27 @@
+include ../../config.mk
+
+.PHONY : all binary check clean reallyclean test install uninstall
+
+PLUGIN_NAME=add_properties
+
+all : binary
+
+binary : ${PLUGIN_NAME}.so
+
+${PLUGIN_NAME}.so : ${PLUGIN_NAME}.c
+	$(CROSS_COMPILE)$(CC) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) $(PLUGIN_LDFLAGS) -fPIC -shared $< -o $@
+
+reallyclean : clean
+clean:
+	-rm -f *.o ${PLUGIN_NAME}.so *.gcda *.gcno
+
+check: test
+test:
+
+install: ${PLUGIN_NAME}.so
+	# Don't install, these are examples only.
+	#$(INSTALL) -d "${DESTDIR}$(libdir)"
+	#$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"
+
+uninstall :
+	-rm -f "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"

--- a/plugins/add-user-properties/add_properties.c
+++ b/plugins/add-user-properties/add_properties.c
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2020 Roger Light <roger@atchoo.org>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+ 
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+ 
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Contributors:
+   Roger Light - initial implementation and documentation.
+   Simon Christmann - use timestamp in unix epoch milliseconds; add client properties
+*/
+
+/*
+ * Adds MQTT v5 user-properties to incoming messages:
+ *  - $timestamp: unix epoch in milliseconds
+ *  - $client_id: client id of the publishing client
+ *  - $client_username: username that the publishing client used to authenticate
+ *
+ * Compile with:
+ *   gcc -I<path to mosquitto-repo/include> -fPIC -shared add_properties.c -o add_properties.so
+ *
+ * Use in config with:
+ *
+ *   plugin /path/to/add_properties.so
+ *
+ * Note that this only works on Mosquitto 2.0 or later.
+ */
+#include "config.h"
+
+#include <stdio.h>
+#include <time.h>
+
+#include "mosquitto_broker.h"
+#include "mosquitto_plugin.h"
+#include "mosquitto.h"
+#include "mqtt_protocol.h"
+
+#define TS_BUF_LEN (14+1)  // 14 characters in unix epoch (ms) is ≈16 Nov 5138
+
+static mosquitto_plugin_id_t *mosq_pid = NULL;
+
+static int callback_message(int event, void *event_data, void *userdata)
+{
+	struct mosquitto_evt_message *ed = event_data;
+
+	UNUSED(event);
+	UNUSED(userdata);
+
+	int result;
+
+	// Add timestamp in unix epoch (ms)
+	struct timespec ts;
+	char ts_buf[TS_BUF_LEN];
+	clock_gettime(CLOCK_REALTIME, &ts);
+	snprintf(ts_buf, TS_BUF_LEN, "%li%03lu", ts.tv_sec, ts.tv_nsec / 1000 / 1000);
+	
+	result = mosquitto_property_add_string_pair(
+		&ed->properties,
+		MQTT_PROP_USER_PROPERTY,
+		"$timestamp",
+		ts_buf);
+	if (result != MOSQ_ERR_SUCCESS) return result;
+
+	// Add client id
+	result = mosquitto_property_add_string_pair(
+		&ed->properties,
+		MQTT_PROP_USER_PROPERTY,
+		"$client_id",
+		ed->client_id);
+	if (result != MOSQ_ERR_SUCCESS) return result;
+
+	// Add client username
+	result = mosquitto_property_add_string_pair(
+		&ed->properties,
+		MQTT_PROP_USER_PROPERTY,
+		"$client_username",
+		ed->client_id);
+	if (result != MOSQ_ERR_SUCCESS) return result;
+
+	// If no return occurred up to this point, we were successful
+	return MOSQ_ERR_SUCCESS;
+}
+
+int mosquitto_plugin_version(int supported_version_count, const int *supported_versions)
+{
+	int i;
+
+	for(i=0; i<supported_version_count; i++){
+		if(supported_versions[i] == 5){
+			return 5;
+		}
+	}
+	return -1;
+}
+
+int mosquitto_plugin_init(mosquitto_plugin_id_t *identifier, void **user_data, struct mosquitto_opt *opts, int opt_count)
+{
+	UNUSED(user_data);
+	UNUSED(opts);
+	UNUSED(opt_count);
+
+	mosq_pid = identifier;
+	return mosquitto_callback_register(mosq_pid, MOSQ_EVT_MESSAGE, callback_message, NULL, NULL);
+}
+
+int mosquitto_plugin_cleanup(void *user_data, struct mosquitto_opt *opts, int opt_count)
+{
+	UNUSED(user_data);
+	UNUSED(opts);
+	UNUSED(opt_count);
+
+	return mosquitto_callback_unregister(mosq_pid, MOSQ_EVT_MESSAGE, callback_message, NULL);
+}

--- a/plugins/printf-example/CMakeLists.txt
+++ b/plugins/printf-example/CMakeLists.txt
@@ -1,0 +1,15 @@
+include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/include
+			${STDBOOL_H_PATH} ${STDINT_H_PATH})
+link_directories(${mosquitto_SOURCE_DIR})
+
+add_library(mosquitto_payload_modification SHARED mosquitto_payload_modification.c)
+set_target_properties(mosquitto_payload_modification PROPERTIES
+	POSITION_INDEPENDENT_CODE 1
+)
+set_target_properties(mosquitto_payload_modification PROPERTIES PREFIX "")
+if(WIN32)
+	target_link_libraries(mosquitto_payload_modification mosquitto)
+endif(WIN32)
+
+# Don't install, these are example plugins only.
+#install(TARGETS mosquitto_payload_modification RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/plugins/printf-example/Makefile
+++ b/plugins/printf-example/Makefile
@@ -1,0 +1,27 @@
+include ../../config.mk
+
+.PHONY : all binary check clean reallyclean test install uninstall
+
+PLUGIN_NAME=printf_example
+
+all : binary
+
+binary : ${PLUGIN_NAME}.so
+
+${PLUGIN_NAME}.so : ${PLUGIN_NAME}.c
+	$(CROSS_COMPILE)$(CC) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) $(PLUGIN_LDFLAGS) -fPIC -shared $< -o $@
+
+reallyclean : clean
+clean:
+	-rm -f *.o ${PLUGIN_NAME}.so *.gcda *.gcno
+
+check: test
+test:
+
+install: ${PLUGIN_NAME}.so
+	# Don't install, these are examples only.
+	#$(INSTALL) -d "${DESTDIR}$(libdir)"
+	#$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"
+
+uninstall :
+	-rm -f "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"

--- a/plugins/printf-example/printf_example.c
+++ b/plugins/printf-example/printf_example.c
@@ -1,0 +1,70 @@
+/*
+ * This is an *example* plugin which prints information of a message after it is
+ * received by the broker and before it is sent on to other clients. 
+ *
+ * Compile with:
+ *   gcc -I<path to mosquitto-repo/include> -fPIC -shared printf_example.c -o printf_example.so
+ *
+ * Use in config with:
+ *
+ *   plugin /path/to/printf_example.so
+ *
+ * Note that this only works on Mosquitto 2.0 or later.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "mosquitto_broker.h"
+#include "mosquitto_plugin.h"
+#include "mosquitto.h"
+#include "mqtt_protocol.h"
+
+#define UNUSED(A) (void)(A)
+
+static mosquitto_plugin_id_t *mosq_pid = NULL;
+
+static int callback_message(int event, void *event_data, void *userdata)
+{
+	struct mosquitto_evt_message *ed = event_data;
+
+	UNUSED(event);
+	UNUSED(userdata);
+
+	printf("client address: %s\n", ed->client_address);
+	printf("client id: %s\n", ed->client_id);
+	printf("client username: %s\n", ed->client_username);
+	printf("payload: '%.*s'\n", ed->payloadlen, (char *)ed->payload);
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+int mosquitto_plugin_version(int supported_version_count, const int *supported_versions)
+{
+	int i;
+
+	for(i=0; i<supported_version_count; i++){
+		if(supported_versions[i] == 5){
+			return 5;
+		}
+	}
+	return -1;
+}
+
+int mosquitto_plugin_init(mosquitto_plugin_id_t *identifier, void **user_data, struct mosquitto_opt *opts, int opt_count)
+{
+	UNUSED(user_data);
+	UNUSED(opts);
+	UNUSED(opt_count);
+
+	mosq_pid = identifier;
+	return mosquitto_callback_register(mosq_pid, MOSQ_EVT_MESSAGE, callback_message, NULL, NULL);
+}
+
+int mosquitto_plugin_cleanup(void *user_data, struct mosquitto_opt *opts, int opt_count)
+{
+	UNUSED(user_data);
+	UNUSED(opts);
+	UNUSED(opt_count);
+
+	return mosquitto_callback_unregister(mosq_pid, MOSQ_EVT_MESSAGE, callback_message, NULL);
+}

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -177,6 +177,9 @@ int plugin__handle_message(struct mosquitto *context, struct mosquitto_msg_store
 	event_data.qos = stored->qos;
 	event_data.retain = stored->retain;
 	event_data.properties = stored->properties;
+	event_data.client_address = context->address;
+	event_data.client_id = context->id;
+	event_data.client_username = context->username;
 
 	DL_FOREACH(opts->plugin_callbacks.message, cb_base){
 		rc = cb_base->cb(MOSQ_EVT_MESSAGE, &event_data, cb_base->userdata);


### PR DESCRIPTION
## Before

Before it was not possible to obtain client information from within a message callback, see [example repository](https://github.com/dersimn/mosquitto-plugin-sandbox/tree/master):

```c
static int callback_message(int event, void *event_data, void *userdata) {
	struct mosquitto_evt_message *ed = (mosquitto_evt_message*)event_data;

	/*
		For some reason struct obtained with this 'Hack' is shifted.
		Maybe lib/mosquitto_internal.h -> stuct mosquitto is compiled with different preprocessor ifdefs?
	*/
	printf("by-struct id: %s\n", ed->client->id);                   // prints IP address
	printf("by-struct username: %s\n", ed->client->username);	// prints client id
	printf("by-struct password: %s\n", ed->client->password);	// prints username
	
	// workaround: Find base by tria & error:
	char **base = &ed->client->id;

	printf("by-base address: %s\n", base[0]);
	printf("by-base id: %s\n", base[1]);
	printf("by-base username: %s\n", base[2]);
	printf("by-base password: %s\n", base[3]);

	printf("payload: '%.*s'\n", ed->payloadlen, (char *)ed->payload);

	return MOSQ_ERR_SUCCESS;
}

// ...

mosquitto_callback_register(mosq_pid, MOSQ_EVT_MESSAGE, callback_message, NULL, NULL);
```

Output:
```
by-struct id: 192.168.161.1
by-struct username: someClient
by-struct password: someUser
by-base address: 192.168.161.1
by-base id: someClient
by-base username: someUser
by-base password: somePassword
payload: 'someMessage'
```

This is probably because we have no information about the struct `ed→client` (types are [mosquitto_evt_message](https://github.com/eclipse/mosquitto/blob/9f21a43eeeafdbb998409d075b986df23c18e649/include/mosquitto_broker.h#L141) → [mosquitto](https://github.com/eclipse/mosquitto/blob/9f21a43eeeafdbb998409d075b986df23c18e649/lib/mosquitto_internal.h#L209)) without including `mosquitto_internal.h` (which seems to be an internal header file, that is not supposed to be used from within a plugin). If you include this header file anyways using a [small hack](https://github.com/dersimn/mosquitto-plugin-sandbox/commit/b73ede6da94965e683f8e0d9abb5052018f90c0a) it leads to the shifting issue above, probably because we don't match all the `#ifdef` conditionals defined in [`struct mosquitto`](https://github.com/eclipse/mosquitto/blob/9f21a43eeeafdbb998409d075b986df23c18e649/lib/mosquitto_internal.h#L210).

## After
See [example repository](https://github.com/dersimn/mosquitto-plugin-sandbox/tree/mosquitto-mod):

```c
static int callback_message(int event, void *event_data, void *userdata) {
	struct mosquitto_evt_message *ed = (mosquitto_evt_message*)event_data;

	printf("client address: %s\n", ed->client_address);
	printf("client id: %s\n", ed->client_id);
	printf("client username: %s\n", ed->client_username);
	printf("payload: '%.*s'\n", ed->payloadlen, (char *)ed->payload);

	return MOSQ_ERR_SUCCESS;
}
```

This comes in handy for e.g. if you want to tag incoming messages with information about the publishing client, see example plugin ["add-user-properties"](https://github.com/dersimn/mosquitto/blob/efe1beb982dd8d2a1d5d48f3495a8d73835195d9/plugins/add-user-properties/add_properties.c#L49) which adds these information to outgoing messages as MQTTv5 user properties, resulting in messages like:
```javascript
Packet {
  cmd: 'publish',
  retain: false,
  qos: 0,
  dup: false,
  length: 143,
  topic: 'some/topic',
  payload: <Buffer 73 6f 6d 65 4d 65 73 73 61 67 65>,
  properties: {
    userProperties: [Object: null prototype] {
      foo: 'bar',
      foo_num: '42',
      '$timestamp': '1615989213367',
      '$client_id': 'someClientId',
      '$client_username': 'someUsername'
    }
  }
}
```