### PR TITLE
Add asynchronous connection method for MQTT v5

### DIFF
--- a/include/mosquitto.h
+++ b/include/mosquitto.h
@@ -122,6 +122,7 @@ enum mosq_err_t {
 	/* 28, 29, 30 - was internal only, moved to MQTT v5 section. */
 	MOSQ_ERR_ALREADY_EXISTS = 31,
 	MOSQ_ERR_PLUGIN_IGNORE = 32,
+	MOSQ_ERR_CONN_INPROGRESS = 33,
 
 	/* MQTT v5 direct equivalents 128-255 */
 	MOSQ_ERR_UNSPECIFIED = 128,
@@ -682,6 +683,95 @@ libmosq_EXPORT int mosquitto_connect_async(struct mosquitto *mosq, const char *h
  * 	<mosquitto_connect_async>, <mosquitto_connect>, <mosquitto_connect_bind>
  */
 libmosq_EXPORT int mosquitto_connect_bind_async(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address);
+
+/*
+ * Function: mosquitto_connect_bind_async_v5
+ *
+ * Connect to an MQTT broker. This is a non-blocking call. This will work with
+ * both the threaded and event loop interface of mosquitto.
+ *
+ * This extends the functionality of <mosquitto_connect_async> by adding the
+ * bind_address parameter. Use this function if you need to restrict network
+ * communication over a particular interface.
+ *
+ * May be called before or after <mosquitto_loop_start>.
+ * 
+ * Use e.g. <mosquitto_property_add_string> and similar to create a list of
+ * properties, then attach them to this publish. Properties need freeing with
+ * <mosquitto_property_free_all>.
+ *
+ * If the mosquitto instance `mosq` is using MQTT v5, the `properties` argument
+ * will be applied to the CONNECT message. For MQTT v3.1.1 and below, the
+ * `properties` argument will be ignored.
+ *
+ * Set your client to use MQTT v5 immediately after it is created:
+ *
+ * mosquitto_int_option(mosq, MOSQ_OPT_PROTOCOL_VERSION, MQTT_PROTOCOL_V5);
+ *
+ * Parameters:
+ * 	mosq -         a valid mosquitto instance.
+ * 	host -         the hostname or ip address of the broker to connect to.
+ * 	port -         the network port to connect to. Usually 1883.
+ * 	keepalive -    the number of seconds after which the broker should send a PING
+ *                 message to the client if no other messages have been exchanged
+ *                 in that time.
+ *  bind_address - the hostname or ip address of the local network interface to
+ *                 bind to. If you do not want to bind to a specific interface,
+ *                 set this to NULL.
+ *  properties -   the MQTT 5 properties for the connect (not for the Will).
+ *
+ * Returns:
+ * 	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid, which could be any of:
+ * 	                   * mosq == NULL
+ * 	                   * host == NULL
+ * 	                   * port < 0
+ * 	                   * keepalive < 5
+ * 	MOSQ_ERR_ERRNO -   if a system call returned an error. The variable errno
+ *                     contains the error code, even on Windows.
+ *                     Use strerror_r() where available or FormatMessage() on
+ *                     Windows.
+ *	MOSQ_ERR_DUPLICATE_PROPERTY - if a property is duplicated where it is forbidden.
+ *	MOSQ_ERR_PROTOCOL - if any property is invalid for use with CONNECT.
+ *  MOSQ_ERR_CONN_INPROGRESS - if the socket connection is in progress. Call
+ * 							   mosquitto_send_connect when the socket fd is
+ * 							   ready for writing
+ * 
+ * See Also:
+ * 	<mosquitto_connect_bind_async>, <mosquitto_connect_bind_v5>
+ */
+libmosq_EXPORT int mosquitto_connect_bind_async_v5(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address, const mosquitto_property *properties);
+
+/*
+ * Function: mosquitto_send_connect
+ *
+ * This function can be used to send the actual MQTT CONNECT message to the
+ * broker. It is intended to be used in combination with
+ * mosquitto_connect_bind_async_v5, when it returns MOSQ_ERR_CONN_INPROGRESS.
+ * This indicates that the socket connection between client and broker is still
+ * being set up and the CONNECT message cannot be sent yet. Once the socket is
+ * ready for writing, use mosquitto_send_connect to finish the connection setup.
+ * 
+ * Parameters:
+ * 	mosq -         a valid mosquitto instance that was previously used with
+ * 				   mosquitto_connect_bind_async_v5.
+ * 
+ * Returns:
+ * 	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid, which could be any of:
+ * 	                   * mosq == NULL
+ * 	                   * mosq->host == NULL
+ * 	MOSQ_ERR_ERRNO -   if a system call returned an error. The variable errno
+ *                     contains the error code, even on Windows.
+ *                     Use strerror_r() where available or FormatMessage() on
+ *                     Windows.
+ *	MOSQ_ERR_DUPLICATE_PROPERTY - if a property is duplicated where it is forbidden.
+ *	MOSQ_ERR_PROTOCOL - if any property is invalid for use with CONNECT.
+ * 
+ * See also:
+ *  <mosquitto_connect_bind_async_v5>
+ */
+libmosq_EXPORT int mosquitto_send_connect(struct mosquitto *mosq);
 
 /*
  * Function: mosquitto_connect_srv

--- a/lib/linker.version
+++ b/lib/linker.version
@@ -148,4 +148,6 @@ MOSQ_2.1 {
 		mosquitto_topic_matches_sub_with_pattern;
 		mosquitto_sub_matches_acl;
 		mosquitto_sub_matches_acl_with_pattern;
+		mosquitto_connect_bind_async_v5;
+		mosquitto_send_connect;
 } MOSQ_1.7;

--- a/lib/net_mosq.h
+++ b/lib/net_mosq.h
@@ -68,6 +68,7 @@ int net__try_connect(const char *host, uint16_t port, mosq_sock_t *sock, const c
 int net__try_connect_step1(struct mosquitto *mosq, const char *host);
 int net__try_connect_step2(struct mosquitto *mosq, uint16_t port, mosq_sock_t *sock);
 int net__socket_connect_step3(struct mosquitto *mosq, const char *host);
+int net__finish_connect(struct mosquitto *mosq, const char *host);
 int net__socket_nonblock(mosq_sock_t *sock);
 int net__socketpair(mosq_sock_t *sp1, mosq_sock_t *sp2);
 bool net__is_connected(struct mosquitto *mosq);


### PR DESCRIPTION
## Description

It is currently only possible to make a blocking MQTT v5 connection to a broker by using `mosquitto_connect_bind_v5`. The non-blocking alternative `mosquitto_connect_bind_async` can only be used for MQTT v3, because it does not allow passing MQTT v5 properties.

This pull request adds 2 new API functions to the mosquitto library:
- `mosquitto_connect_bind_async_v5`: This function will create a non-blocking socket connection to the MQTT broker. It will return with `MOSQ_ERR_CONN_INPROGRESS` when the socket connection was created, but the connection is still in progress. The socket can be added to an event loop to check when it becomes ready for writing.
- `mosquitto_send_connect`: This function must be called once the connection is ready for writing to send the actual MQTT CONNECT message.

Started from this issue: https://github.com/eclipse/mosquitto/issues/1835

## Checklist

Signed-off-by: Johan Jacobs <jacobs-johan@hotmail.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
