### PR TITLE
Disable HTTP2 when building libwebsockets for docker images.

### DIFF
--- a/docker/1.5-openssl/Dockerfile
+++ b/docker/1.5-openssl/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x && \
         -DLWS_WITHOUT_CLIENT=ON \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \

--- a/docker/1.5/Dockerfile
+++ b/docker/1.5/Dockerfile
@@ -30,6 +30,7 @@ RUN set -x && \
         -DLWS_WITHOUT_CLIENT=ON \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \

--- a/docker/1.6-openssl/Dockerfile
+++ b/docker/1.6-openssl/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x && \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
         -DLWS_WITH_EXTERNAL_POLL=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \

--- a/docker/1.6/Dockerfile
+++ b/docker/1.6/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x && \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
         -DLWS_WITH_EXTERNAL_POLL=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \

--- a/docker/2.0-openssl/Dockerfile
+++ b/docker/2.0-openssl/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x && \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
         -DLWS_WITH_EXTERNAL_POLL=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \

--- a/docker/2.0/Dockerfile
+++ b/docker/2.0/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x && \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
         -DLWS_WITH_EXTERNAL_POLL=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \

--- a/docker/generic/Dockerfile
+++ b/docker/generic/Dockerfile
@@ -37,6 +37,7 @@ RUN set -x && \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
         -DLWS_WITH_EXTERNAL_POLL=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x && \
         -DLWS_WITHOUT_EXTENSIONS=ON \
         -DLWS_WITHOUT_TESTAPPS=ON \
         -DLWS_WITH_EXTERNAL_POLL=ON \
+        -DLWS_WITH_HTTP2=OFF \
         -DLWS_WITH_SHARED=OFF \
         -DLWS_WITH_ZIP_FOPS=OFF \
         -DLWS_WITH_ZLIB=OFF && \


### PR DESCRIPTION
As reported in #1211, Firefox cannot connect over websocekts with TLS when using HTTP2. Without HTTP2 support in libwebsockets the connections fallback to HTTP and are able to complete.

This work around has been successfully used by multiple commenters and tests well. This pull requests implements the work around when building Docker images.

Signed-off-by: Tom Parker <tparker@usgs.gov>
