### PR TITLE
Update 'last_msg' after removal of messages that are no longer allowe…

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -735,6 +735,8 @@ int db__message_reconnect_reset(struct mosquitto_db *db, struct mosquitto *conte
 	context->msg_bytes12 = 0;
 	context->msg_count = 0;
 	context->msg_count12 = 0;
+	context->last_inflight_msg = NULL;
+	context->last_queued_msg = NULL;
 	while(msg){
 		context->last_inflight_msg = msg;
 


### PR DESCRIPTION
1) This patch fixes issue which occurs when there are changes in ACL list and last_msg is not updated properly. Corresponding last_msg should be updated when current last_msg is deleted from corresponding list (inflight_msgs/queued_msgs).
If this issue occurs, later on, when we try to insert new message in inflight_msgs/queued_msgs list in 'db__message_insert', message is added in list after non-valid last_inflight_msg/last_queued_msg pointer. At this point  last_inflight_msg/last_queued_msg pointer is not even in inflight_msgs/queued_msgs list anymore at all and these messages are never published to clients. Changes that are necessary to fix this issue are in handle_connect.c. This change is verified within our internal project.

This issue is noticed on 1.5.x branch.


2) Additionally, while debugging this issue I have encountered another potential issue as well. Before calling 'db__message_reconnect_reset' is it possible that context->inflight_msgs or context->queued_msgs contain any messages already? If so, last_msgs should be initialized to NULL as well as in 'db__message_reconnect_reset' inflight_msgs or queued_msgs might be empty and not update their corresponding last_msg. In that case there might be a memory leak as well as I don't see that current context->inflight_msgs and context->queued_msg are free()-ing list elements anywhere. Fix for this potential issue of not updating 'last_msg' is added in 'database.c. Fix for potential memory leak isn't.
Anyway, even if this use case cannot occur in practice (that context->inflight_msgs  and context->queued_msgs contain anything at this point) initializing these 'last_msg' pointers won't do any harm. Anyway, if you think that this part of this patch is obsolete this part of the patch can be removed. 
If its possible that this occurs it will lead to same situation as we had with issue mentioned in 1).


-----
