### PR TITLE
add cipher settings for bridge, and support for TLS 1.3 ciphers

### DIFF
--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -254,6 +254,7 @@ struct mosquitto {
 	int (*tls_pw_callback)(char *buf, int size, int rwflag, void *userdata);
 	char *tls_version;
 	char *tls_ciphers;
+	char *tls_13_ciphers;
 	char *tls_psk;
 	char *tls_psk_identity;
 	char *tls_engine;

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -760,6 +760,17 @@ static int net__init_ssl_ctx(struct mosquitto *mosq)
 				return MOSQ_ERR_TLS;
 			}
 		}
+
+#if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
+		if(mosq->tls_13_ciphers){
+			ret = SSL_CTX_set_ciphersuites(mosq->ssl_ctx, mosq->tls_13_ciphers);
+			if(ret == 0){
+				log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to set TLS 1.3 ciphersuites. Check cipher_tls13 list \"%s\".", mosq->tls_13_ciphers);
+				return MOSQ_ERR_TLS;
+			}
+		}
+#endif
+
 		if(mosq->tls_cafile || mosq->tls_capath || mosq->tls_use_os_certs){
 			ret = net__tls_load_ca(mosq);
 			if(ret != MOSQ_ERR_SUCCESS){

--- a/lib/options.c
+++ b/lib/options.c
@@ -231,13 +231,19 @@ int mosquitto_tls_opts_set(struct mosquitto *mosq, int cert_reqs, const char *tl
 		mosq->tls_version = mosquitto__strdup("tlsv1.2");
 		if(!mosq->tls_version) return MOSQ_ERR_NOMEM;
 	}
-	if(ciphers){
-		mosq->tls_ciphers = mosquitto__strdup(ciphers);
-		if(!mosq->tls_ciphers) return MOSQ_ERR_NOMEM;
-	}else{
-		mosq->tls_ciphers = NULL;
-	}
 
+	mosq->tls_ciphers = NULL;
+	mosq->tls_13_ciphers = NULL;
+
+	if(ciphers){
+		if(!strcasecmp(tls_version, "tlsv1.3")){
+			mosq->tls_13_ciphers = mosquitto__strdup(ciphers);
+			if(!mosq->tls_13_ciphers) return MOSQ_ERR_NOMEM;
+		}else{
+			mosq->tls_ciphers = mosquitto__strdup(ciphers);
+			if(!mosq->tls_ciphers) return MOSQ_ERR_NOMEM;
+		}
+	}
 
 	return MOSQ_ERR_SUCCESS;
 #else

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -2006,6 +2006,24 @@ topic clients/total in 0 test/mosquitto/org/ $SYS/broker/
 					<para>Defaults to <replaceable>true</replaceable>.</para>
 				</listitem>
 			</varlistentry>
+			<varlistentry>
+				<term><option>bridge_reload_type</option> [ lazy | immediate ]</term>
+				<listitem>
+					<para>If you change bridge options in the configuration file,
+					those configuration changes are applied during a bridge
+					reconnection. The <option>bridge_reload_type</option> option
+					determines when that reconnection happens, and can be set to either
+					<replaceable>lazy</replaceable> or <replaceable>immediate</replaceable>.</para>
+
+					<para><replaceable>lazy</replaceable> is the default, and means
+					that any connected bridge will remain in its current state until
+					a natural reconnection happens, at which point the new configuration
+					will be used.</para>
+
+					<para><replaceable>immediate</replaceable> forces a reconnection and so
+					uses the new configuration straight away.</para>
+				</listitem>
+			</varlistentry>
 		</variablelist>
 		<refsect2>
 			<title>SSL/TLS Support</title>
@@ -2108,24 +2126,6 @@ topic clients/total in 0 test/mosquitto/org/ $SYS/broker/
 					</listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>bridge_reload_type</option> [ lazy | immediate ]</term>
-					<listitem>
-						<para>If you change bridge options in the configuration file,
-						those configuration changes are applied during a bridge
-						reconnection. The <option>bridge_reload_type</option> option
-						determines when that reconnection happens, and can be set to either
-						<replaceable>lazy</replaceable> or <replaceable>immediate</replaceable>.</para>
-
-						<para><replaceable>lazy</replaceable> is the default, and means
-						that any connected bridge will remain in its current state until
-						a natural reconnection happens, at which point the new configuration
-						will be used.</para>
-
-						<para><replaceable>immediate</replaceable> forces a reconnection and so
-						uses the new configuration straight away.</para>
-					</listitem>
-				</varlistentry>
-				<varlistentry>
 					<term><option>bridge_require_ocsp</option> [ true | false ]</term>
 					<listitem>
 						<para>When set to true, the bridge requires OCSP on the TLS
@@ -2145,6 +2145,27 @@ topic clients/total in 0 test/mosquitto/org/ $SYS/broker/
 							connection to succeed.</para>
 					</listitem>
 				</varlistentry>
+				<varlistentry>
+					<term><option>bridge_ciphers</option> <replaceable>cipher:list</replaceable></term>
+					<listitem>
+						<para>
+							The list of allowed ciphers for this bridge, for
+							TLS v1.2 and earlier only, each separated with
+							a colon. Available ciphers can be obtained using
+							the "openssl ciphers" command.
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
+					<term><option>bridge_ciphers_tls1.3</option> <replaceable>cipher:list</replaceable></term>
+					<listitem>
+						<para>
+							The list of allowed ciphersuites for this bridge,
+							for TLS v1.3, each separated with a colon.
+						</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
 			</variablelist>
 		</refsect2>
 	</refsect1>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -300,6 +300,10 @@
 # Path to the PEM encoded keyfile.
 #keyfile
 
+# Configure the minimum version of the TLS protocol to be used for this listener.
+# Possible values are tlsv1.3, tlsv1.2 and tlsv1.1.
+#tls_version tlsv1.2
+
 # If you wish to control which encryption ciphers are used, use the ciphers
 # option. The list of available ciphers can be optained using the "openssl
 # ciphers" command and should be provided in the same format as the output of
@@ -878,6 +882,9 @@
 # requested. Note that WebSockets support for bridges is not yet available.
 #bridge_alpn
 
+# Require the use of Online Certificate Status Protocol (OCSP) for this bridge
+#bridge_require_ocsp false
+
 # When using certificate based encryption, bridge_insecure disables
 # verification of the server hostname in the server certificate. This can be
 # useful when testing initial server configurations, but makes it possible for
@@ -892,6 +899,22 @@
 
 # Path to the PEM encoded client private key, if required by the remote broker.
 #bridge_keyfile
+
+# Configure the version of the TLS protocol to be used for this bridge.
+# Possible values are tlsv1.3, tlsv1.2 and tlsv1.1. Defaults to tlsv1.2.
+# The remote broker must support the same version of TLS for the connection to succeed.
+#bridge_tls_version
+
+# If you wish to control which encryption ciphers are used, use the ciphers
+# option. The list of available ciphers can be optained using the "openssl
+# ciphers" command and should be provided in the same format as the output of
+# that command. This applies to TLS 1.2 and earlier versions only. Use
+# bridge_ciphers_tls1.3 for TLS v1.3.
+#bridge_ciphers
+
+# Choose which TLS v1.3 ciphersuites are used for this bridge.
+# Defaults to "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+#bridge_ciphers_tls1.3
 
 # -----------------------------------------------------------------
 # PSK based SSL/TLS support

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -99,6 +99,8 @@ static struct mosquitto *bridge__new(struct mosquitto__bridge *bridge)
 	new_context->tls_version = bridge->tls_version;
 	new_context->tls_insecure = bridge->tls_insecure;
 	new_context->tls_alpn = bridge->tls_alpn;
+	new_context->tls_ciphers = bridge->tls_ciphers;
+	new_context->tls_13_ciphers = bridge->tls_13_ciphers;
 	new_context->tls_engine = db.config->default_listener.tls_engine;
 	new_context->tls_keyform = db.config->default_listener.tls_keyform;
 #ifdef FINAL_WITH_TLS_PSK

--- a/src/conf.c
+++ b/src/conf.c
@@ -989,6 +989,26 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, struct
 #else
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge and/or TLS support not available.");
 #endif
+				}else if(!strcmp(token, "bridge_ciphers")){
+#if defined(WITH_BRIDGE) && defined(WITH_TLS)
+					if(!cur_bridge){
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge configuration.");
+						return MOSQ_ERR_INVAL;
+					}
+					if(conf__parse_string(&token, "bridge_ciphers", &cur_bridge->tls_ciphers, &saveptr)) return MOSQ_ERR_INVAL;
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge and/or TLS support not available.");
+#endif
+				}else if(!strcmp(token, "bridge_ciphers_tls1.3")){
+#if defined(WITH_BRIDGE) && defined(WITH_TLS)
+					if(!cur_bridge){
+						log__printf(NULL, MOSQ_LOG_ERR, "Error: Invalid bridge configuration.");
+						return MOSQ_ERR_INVAL;
+					}
+					if(conf__parse_string(&token, "bridge_ciphers_tls1.3", &cur_bridge->tls_13_ciphers, &saveptr)) return MOSQ_ERR_INVAL;
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge and/or TLS support not available.");
+#endif
 				}else if(!strcmp(token, "bridge_bind_address")){
 #if defined(WITH_BRIDGE) && defined(WITH_TLS)
 					if(reload) continue; /* FIXME */

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -566,6 +566,8 @@ struct mosquitto__bridge{
 	char *tls_keyfile;
 	char *tls_version;
 	char *tls_alpn;
+	char *tls_ciphers;
+	char *tls_13_ciphers;
 #  ifdef FINAL_WITH_TLS_PSK
 	char *tls_psk_identity;
 	char *tls_psk;


### PR DESCRIPTION
Current configuration of bridges does not allow specifying ciphers, this PR adds support for it.

TLS 1.3 requires using SSL_CTX_set_ciphersuites instead of SSL_CTX_set_cipher_list, this PR also covers that.

Updated documentation.

-----

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [N/A] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
