### PR TITLE
WiP: enable sandboxing for mosquitto systemd service

### DIFF
--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -7,13 +7,64 @@ Wants=network.target
 [Service]
 Type=notify
 NotifyAccess=main
+
+User=mosquitto
+Group=mosquitto
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
-ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
-ExecStartPre=/bin/chown mosquitto /var/log/mosquitto
-ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto
-ExecStartPre=/bin/chown mosquitto /run/mosquitto
+
+# vvv EXPERIMENTAL vvv
+# mount empty, read-only tmpfs on / and bind mosquitto and dependencies
+# NOTE: conflicts with ProtectSystem= (which binds original rootfs on top of /)
+#       and restrictive UMask= (Bind*= directives will create parent directories
+#       owned by root:root and with configured umask, which may make parents
+#       inaccessible to services not running as root)
+#TemporaryFileSystem=/:ro
+#BindReadOnlyPaths=/bin/kill /etc/group /etc/hosts.allow /etc/hosts.deny /etc/ld.so.cache /etc/passwd /lib/x86_64-linux-gnu /lib64 /run/systemd/notify /usr/sbin/mosquitto
+# ^^^ EXPERIMENTAL ^^^
+
+# bind/create mosquitto directories in /etc, /run, /var/lib, and /var/log
+ConfigurationDirectory=mosquitto
+ConfigurationDirectoryMode=755
+RuntimeDirectory=mosquitto
+RuntimeDirectoryMode=740
+StateDirectory=mosquitto
+StateDirectoryMode=740
+LogsDirectory=mosquitto
+LogsDirectoryMode=740
+
+# drop as many privileges as possible (see `systemd-analyze security
+# mosquitto.service` for suggestions)
+CapabilityBoundingSet=
+DevicePolicy=closed
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=yes
+# AF_UNIX is required for sd_notify(3)
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+UMask=027
+
+# whitelist syscalls required by mosquitto
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @default @file-system @io-event @network-io @signal @sync arch_prctl getrandom kill mprotect prctl umask
 
 [Install]
 WantedBy=multi-user.target

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -5,13 +5,62 @@ After=network.target
 Wants=network.target
 
 [Service]
+User=mosquitto
+Group=mosquitto
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
-ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
-ExecStartPre=/bin/chown mosquitto /var/log/mosquitto
-ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto
-ExecStartPre=/bin/chown mosquitto /run/mosquitto
+
+# vvv EXPERIMENTAL vvv
+# mount empty, read-only tmpfs on / and bind mosquitto and dependencies
+# NOTE: conflicts with ProtectSystem= (which binds original rootfs on top of /)
+#       and restrictive UMask= (Bind*= directives will create parent directories
+#       owned by root:root and with configured umask, which may make parents
+#       inaccessible to services not running as root)
+#TemporaryFileSystem=/:ro
+#BindReadOnlyPaths=/bin/kill /etc/group /etc/hosts.allow /etc/hosts.deny /etc/ld.so.cache /etc/passwd /lib/x86_64-linux-gnu /lib64 /run/systemd/notify /usr/sbin/mosquitto
+# ^^^ EXPERIMENTAL ^^^
+
+# bind/create mosquitto directories in /etc, /run, /var/lib, and /var/log
+ConfigurationDirectory=mosquitto
+ConfigurationDirectoryMode=755
+RuntimeDirectory=mosquitto
+RuntimeDirectoryMode=740
+StateDirectory=mosquitto
+StateDirectoryMode=740
+LogsDirectory=mosquitto
+LogsDirectoryMode=740
+
+# drop as many privileges as possible (see `systemd-analyze security
+# mosquitto.service` for suggestions)
+CapabilityBoundingSet=
+DevicePolicy=closed
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=yes
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+UMask=027
+
+# whitelist syscalls required by mosquitto
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @default @file-system @io-event @network-io @signal @sync arch_prctl getrandom kill mprotect prctl umask
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Systemd has supported various [sandboxing features](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing) and [seccomp syscall filtering](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#System%20Call%20Filtering) for services for a while now. As a network facing daemon, mosquitto could benefit from using both features to reduce the potential impact of security vulnerabilities.

This pull request modifies the systemd `.service` files to make use of both features. It enables everything that `systemd-analyze security` suggests (except for features that would interfere with mosquitto's operation, of course) and also sets a syscall whitelist based on syscalls made by mosquitto during normal operation (see below for details). Therefore, the list may be short a few sparely used syscalls.

The pull request also includes a highly experimental idea to reduce the potential extent of information disclosure even further. By using `TemporaryFileSystem=/:ro` to mount a read-only tmpfs on `/` and then binding only files/directories required to run mosquitto into that tmpfs, the majority of the actual root file system is inaccessible to mosquitto. Even though I'm using it, I don't consider it ready for upstream use, because it interferes with systemd's `ProtectSystem` and is likely specific to Debian and x86-64. Therefore, it is commented out.

How was this tested: Since I did not modify the source code, I did not run `make test` as requested. I also only tried it with mosquitto 2.0.10-6 on Debian Sid when run with the default configuration and only with a pair of `mosquitto_pub` and `mosquitto_sub` clients. If you're interested in merging this PR, I could invest more time into tests, of course.
