### PR TITLE
fix duplication of messages during connect

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1787,6 +1787,8 @@ Client library:
 - Add support for MQTT v3.1.1.
 - Don't quit mosquitto_loop_forever() if broker not available on first
   connect. Closes bug #453293, but requires more work.
+- Don't reset queued messages state on CONNACK. Fixes bug with duplicate
+  messages on connection.
 
 
 1.3.5 - 20141008

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -189,7 +189,7 @@ static int mosquitto__reconnect(struct mosquitto *mosq, bool blocking)
 
 	packet__cleanup_all(mosq);
 
-	message__reconnect_reset(mosq);
+	message__reconnect_reset(mosq, false);
 
 	if(mosq->sock != INVALID_SOCKET){
         net__socket_close(mosq); //close socket

--- a/lib/handle_connack.c
+++ b/lib/handle_connack.c
@@ -106,7 +106,7 @@ int handle__connack(struct mosquitto *mosq)
 	mosquitto_property_read_int32(properties, MQTT_PROP_MAXIMUM_PACKET_SIZE, &mosq->maximum_packet_size, false);
 
 	mosq->msgs_out.inflight_quota = mosq->msgs_out.inflight_maximum;
-	message__reconnect_reset(mosq);
+	message__reconnect_reset(mosq, true);
 
 	connack_callback(mosq, reason_code, connect_flags, properties);
 	mosquitto_property_free_all(&properties);

--- a/lib/messages_mosq.h
+++ b/lib/messages_mosq.h
@@ -25,7 +25,7 @@ void message__cleanup_all(struct mosquitto *mosq);
 void message__cleanup(struct mosquitto_message_all **message);
 int message__delete(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg_direction dir, int qos);
 int message__queue(struct mosquitto *mosq, struct mosquitto_message_all *message, enum mosquitto_msg_direction dir);
-void message__reconnect_reset(struct mosquitto *mosq);
+void message__reconnect_reset(struct mosquitto *mosq, bool update_quota_only);
 int message__release_to_inflight(struct mosquitto *mosq, enum mosquitto_msg_direction dir);
 int message__remove(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg_direction dir, struct mosquitto_message_all **message, int qos);
 void message__retry_check(struct mosquitto *mosq);


### PR DESCRIPTION
On recent libmosquitto versions, messages on the output queue are sent twice, one time between CONNECT and CONNACK, and another time after CONNACK.

Bisecting the code changes, I was able to pinpoint the issue being introduced at: 298d84941ed673ea386c886bb9dda9b0ed18cc61

This pull request fixes the issue by avoiding resetting the state of the queued messages during CONNACK.

-----

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
