### PR TITLE
Add bridge config reload and dynamic bridges support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ apps/mosquitto_passwd/mosquitto_passwd
 
 build/
 build64/
+cmake-build-*/
 
 client/mosquitto_pub
 client/mosquitto_rr
@@ -85,3 +86,7 @@ test/unit/out/
 
 www/cache/
 __pycache__
+
+.clang-format
+
+.idea/

--- a/apps/mosquitto_ctrl/CMakeLists.txt
+++ b/apps/mosquitto_ctrl/CMakeLists.txt
@@ -1,5 +1,8 @@
 if (WITH_TLS AND CJSON_FOUND)
 	add_definitions("-DWITH_CJSON")
+	if (INC_BRIDGE_SUPPORT)
+		add_definitions("-DWITH_BRIDGE")
+	endif()
 
 	include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/include
 			${mosquitto_SOURCE_DIR}/lib ${mosquitto_SOURCE_DIR}/src
@@ -11,6 +14,7 @@ if (WITH_TLS AND CJSON_FOUND)
 	add_executable(mosquitto_ctrl
 		mosquitto_ctrl.c mosquitto_ctrl.h
 		client.c
+		dynbridge.c
 		dynsec.c
 		dynsec_client.c
 		dynsec_group.c

--- a/apps/mosquitto_ctrl/Makefile
+++ b/apps/mosquitto_ctrl/Makefile
@@ -26,6 +26,10 @@ OBJS=	mosquitto_ctrl.o \
 		options.o \
 		password_mosq.o
 
+ifeq ($(WITH_BRIDGE),yes)
+OBJS+=  dynbridge.o
+endif
+
 EXAMPLE_OBJS= example.o
 
 ifeq ($(WITH_TLS),yes)
@@ -52,6 +56,11 @@ mosquitto_ctrl.o : mosquitto_ctrl.c mosquitto_ctrl.h
 
 client.o : client.c mosquitto_ctrl.h
 	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(APP_CPPFLAGS) $(APP_CFLAGS) -c $< -o $@
+
+ifeq ($(WITH_BRIDGE),yes)
+dynbridge.o : dynbridge.c mosquitto_ctrl.h
+	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(APP_CPPFLAGS) $(APP_CFLAGS) -c $< -o $@
+endif
 
 dynsec.o : dynsec.c mosquitto_ctrl.h
 	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(APP_CPPFLAGS) $(APP_CFLAGS) -c $< -o $@

--- a/apps/mosquitto_ctrl/dynbridge.c
+++ b/apps/mosquitto_ctrl/dynbridge.c
@@ -1,0 +1,253 @@
+#ifdef WITH_BRIDGE
+/*
+Copyright (c) 2021 Benjamin Hansmann <benjamin.hansmann@riedel.net>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Contributors:
+   Benjamin Hansmann - initial implementation and documentation.
+*/
+
+#include "config.h"
+
+#include <cjson/cJSON.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mosquitto_ctrl.h"
+#include "mosquitto.h"
+
+void dynbridge__print_usage(void)
+{
+	printf("\nDynamic Bridge module\n");
+	printf("=====================\n");
+	printf("\nAvailable commands:\n-------------------\n");
+	printf("Create dynamic bridge:    create <name> <address>\n");
+	printf("  [-p port]\n");
+	printf("  [-m protocol_version]   mqttv31|mqttv311|mqttv50 (default: mqttv311)\n");
+	printf("  [-c]                    clean session (default: false)\n");
+	printf("Get all dynamic bridges:  list\n");
+	printf("Delete dynamic bridge:    delete <name>\n");
+	printf("\n");
+}
+
+/* ################################################################
+ * #
+ * # Payload callback
+ * #
+ * ################################################################ */
+
+static void dynbridge__payload_callback(struct mosq_ctrl *ctrl, long payloadlen, const void *payload)
+{
+	cJSON *tree, *j_responses, *j_response, *j_command, *j_error;
+
+	UNUSED(ctrl);
+
+#if CJSON_VERSION_FULL < 1007013
+	UNUSED(payloadlen);
+	tree = cJSON_Parse(payload);
+#else
+	tree = cJSON_ParseWithLength(payload, (size_t)payloadlen);
+#endif
+	if(tree == NULL){
+		fprintf(stderr, "Error: Payload not JSON.\n");
+		return;
+	}
+
+	j_responses = cJSON_GetObjectItem(tree, "responses");
+	if(j_responses == NULL || !cJSON_IsArray(j_responses)){
+		fprintf(stderr, "Error: Payload missing data.\n");
+		cJSON_Delete(tree);
+		return;
+	}
+
+	j_response = cJSON_GetArrayItem(j_responses, 0);
+	if(j_response == NULL){
+		fprintf(stderr, "Error: Payload missing data.\n");
+		cJSON_Delete(tree);
+		return;
+	}
+
+	j_command = cJSON_GetObjectItem(j_response, "command");
+	if(j_command == NULL){
+		fprintf(stderr, "Error: Payload missing data.\n");
+		cJSON_Delete(tree);
+		return;
+	}
+
+	j_error = cJSON_GetObjectItem(j_response, "error");
+	if(j_error){
+		fprintf(stderr, "%s: Error: %s\n", j_command->valuestring, j_error->valuestring);
+	}else{
+		if(!strcasecmp(j_command->valuestring, "list")){
+			printf("Dynamic bridges: %s\n", cJSON_Print(j_responses));
+		}
+		fprintf(stderr, "%s: Success\n", j_command->valuestring);
+	}
+	cJSON_Delete(tree);
+}
+
+static int dynbridge__create(int argc, char *argv[], cJSON *j_command)
+{
+	char *name, *address;
+	char *protocol_version = "mqttv311";
+	int port = 1883;
+	bool cleansession = false;
+	int i;
+
+	if(argc < 2){
+		return MOSQ_ERR_INVAL;
+	}
+	name = argv[0];
+	address = argv[1];
+
+	for(i=1; i<argc; i++){
+		if(!strcmp(argv[i], "-p")){
+			if(i+1 == argc){
+				fprintf(stderr, "Error: -p argument given, but no port provided.\n");
+				return MOSQ_ERR_INVAL;
+			}
+			port = atoi(argv[i+1]);
+			if(port < 1 || port > UINT16_MAX){
+				fprintf(stderr, "Error: Invalid port provided.\n");
+				return MOSQ_ERR_INVAL;
+			}
+			i++;
+		}else if(!strcmp(argv[i], "-m")){
+			if(i+1 == argc){
+				fprintf(stderr, "Error: -m argument given, but no MQTT protocol version provided.\n");
+				return MOSQ_ERR_INVAL;
+			}
+			protocol_version = argv[i+1];
+			if(strcmp(protocol_version, "mqttv31")
+					&& strcmp(protocol_version, "mqttv311")
+					&& strcmp(protocol_version, "mqttv50")
+					){
+				fprintf(stderr, "Error: Invalid MQTT protocol version provided.\n");
+				return MOSQ_ERR_INVAL;
+			}
+			i++;
+		}else if(!strcmp(argv[i], "-c")){
+			cleansession = true;
+		}
+	}
+
+	if(cJSON_AddStringToObject(j_command, "command", "create") == NULL
+			|| cJSON_AddStringToObject(j_command, "name", name) == NULL
+			|| cJSON_AddStringToObject(j_command, "address", address) == NULL
+			|| cJSON_AddIntToObject(j_command, "port", port) == NULL
+			|| cJSON_AddStringToObject(j_command, "protocolVersion", protocol_version) == NULL
+			|| cJSON_AddBoolToObject(j_command, "cleanSession", cleansession) == NULL
+			){
+		return MOSQ_ERR_NOMEM;
+	}else{
+		return MOSQ_ERR_SUCCESS;
+	}
+}
+
+static int dynbridge__list(int argc, char *argv[], cJSON *j_command)
+{
+	UNUSED(argv);
+
+	if(argc != 0){
+		return MOSQ_ERR_INVAL;
+	}
+
+	if(cJSON_AddStringToObject(j_command, "command", "list") == NULL){
+		return MOSQ_ERR_NOMEM;
+	}else{
+		return MOSQ_ERR_SUCCESS;
+	}
+}
+
+static int dynbridge__delete(int argc, char *argv[], cJSON *j_command)
+{
+	char *name;
+
+	if(argc != 1){
+		return MOSQ_ERR_INVAL;
+	}
+	name = argv[0];
+
+	if(cJSON_AddStringToObject(j_command, "command", "delete") == NULL
+			|| cJSON_AddStringToObject(j_command, "name", name) == NULL
+			){
+		return MOSQ_ERR_NOMEM;
+	}else{
+		return MOSQ_ERR_SUCCESS;
+	}
+}
+
+/* ################################################################
+ * #
+ * # Main
+ * #
+ * ################################################################ */
+
+int dynbridge__main(int argc, char *argv[], struct mosq_ctrl *ctrl)
+{
+	int rc = -1;
+	cJSON *j_tree;
+	cJSON *j_commands, *j_command;
+
+	if(!strcasecmp(argv[0], "help")){
+		dynbridge__print_usage();
+		return -1;
+	}
+
+	/* The remaining commands need a network connection and JSON command. */
+
+	ctrl->payload_callback = dynbridge__payload_callback;
+	ctrl->request_topic = strdup("$CONTROL/dynamic-bridge/v1");
+	ctrl->response_topic = strdup("$CONTROL/dynamic-bridge/v1/response");
+	if(ctrl->request_topic == NULL || ctrl->response_topic == NULL){
+		return MOSQ_ERR_NOMEM;
+	}
+	j_tree = cJSON_CreateObject();
+	if(j_tree == NULL) return MOSQ_ERR_NOMEM;
+	j_commands = cJSON_AddArrayToObject(j_tree, "commands");
+	if(j_commands == NULL){
+		cJSON_Delete(j_tree);
+		j_tree = NULL;
+		return MOSQ_ERR_NOMEM;
+	}
+	j_command = cJSON_CreateObject();
+	if(j_command == NULL){
+		cJSON_Delete(j_tree);
+		j_tree = NULL;
+		return MOSQ_ERR_NOMEM;
+	}
+	cJSON_AddItemToArray(j_commands, j_command);
+
+	if(!strcasecmp(argv[0], "create")){
+		rc = dynbridge__create(argc - 1, &argv[1], j_command);
+	} else if(!strcasecmp(argv[0], "list")){
+		rc = dynbridge__list(argc-1, &argv[1], j_command);
+	} else if(!strcasecmp(argv[0], "delete")){
+		rc = dynbridge__delete(argc-1, &argv[1], j_command);
+	}else{
+		fprintf(stderr, "Command '%s' not recognised.\n", argv[0]);
+		return MOSQ_ERR_UNKNOWN;
+	}
+
+	if(rc == MOSQ_ERR_SUCCESS){
+		ctrl->payload = cJSON_PrintUnformatted(j_tree);
+		cJSON_Delete(j_tree);
+		if(ctrl->payload == NULL){
+			fprintf(stderr, "Error: Out of memory.\n");
+			return MOSQ_ERR_NOMEM;
+		}
+	}
+	return rc;
+}
+#endif

--- a/apps/mosquitto_ctrl/mosquitto_ctrl.c
+++ b/apps/mosquitto_ctrl/mosquitto_ctrl.c
@@ -42,7 +42,11 @@ static void print_usage(void)
 	print_version();
 	printf("\nGeneral usage: mosquitto_ctrl <module> <module-command> <command-options>\n");
 	printf("For module specific help use: mosquitto_ctrl <module> help\n");
-	printf("\nModules available: dynsec\n");
+	printf("\nModules available: dynsec");
+#ifdef WITH_BRIDGE
+	printf(", dynbridge");
+#endif
+	printf("\n");
 	printf("\nFor more information see:\n");
 	printf("    https://mosquitto.org/man/mosquitto_ctrl-1.html\n\n");
 }
@@ -78,6 +82,10 @@ int main(int argc, char *argv[])
 	/* In built modules */
 	if(!strcasecmp(argv[0], "dynsec")){
 		l_ctrl_main = dynsec__main;
+#ifdef WITH_BRIDGE
+	}else if(!strcasecmp(argv[0], "dynbridge")){
+		l_ctrl_main = dynbridge__main;
+#endif
 	}else{
 		/* Attempt external module */
 		snprintf(lib_name, sizeof(lib_name), "mosquitto_ctrl_%s.so", argv[0]);

--- a/apps/mosquitto_ctrl/mosquitto_ctrl.h
+++ b/apps/mosquitto_ctrl/mosquitto_ctrl.h
@@ -116,6 +116,11 @@ int dynsec_role__list_all(int argc, char *argv[], cJSON *j_command);
 int dynsec_role__add_acl(int argc, char *argv[], cJSON *j_command);
 int dynsec_role__remove_acl(int argc, char *argv[], cJSON *j_command);
 
+#ifdef WITH_BRIDGE
+void dynbridge__print_usage(void);
+int dynbridge__main(int argc, char *argv[], struct mosq_ctrl *ctrl);
+#endif
+
 /* Functions to implement as an external module: */
 void ctrl_help(void);
 int ctrl_main(int argc, char *argv[], struct mosq_ctrl *ctrl);

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(dynamic-bridge)
 add_subdirectory(dynamic-security)
 if(NOT WIN32)
 	add_subdirectory(message-timestamp)

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,5 +1,6 @@
 DIRS= \
 		auth-by-ip \
+		dynamic-bridge \
 		dynamic-security \
 		message-timestamp \
 		payload-modification

--- a/plugins/dynamic-bridge/CMakeLists.txt
+++ b/plugins/dynamic-bridge/CMakeLists.txt
@@ -1,0 +1,42 @@
+if (CJSON_FOUND AND INC_BRIDGE_SUPPORT)
+	add_definitions("-DWITH_CJSON")
+	add_definitions("-DWITH_BRIDGE")
+
+	set( CLIENT_INC ${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/include
+		${mosquitto_SOURCE_DIR}/lib
+		${STDBOOL_H_PATH} ${STDINT_H_PATH} ${PTHREAD_INCLUDE_DIR}
+		${OPENSSL_INCLUDE_DIR} ${mosquitto_SOURCE_DIR}/deps
+		${mosquitto_SOURCE_DIR}/src
+		${CJSON_INCLUDE_DIRS} )
+
+	set( CLIENT_DIR ${mosquitto_BINARY_DIR}/lib ${CJSON_DIR})
+
+	include_directories(${CLIENT_INC})
+	link_directories(${CLIENT_DIR} ${mosquitto_SOURCE_DIR})
+
+	add_library(mosquitto_dynamic_bridge MODULE
+		dynamic_bridge.c
+		dynamic_bridge.h
+		json_help.c
+		json_help.h
+		plugin.c
+    )
+
+	set_target_properties(mosquitto_dynamic_bridge PROPERTIES
+		POSITION_INDEPENDENT_CODE 1
+	)
+	set_target_properties(mosquitto_dynamic_bridge PROPERTIES PREFIX "")
+
+	target_link_libraries(mosquitto_dynamic_bridge ${CJSON_LIBRARIES})
+	if(WITH_TLS)
+		target_link_libraries(mosquitto_dynamic_bridge ${OPENSSL_LIBRARIES})
+	endif(WITH_TLS)
+	if(WIN32)
+		target_link_libraries(mosquitto_dynamic_bridge mosquitto)
+	endif(WIN32)
+
+	install(TARGETS mosquitto_dynamic_bridge
+		RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+		LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    )
+endif()

--- a/plugins/dynamic-bridge/Makefile
+++ b/plugins/dynamic-bridge/Makefile
@@ -1,0 +1,54 @@
+include ../../config.mk
+
+.PHONY : all binary check clean reallyclean test install uninstall
+
+PLUGIN_NAME=mosquitto_dynamic_bridge
+LOCAL_CPPFLAGS=-I../../src/ -I../../lib/ -DWITH_CJSON -DWITH_BRIDGE
+
+OBJS=	\
+		dynamic_bridge.o \
+		json_help.o \
+		plugin.o
+
+ifeq ($(WITH_CJSON),yes)
+ifeq ($(WITH_BRIDGE),yes)
+ALL_DEPS:= binary
+else
+ALL_DEPS:=
+endif
+else
+ALL_DEPS:=
+endif
+
+all : ${ALL_DEPS}
+binary : ${PLUGIN_NAME}.so
+
+${PLUGIN_NAME}.so : ${OBJS}
+	${CROSS_COMPILE}${CC} $(PLUGIN_LDFLAGS) -fPIC -shared $^ -o $@ -lcjson
+
+dynamic_bridge.o : dynamic_bridge.c dynamic_bridge.h
+	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
+
+json_help.o : json_help.c
+	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
+
+plugin.o : plugin.c dynamic_bridge.h
+	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
+
+reallyclean : clean
+clean:
+	-rm -f *.o ${PLUGIN_NAME}.so *.gcda *.gcno
+
+check: test
+test:
+
+install: all
+ifeq ($(WITH_CJSON),yes)
+ifeq ($(WITH_BRIDGE),yes)
+	$(INSTALL) -d "${DESTDIR}$(libdir)"
+	$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"
+endif
+endif
+
+uninstall :
+	-rm -f "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"

--- a/plugins/dynamic-bridge/dynamic_bridge.c
+++ b/plugins/dynamic-bridge/dynamic_bridge.c
@@ -1,0 +1,220 @@
+/*
+Copyright (c) 2021 Benjamin Hansmann <benjamin.hansmann@riedel.net>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Contributors:
+   Benjamin Hansmann - initial implementation and documentation.
+*/
+
+#include "config.h"
+
+#include <cjson/cJSON.h>
+#include <memory_mosq.h>
+
+#include "json_help.h"
+#include "mosquitto_broker_internal.h"
+
+#include "dynamic_bridge.h"
+
+static int from_json(cJSON *command, struct mosquitto__bridge *bridge)
+{
+	char *name_tmp, *address_tmp, *protocol_version_tmp;
+	int port_tmp;
+	bool cleansession;
+	enum mosquitto__protocol protocol_version;
+	int rc;
+
+	if(json_get_string(command, "name", &name_tmp, false) != MOSQ_ERR_SUCCESS){
+		return MOSQ_ERR_INVAL;
+	}
+	if(mosquitto_validate_utf8(name_tmp, (int)strlen(name_tmp)) != MOSQ_ERR_SUCCESS){
+		return MOSQ_ERR_INVAL;
+	}
+	if(json_get_string(command, "address", &address_tmp, false) != MOSQ_ERR_SUCCESS){
+		return MOSQ_ERR_INVAL;
+	}
+	if(json_get_int(command, "port", &port_tmp, true, 1883) != MOSQ_ERR_SUCCESS){
+		return MOSQ_ERR_INVAL;
+	}
+	if(port_tmp < 1 || port_tmp > UINT16_MAX){
+		return MOSQ_ERR_INVAL;
+	}
+	if(json_get_string(command, "protocolVersion", &protocol_version_tmp, true) != MOSQ_ERR_SUCCESS){
+		return MOSQ_ERR_INVAL;
+	}
+	if(!protocol_version_tmp || !strcmp(protocol_version_tmp, "mqttv311")){
+		protocol_version = mosq_p_mqtt311;
+	}else if(!strcmp(protocol_version_tmp, "mqttv31")){
+		protocol_version = mosq_p_mqtt31;
+	}else if(!strcmp(protocol_version_tmp, "mqttv50")){
+		protocol_version = mosq_p_mqtt5;
+	}else{
+		return MOSQ_ERR_INVAL;
+	}
+	if(json_get_bool(command, "cleanSession", &cleansession, true, false) != MOSQ_ERR_SUCCESS){
+		return MOSQ_ERR_INVAL;
+	}
+
+	rc = config__init_bridge(bridge, name_tmp);
+	if(rc != MOSQ_ERR_SUCCESS) {
+		return rc;
+	}
+	bridge->name = mosquitto__strdup(name_tmp);
+	if(!bridge->name){
+		log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
+		return MOSQ_ERR_NOMEM;
+	}
+	if(bridge__add_topic(bridge, "#", bd_both, 0, "", "")){
+		return MOSQ_ERR_INVAL;
+	}
+	bridge->addresses = mosquitto__realloc(bridge->addresses, sizeof(struct bridge_address)*(size_t)(bridge->address_count+1));
+	if(!bridge->addresses){
+		return MOSQ_ERR_NOMEM;
+	}
+	bridge->address_count++;
+	bridge->addresses[bridge->address_count-1].address = mosquitto__strdup(address_tmp);
+	bridge->addresses[bridge->address_count-1].port = (uint16_t)port_tmp;
+	bridge->protocol_version = protocol_version;
+	bridge->clean_start = cleansession;
+
+	return rc;
+}
+
+static cJSON *to_json(const struct mosquitto__bridge *bridge)
+{
+	cJSON *j_bridge = NULL;
+
+	j_bridge = cJSON_CreateObject();
+	if(j_bridge == NULL){
+		return NULL;
+	}
+
+	if(cJSON_AddStringToObject(j_bridge, "name", bridge->name) == NULL
+			|| cJSON_AddStringToObject(j_bridge, "address", bridge->addresses->address) == NULL
+			|| cJSON_AddIntToObject(j_bridge, "port", bridge->addresses->port) == NULL
+			){
+		cJSON_Delete(j_bridge);
+		return NULL;
+	}
+
+	return j_bridge;
+}
+
+int dynbridge__process_create(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data)
+{
+	struct mosquitto__bridge *bridge;
+	int rc;
+	const char *admin_clientid, *admin_username;
+
+	bridge = mosquitto_calloc(1, sizeof(struct mosquitto__bridge));
+	if(!bridge){
+		log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
+		dynbridge__command_reply(j_responses, context, "create", "Internal error", correlation_data);
+		return MOSQ_ERR_NOMEM;
+	}
+	if(from_json(command, bridge) != MOSQ_ERR_SUCCESS){
+		config__cleanup_bridge(bridge);
+		mosquitto__free(bridge);
+		dynbridge__command_reply(j_responses, context, "create", "Invalid bridge configuration", correlation_data);
+		return MOSQ_ERR_INVAL;
+	}
+	rc = config__check_dynamic_bridge(bridge);
+	if(rc != MOSQ_ERR_SUCCESS){
+		config__cleanup_bridge(bridge);
+		mosquitto__free(bridge);
+		if (rc == MOSQ_ERR_ALREADY_EXISTS){
+			dynbridge__command_reply(j_responses, context, "create", "Bridge connection name or clientId already in use", correlation_data);
+		}else{
+			dynbridge__command_reply(j_responses, context, "create", "Invalid bridge configuration", correlation_data);
+		}
+		return MOSQ_ERR_INVAL;
+	}
+
+	config__add_dynamic_bridge(bridge);
+	bridge__start_all();
+	dynbridge__command_reply(j_responses, context, "create", NULL, correlation_data);
+
+	admin_clientid = mosquitto_client_id(context);
+	admin_username = mosquitto_client_username(context);
+	mosquitto_log_printf(MOSQ_LOG_INFO, "dynbridge: %s/%s | create", admin_clientid, admin_username);
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+static void add_bridge_to_json(const struct mosquitto__bridge *bridge, cJSON *j_bridges)
+{
+	cJSON *j_bridge;
+	j_bridge = to_json(bridge);
+	if(j_bridge){
+		cJSON_AddItemToArray(j_bridges, j_bridge);
+	}else{
+		log__printf(NULL, MOSQ_LOG_ERR, "Error: Out of memory.");
+	}
+}
+
+int dynbridge__process_list(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data)
+{
+	cJSON *tree, *j_bridges, *j_data;
+	const char *admin_clientid, *admin_username;
+
+	UNUSED(command);
+
+	tree = cJSON_CreateObject();
+	if(tree == NULL){
+		dynbridge__command_reply(j_responses, context, "list", "Internal error", correlation_data);
+		return MOSQ_ERR_NOMEM;
+	}
+
+	if(cJSON_AddStringToObject(tree, "command", "list") == NULL
+			|| (j_data = cJSON_AddObjectToObject(tree, "data")) == NULL
+			|| (j_bridges = cJSON_AddArrayToObject(j_data, "bridges")) == NULL
+			|| (correlation_data && cJSON_AddStringToObject(tree, "correlationData", correlation_data) == NULL)
+			){
+		cJSON_Delete(tree);
+		dynbridge__command_reply(j_responses, context, "list", "Internal error", correlation_data);
+		return MOSQ_ERR_NOMEM;
+	}
+	config__visit_dynamic_bridges((FUNC_config__accept_bridge) add_bridge_to_json, j_bridges);
+	cJSON_AddItemToArray(j_responses, tree);
+
+	admin_clientid = mosquitto_client_id(context);
+	admin_username = mosquitto_client_username(context);
+	mosquitto_log_printf(MOSQ_LOG_INFO, "dynbridge: %s/%s | list", admin_clientid, admin_username);
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+int dynbridge__process_delete(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data)
+{
+	char *name;
+	int rc;
+	const char *admin_clientid, *admin_username;
+
+	if(json_get_string(command, "name", &name, false) != MOSQ_ERR_SUCCESS){
+		dynbridge__command_reply(j_responses, context, "delete", "Invalid/missing connection name", correlation_data);
+		return MOSQ_ERR_INVAL;
+	}
+	rc = config__invalidate_dynamic_bridge(name);
+	bridge__start_all();
+	if(rc){
+		dynbridge__command_reply(j_responses, context, "delete", "Bridge not found", correlation_data);
+		return MOSQ_ERR_SUCCESS;
+	}
+	dynbridge__command_reply(j_responses, context, "delete", NULL, correlation_data);
+
+	admin_clientid = mosquitto_client_id(context);
+	admin_username = mosquitto_client_username(context);
+	mosquitto_log_printf(MOSQ_LOG_INFO, "dynbridge: %s/%s | delete", admin_clientid, admin_username);
+
+	return MOSQ_ERR_SUCCESS;
+}

--- a/plugins/dynamic-bridge/dynamic_bridge.h
+++ b/plugins/dynamic-bridge/dynamic_bridge.h
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2021 Benjamin Hansmann <benjamin.hansmann@riedel.net>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Contributors:
+   Benjamin Hansmann - initial implementation and documentation.
+*/
+
+#ifndef DYNAMIC_BRIDGE_H
+#define DYNAMIC_BRIDGE_H
+
+#include <cjson/cJSON.h>
+
+#include "mosquitto.h"
+
+/* ################################################################
+ * #
+ * # Plugin Functions
+ * #
+ * ################################################################ */
+
+int dynbridge__handle_control(cJSON *j_responses, struct mosquitto *context, cJSON *commands);
+void dynbridge__command_reply(cJSON *j_responses, struct mosquitto *context, const char *command, const char *error, const char *correlation_data);
+
+/* ################################################################
+ * #
+ * # Client Functions
+ * #
+ * ################################################################ */
+
+int dynbridge__process_create(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
+int dynbridge__process_list(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
+int dynbridge__process_delete(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
+
+#endif

--- a/plugins/dynamic-bridge/json_help.c
+++ b/plugins/dynamic-bridge/json_help.c
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2020 Roger Light <roger@atchoo.org>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Contributors:
+   Roger Light - initial implementation and documentation.
+*/
+
+#include "config.h"
+
+#include <cjson/cJSON.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "json_help.h"
+#include "mosquitto.h"
+
+
+int json_get_bool(cJSON *json, const char *name, bool *value, bool optional, bool default_value)
+{
+	cJSON *jtmp;
+
+	if(optional == true){
+		*value = default_value;
+	}
+
+	jtmp = cJSON_GetObjectItem(json, name);
+	if(jtmp){
+		if(cJSON_IsBool(jtmp) == false){
+			return MOSQ_ERR_INVAL;
+		}
+		*value = cJSON_IsTrue(jtmp);
+	}else{
+		if(optional == false){
+			return MOSQ_ERR_INVAL;
+		}
+	}
+	return MOSQ_ERR_SUCCESS;
+}
+
+
+int json_get_int(cJSON *json, const char *name, int *value, bool optional, int default_value)
+{
+	cJSON *jtmp;
+
+	if(optional == true){
+		*value = default_value;
+	}
+
+	jtmp = cJSON_GetObjectItem(json, name);
+	if(jtmp){
+		if(cJSON_IsNumber(jtmp) == false){
+			return MOSQ_ERR_INVAL;
+		}
+		*value  = jtmp->valueint;
+	}else{
+		if(optional == false){
+			return MOSQ_ERR_INVAL;
+		}
+	}
+	return MOSQ_ERR_SUCCESS;
+}
+
+
+int json_get_string(cJSON *json, const char *name, char **value, bool optional)
+{
+	cJSON *jtmp;
+
+	*value = NULL;
+
+	jtmp = cJSON_GetObjectItem(json, name);
+	if(jtmp){
+		if(cJSON_IsString(jtmp) == false){
+			return MOSQ_ERR_INVAL;
+		}
+		*value  = jtmp->valuestring;
+	}else{
+		if(optional == false){
+			return MOSQ_ERR_INVAL;
+		}
+	}
+	return MOSQ_ERR_SUCCESS;
+}
+
+
+cJSON *cJSON_AddIntToObject(cJSON * const object, const char * const name, int number)
+{
+	char buf[30];
+
+	snprintf(buf, sizeof(buf), "%d", number);
+	return cJSON_AddRawToObject(object, name, buf);
+}

--- a/plugins/dynamic-bridge/json_help.h
+++ b/plugins/dynamic-bridge/json_help.h
@@ -1,0 +1,31 @@
+#ifndef JSON_HELP_H
+#define JSON_HELP_H
+/*
+Copyright (c) 2020 Roger Light <roger@atchoo.org>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Contributors:
+   Roger Light - initial implementation and documentation.
+*/
+#include <cjson/cJSON.h>
+#include <stdbool.h>
+
+/* "optional==false" can also be taken to mean "only return success if the key exists and is valid" */
+int json_get_bool(cJSON *json, const char *name, bool *value, bool optional, bool default_value);
+int json_get_int(cJSON *json, const char *name, int *value, bool optional, int default_value);
+int json_get_string(cJSON *json, const char *name, char **value, bool optional);
+
+cJSON *cJSON_AddIntToObject(cJSON * const object, const char * const name, int number);
+cJSON *cJSON_CreateInt(int num);
+
+#endif

--- a/plugins/dynamic-bridge/plugin.c
+++ b/plugins/dynamic-bridge/plugin.c
@@ -1,0 +1,214 @@
+/*
+Copyright (c) 2021 Benjamin Hansmann <benjamin.hansmann@riedel.net>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Contributors:
+   Benjamin Hansmann - initial implementation and documentation.
+*/
+
+#include "config.h"
+
+#include <cjson/cJSON.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "json_help.h"
+#include "mosquitto.h"
+#include "mosquitto_broker.h"
+#include "mosquitto_plugin.h"
+#include "mqtt_protocol.h"
+
+#include "dynamic_bridge.h"
+
+static mosquitto_plugin_id_t *plg_id = NULL;
+
+void dynbridge__command_reply(cJSON *j_responses, struct mosquitto *context, const char *command, const char *error, const char *correlation_data)
+{
+	cJSON *j_response;
+
+	UNUSED(context);
+
+	j_response = cJSON_CreateObject();
+	if(j_response == NULL) return;
+
+	if(cJSON_AddStringToObject(j_response, "command", command) == NULL
+			|| (error && cJSON_AddStringToObject(j_response, "error", error) == NULL)
+			|| (correlation_data && cJSON_AddStringToObject(j_response, "correlationData", correlation_data) == NULL)
+			){
+
+		cJSON_Delete(j_response);
+		return;
+	}
+
+	cJSON_AddItemToArray(j_responses, j_response);
+}
+
+static void send_response(cJSON *tree)
+{
+	char *payload;
+	size_t payload_len;
+
+	payload = cJSON_PrintUnformatted(tree);
+	cJSON_Delete(tree);
+	if(payload == NULL) return;
+
+	payload_len = strlen(payload);
+	if(payload_len > MQTT_MAX_PAYLOAD){
+		free(payload);
+		return;
+	}
+	mosquitto_broker_publish(NULL, "$CONTROL/dynamic-bridge/v1/response",
+			(int)payload_len, payload, 0, 0, NULL);
+}
+
+
+static int dynbridge_control_callback(int event, void *event_data, void *userdata)
+{
+	struct mosquitto_evt_control *ed = event_data;
+	cJSON *tree, *commands;
+	cJSON *j_response_tree, *j_responses;
+
+	UNUSED(event);
+	UNUSED(userdata);
+
+	/* Create object for responses */
+	j_response_tree = cJSON_CreateObject();
+	if(j_response_tree == NULL){
+		return MOSQ_ERR_NOMEM;
+	}
+	j_responses = cJSON_CreateArray();
+	if(j_responses == NULL){
+		cJSON_Delete(j_response_tree);
+		return MOSQ_ERR_NOMEM;
+	}
+	cJSON_AddItemToObject(j_response_tree, "responses", j_responses);
+
+
+	/* Parse cJSON tree.
+	 * Using cJSON_ParseWithLength() is the best choice here, but Mosquitto
+	 * always adds an extra 0 to the end of the payload memory, so using
+	 * cJSON_Parse() on its own will still not overrun. */
+#if CJSON_VERSION_FULL < 1007013
+	tree = cJSON_Parse(ed->payload);
+#else
+	tree = cJSON_ParseWithLength(ed->payload, ed->payloadlen);
+#endif
+	if(tree == NULL){
+		dynbridge__command_reply(j_responses, ed->client, "Unknown command", "Payload not valid JSON", NULL);
+		send_response(j_response_tree);
+		return MOSQ_ERR_SUCCESS;
+	}
+	// TODO remove debug print
+	printf("Request: %s\n", cJSON_Print(tree));
+
+	commands = cJSON_GetObjectItem(tree, "commands");
+	if(commands == NULL || !cJSON_IsArray(commands)){
+		cJSON_Delete(tree);
+		dynbridge__command_reply(j_responses, ed->client, "Unknown command", "Invalid/missing commands", NULL);
+		send_response(j_response_tree);
+		return MOSQ_ERR_SUCCESS;
+	}
+
+	/* Handle commands */
+	dynbridge__handle_control(j_responses, ed->client, commands);
+	cJSON_Delete(tree);
+
+	send_response(j_response_tree);
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+int mosquitto_plugin_version(int supported_version_count, const int *supported_versions)
+{
+	int i;
+
+	for(i=0; i<supported_version_count; i++){
+		if(supported_versions[i] == 5){
+			return 5;
+		}
+	}
+	return -1;
+}
+
+int mosquitto_plugin_init(mosquitto_plugin_id_t *identifier, void **user_data, struct mosquitto_opt *options, int option_count)
+{
+	UNUSED(user_data);
+	UNUSED(options);
+	UNUSED(option_count);
+
+	plg_id = identifier;
+
+	mosquitto_callback_register(plg_id, MOSQ_EVT_CONTROL, dynbridge_control_callback, "$CONTROL/dynamic-bridge/v1", NULL);
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+int mosquitto_plugin_cleanup(void *user_data, struct mosquitto_opt *options, int option_count)
+{
+	UNUSED(user_data);
+	UNUSED(options);
+	UNUSED(option_count);
+
+	if(plg_id){
+		mosquitto_callback_unregister(plg_id, MOSQ_EVT_CONTROL, dynbridge_control_callback, "$CONTROL/dynamic-bridge/v1");
+	}
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+/* ################################################################
+ * #
+ * # $CONTROL/dynamic-bridge/v1 handler
+ * #
+ * ################################################################ */
+
+int dynbridge__handle_control(cJSON *j_responses, struct mosquitto *context, cJSON *commands)
+{
+	int rc = MOSQ_ERR_SUCCESS;
+	cJSON *aiter;
+	char *command;
+	char *correlation_data = NULL;
+
+	cJSON_ArrayForEach(aiter, commands){
+		if(cJSON_IsObject(aiter)){
+			if(json_get_string(aiter, "command", &command, false) == MOSQ_ERR_SUCCESS){
+				if(json_get_string(aiter, "correlationData", &correlation_data, true) != MOSQ_ERR_SUCCESS){
+					dynbridge__command_reply(j_responses, context, command, "Invalid correlationData data type.", NULL);
+					return MOSQ_ERR_INVAL;
+				}
+
+				/* Plugin */
+				if(!strcasecmp(command, "create")){
+					rc = dynbridge__process_create(j_responses, context, aiter, correlation_data);
+				}else if(!strcasecmp(command, "list")){
+					rc = dynbridge__process_list(j_responses, context, aiter, correlation_data);
+				}else if(!strcasecmp(command, "delete")){
+					rc = dynbridge__process_delete(j_responses, context, aiter, correlation_data);
+				/* Unknown */
+				}else{
+					dynbridge__command_reply(j_responses, context, command, "Unknown command", correlation_data);
+					rc = MOSQ_ERR_INVAL;
+				}
+			}else{
+				dynbridge__command_reply(j_responses, context, "Unknown command", "Missing command", correlation_data);
+				rc = MOSQ_ERR_INVAL;
+			}
+		}else{
+			dynbridge__command_reply(j_responses, context, "Unknown command", "Command not an object", correlation_data);
+			rc = MOSQ_ERR_INVAL;
+		}
+	}
+
+	return rc;
+}

--- a/src/context.c
+++ b/src/context.c
@@ -115,9 +115,8 @@ void context__cleanup(struct mosquitto *context, bool force_free)
 	}
 
 #ifdef WITH_BRIDGE
-	if(context->bridge){
-		bridge__cleanup(context);
-	}
+	/* The bridge is still part of the config, so it is not freed */
+	context->bridge = NULL;
 #endif
 
 	alias__free_all(context);
@@ -160,6 +159,12 @@ void context__cleanup(struct mosquitto *context, bool force_free)
 		mosquitto__free(packet);
 	}
 	context->out_packet_count = 0;
+#ifdef WITH_TLS
+	if(context->ssl_ctx){
+		SSL_CTX_free(context->ssl_ctx);
+		context->ssl_ctx = NULL;
+	}
+#endif
 #if defined(WITH_BROKER) && defined(__GLIBC__) && defined(WITH_ADNS)
 	if(context->adns){
 		gai_cancel(context->adns);

--- a/src/database.c
+++ b/src/database.c
@@ -191,10 +191,6 @@ int db__open(struct mosquitto__config *config)
 	db.contexts_by_id = NULL;
 	db.contexts_by_sock = NULL;
 	db.contexts_for_free = NULL;
-#ifdef WITH_BRIDGE
-	db.bridges = NULL;
-	db.bridge_count = 0;
-#endif
 
 	/* Initialize the hashtable */
 	db.clientid_index_hash = NULL;

--- a/src/loop.c
+++ b/src/loop.c
@@ -199,7 +199,7 @@ int mosquitto_main_loop(struct mosquitto__listener_sock *listensock, int listens
 		keepalive__check();
 
 #ifdef WITH_BRIDGE
-		bridge_check();
+		bridge_check_all();
 #endif
 
 		rc = mux__handle(listensock, listensock_count);
@@ -238,6 +238,7 @@ int mosquitto_main_loop(struct mosquitto__listener_sock *listensock, int listens
 			mosquitto_security_apply();
 			log__close(db.config);
 			log__init(db.config);
+			bridge__start_all();
 			flag_reload = false;
 		}
 		if(flag_tree_print){

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -439,9 +439,6 @@ static int pid__write(void)
 int main(int argc, char *argv[])
 {
 	struct mosquitto__config config;
-#ifdef WITH_BRIDGE
-	int i;
-#endif
 	int rc;
 #ifdef WIN32
 	SYSTEMTIME st;
@@ -486,7 +483,10 @@ int main(int argc, char *argv[])
 
 	config__init(&config);
 	rc = config__parse_args(&config, argc, argv);
-	if(rc != MOSQ_ERR_SUCCESS) return rc;
+	if(rc != MOSQ_ERR_SUCCESS){
+		config__cleanup(&config);
+		return rc;
+	}
 	db.config = &config;
 
 	/* Drop privileges permanently immediately after the config is loaded.
@@ -589,14 +589,6 @@ int main(int argc, char *argv[])
 	HASH_ITER(hh_sock, db.contexts_by_sock, ctxt, ctxt_tmp){
 		context__cleanup(ctxt, true);
 	}
-#ifdef WITH_BRIDGE
-	for(i=0; i<db.bridge_count; i++){
-		if(db.bridges[i]){
-			context__cleanup(db.bridges[i], true);
-		}
-	}
-	mosquitto__free(db.bridges);
-#endif
 	context__free_disused();
 
 	db__close();


### PR DESCRIPTION
As the title says, this branch contains work to add support for reloading bridge configurations, as well as a plugin for dynamic bridge configuration (with `mosquitto_ctrl` CLI integration).

I started working off the master branch, and while starting to rebase onto develop (to open this PR), I realized that bridge related code has changed quite a bit and it looked like there are ongoing preparations to support bridge config reloading.

Before investing more time to integrate with these changes, I would like to hear your opinion if the work I've done has any chance to be merged and if it might collide with your plans.