### PR TITLE
Print JSON binary data as unsigned int array

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -37,6 +37,9 @@ Clients:
   that instance. This is useful for negating TLS options provided in a config
   file, or to disable the automatic use of TLS when using port 8883.
   Closes #2180.
+- When `mosquitto_sub` is instructed to print messages as JSON via `-F %j` it
+  will try to figure out whether the payload is printable into a string. If not,
+  it will print the payload into an array of unsigned integers.
 
 
 2.0.10 - 2021-04-03


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----

Follow up on #2213. The current state is, that I try to find a way to validate a given string for UTF-8 correctness without having to depend on another library. 

A possible route might be [iswprint](https://www.cplusplus.com/reference/cwctype/iswprint/) , but that seems to be dependent on the users locale.