### PR TITLE
Add `mosquitto_set_clientid` function for plugins.

### DIFF
--- a/include/mosquitto_broker.h
+++ b/include/mosquitto_broker.h
@@ -462,6 +462,21 @@ mosq_EXPORT const char *mosquitto_client_username(const struct mosquitto *client
  */
 mosq_EXPORT int mosquitto_set_username(struct mosquitto *client, const char *username);
 
+/* Function: mosquitto_set_clientid
+ *
+ * Set the client id for a client.
+ *
+ * This effectively forces the client onto another message queue.
+ * Can be used to scope client ids by prefixing the client id with some user-specific data.
+ * eg. "client1" could become "user1-client1".
+ *
+ * Returns:
+ *   MOSQ_ERR_SUCCESS - on success
+ *   MOSQ_ERR_INVAL - if client is NULL, or if clientid is not a valid utf-8 string
+ *   MOSQ_ERR_NOMEM - on out of memory
+ */
+mosq_EXPORT int mosquitto_set_clientid(struct mosquitto *client, const char *clientid);
+
 
 /* =========================================================================
  *

--- a/src/linker-macosx.syms
+++ b/src/linker-macosx.syms
@@ -29,6 +29,7 @@ _mosquitto_property_free_all
 _mosquitto_pub_topic_check
 _mosquitto_realloc
 _mosquitto_set_username
+_mosquitto_set_clientid
 _mosquitto_strdup
 _mosquitto_sub_matches_acl
 _mosquitto_sub_matches_acl_with_pattern

--- a/src/linker.syms
+++ b/src/linker.syms
@@ -30,6 +30,7 @@
 	mosquitto_pub_topic_check;
 	mosquitto_realloc;
 	mosquitto_set_username;
+	mosquitto_set_clientid;
 	mosquitto_strdup;
 	mosquitto_sub_matches_acl;
 	mosquitto_sub_matches_acl_with_pattern;

--- a/src/plugin_public.c
+++ b/src/plugin_public.c
@@ -268,6 +268,28 @@ int mosquitto_set_username(struct mosquitto *client, const char *username)
 	}
 }
 
+int mosquitto_set_clientid(struct mosquitto *client, const char *clientid)
+{
+    char *u_dup;
+    char *old;
+
+    if(!client) return MOSQ_ERR_INVAL;
+
+    int clientid_len = (int)strlen(clientid);
+    if(mosquitto_validate_utf8(clientid, clientid_len)){
+        return MOSQ_ERR_INVAL;
+    }
+
+    u_dup = mosquitto__strdup(clientid);
+    if(!u_dup) return MOSQ_ERR_NOMEM;
+
+
+    old = client->id;
+    client->id = u_dup;
+
+    mosquitto__free(old);
+    return MOSQ_ERR_SUCCESS;
+}
 
 static void disconnect_client(struct mosquitto *context, bool with_will)
 {


### PR DESCRIPTION
Signed-off-by: Tobias Assarsson <tobias.assarsson@gmail.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----

This is an implementation for feature request #2033

There seem to be some missing flags here and there to add include path for vendored uthash, unrelated to this PR.
I did not include any of those fixes here as they are a different problem.

running `CFLAGS="-I `pwd`/deps" make test` got the tests running, but failed on
```
./02-subscribe-qos1.py c/02-subscribe-qos1-async2.test
connect_async failed: Connection refused
Traceback (most recent call last):
  File "/home/tux/src/git/github.com/eclipse/mosquitto/test/lib/./02-subscribe-qos1.py", line 47, in <module>
    (conn, address) = sock.accept()
  File "/usr/lib/python3.9/socket.py", line 293, in accept
    fd, addr = self._accept()
socket.timeout: timed out
```

This problem also seem unrelated to the changes made here.
