### PR TITLE
Call disconnect callback on TLS error.

### DIFF
--- a/lib/loop.c
+++ b/lib/loop.c
@@ -373,7 +373,11 @@ int mosquitto_loop_read(struct mosquitto *mosq, int max_packets)
 
 #ifdef WITH_TLS
 	if(mosq->want_connect){
-		return net__socket_connect_tls(mosq);
+		rc = net__socket_connect_tls(mosq);
+		if (MOSQ_ERR_TLS == rc){
+			rc = mosquitto__loop_rc_handle(mosq, rc);
+		}
+		return rc;
 	}
 #endif
 


### PR DESCRIPTION
When using the library asynchronously, TLS errors caused e.g. because
of the date/time not set correctly, cause the connection to be silently
dropped without the disconnection callback being invoked, as described
in issue #1052

This commit fixes the issue, returning the behavior to the one the
library had previous to version 1.5.4, if a TLS error occurs, the
disconnect callback will be invoked for the client to get notified of
the error.