### PR TITLE
mosquitto_property_copy_all: copy client_generated flag

### DIFF
--- a/lib/property_mosq.c
+++ b/lib/property_mosq.c
@@ -1209,6 +1209,7 @@ int mosquitto_property_copy_all(mosquitto_property **dest, const mosquitto_prope
 		plast = pnew;
 
 		pnew->identifier = src->identifier;
+		pnew->client_generated = src->client_generated;
 		switch(pnew->identifier){
 			case MQTT_PROP_PAYLOAD_FORMAT_INDICATOR:
 			case MQTT_PROP_REQUEST_PROBLEM_INFORMATION:


### PR DESCRIPTION
The function mosquitto_property_copy_all doesn't copy the flag client_generated. If this function is used on the user side in order to construct mosquitto properties this will lead that only the first properties of the original properties will be send