### PR TITLE
Add socket activation for systemd and s6

### DIFF
--- a/service/s6/run
+++ b/service/s6/run
@@ -1,0 +1,16 @@
+#!/bin/execlineb -P
+
+fdmove 3 0
+s6-fdholder-retrieve /service/s6rc-fdholder/s pipe:s6rc-mosquitto:127.0.0.0:1883
+fdmove 4 0
+s6-fdholder-retrieve /service/s6rc-fdholder/s pipe:s6rc-mosquitto::1:1883
+fdmove 5 0
+s6-fdholder-retrieve /service/s6rc-fdholder/s pipe:s6rc-mosquitto:/run/mosquitto/s
+fdswap 3 0
+
+export LISTEN_FDS 3
+getpid LISTEN_PID
+
+s6-setuidgid mosquitto
+
+mosquitto -c /etc/mosquitto/mosquitto.conf

--- a/service/s6/socket.up
+++ b/service/s6/socket.up
@@ -1,0 +1,12 @@
+#!/bin/execlineb -P
+
+foreground {
+  s6-tcpserver6-socketbinder ::1 1883
+  s6-fdholder-store /service/s6rc-fdholder/s pipe:s6rc-mosquitto::1:1883
+}
+foreground {
+  s6-tcpserver4-socketbinder 127.0.0.1 1883
+  s6-fdholder-store /service/s6rc-fdholder/s pipe:s6rc-mosquitto:127.0.0.1:1883
+}
+s6-ipcserver-socketbinder /run/mosquitto/s
+s6-fdholder-store /service/s6rc-fdholder/s pipe:s6rc-mosquitto:/run/mosquitto/s

--- a/service/systemd/README
+++ b/service/systemd/README
@@ -7,3 +7,19 @@ changed the default build settings.
 With WITH_SYSTEMD mosquitto will notify a complete startup after
 initialization. This means that follow-up units can be started after full
 initialization of mosquitto (i.e. sockets are opened).
+
+Use mosquitto.socket for socket activation. This functionality is
+always available (even if WITH_SYSTEMD is disabled) because it does not
+depend on any systemd includes or libraries.
+
+Mosquitto recognizes the environment variables
+LISTEN_FDS and LISTEN_PID as set by systemd.
+All sockets must be mentioned exactly
+the same way in the mosquitto.conf:
+
+listener 1883 127.0.0.1
+listener 1883 ::1
+listener 0 /run/mosquitto/s
+
+Other socket managing capable service managers like s6 can also
+use this mechanism.

--- a/service/systemd/mosquitto.socket
+++ b/service/systemd/mosquitto.socket
@@ -1,0 +1,7 @@
+[Socket]
+ListenStream=/run/mosquitto/s
+ListenStream=127.0.0.1:1883
+ListenStream=[::1]:1883
+
+[Install]
+WantedBy=sockets.target

--- a/src/listeners.c
+++ b/src/listeners.c
@@ -251,7 +251,8 @@ void listeners__stop(void)
 		mosquitto__free(db.config->listeners[i].ws_protocol);
 #endif
 #ifdef WITH_UNIX_SOCKETS
-		if(db.config->listeners[i].unix_socket_path != NULL){
+		if(db.config->listeners[i].unix_socket_path != NULL &&
+		   db.config->listeners[i].unlink_on_close){
 			unlink(db.config->listeners[i].unix_socket_path);
 		}
 #endif

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -245,6 +245,7 @@ struct mosquitto__listener {
 	struct mosquitto__security_options security_options;
 #ifdef WITH_UNIX_SOCKETS
 	char *unix_socket_path;
+	int unlink_on_close;
 #endif
 	bool disable_protocol_v3;
 	bool disable_protocol_v4;


### PR DESCRIPTION
Use open, listening socket file descriptors  provided by the service manager
via LISTEN_FDS and LISTEN_PID environment variables.

This is how systemd tells the service about open sockets.
However, this change does not depend on systemd libraries or header.

All sockets must be mentioned exactly (IP:Port / unix-path)
in the mosquitto config file in order to be recognized.
Sockets not mentioned in the config file will be ignored.

The service/systemd directory contains an example (mosquitto.socket).
The service/s6 directory contains examples for the s6 service manager.

The new, builtin websocket mechanism can also use already open sockets.
However, the libwebsocket mchanism can not.

Signed-off-by: Christian Hohnstaedt <christian@hohnstaedt.de>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
