### PR TITLE
Fully empty sockpairR on interruptible_sleep

### DIFF
--- a/lib/loop.c
+++ b/lib/loop.c
@@ -204,10 +204,9 @@ static int interruptible_sleep(struct mosquitto *mosq, time_t reconnect_delay)
 	int maxfd = 0;
 
 #ifndef WIN32
-	if(read(mosq->sockpairR, &pairbuf, 1) == 0){
-	}
+	while(read(mosq->sockpairR, &pairbuf, 1) > 0);
 #else
-	recv(mosq->sockpairR, &pairbuf, 1, 0);
+	while(recv(mosq->sockpairR, &pairbuf, 1, 0) > 0);
 #endif
 
 	local_timeout.tv_sec = reconnect_delay;


### PR DESCRIPTION
In commit a3ebeff9d732458a4dac7513fac10a52a97cf4d1 libmosquitto starting misbehaving during backoff. The new behavior, a total skip of the backoff, could be seen when messages were in the output queue.

This was fixed in f8838243fbb9689ce4195a6fbbb499ba477d1c65. This pull request is an improvement on top of that fix, by guaranteeing sockpairR is totally empty before waiting on it.

-----

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
