### PR TITLE
Fix DESTINATION for mosquitto_dynamic_security MODULE

### DIFF
--- a/plugins/dynamic-security/CMakeLists.txt
+++ b/plugins/dynamic-security/CMakeLists.txt
@@ -35,7 +35,12 @@ if (CJSON_FOUND AND WITH_TLS)
 	target_link_libraries(mosquitto_dynamic_security ${CJSON_LIBRARIES} ${OPENSSL_LIBRARIES})
 	if(WIN32)
 		target_link_libraries(mosquitto_dynamic_security mosquitto)
-	endif(WIN32)
+		install(TARGETS mosquitto_dynamic_security
+			DESTINATION "${CMAKE_INSTALL_BINDIR}")
+	else()
+		install(TARGETS mosquitto_dynamic_security
+			RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+			LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+	endif()
 
-	install(TARGETS mosquitto_dynamic_security RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()


### PR DESCRIPTION
On Windows MODULE will be installed as LIBRARY component
to `lib` folder that is not prefer for dynamic loaded modules
but can be found in RUNTIME DESTINATION (`bin` folder) too.

Partially closes #2371

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
