### PR TITLE
support plugin tick callbacks with per_listener_settings config enabled

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -180,10 +180,18 @@ void plugin__handle_tick(void)
 	struct mosquitto_evt_tick event_data;
 	struct mosquitto__callback *cb_base;
 	struct mosquitto__security_options *opts;
+	int i;
 
 	/* FIXME - set now_s and now_ns to avoid need for multiple time lookups */
 	if(db.config->per_listener_settings){
-		/* FIXME - iterate over all listeners */
+		for(i=0; i < db.config->listener_count; i++){
+			opts = &db.config->listeners[i].security_options;
+			memset(&event_data, 0, sizeof(event_data));
+
+			DL_FOREACH(opts->plugin_callbacks.tick, cb_base){
+				cb_base->cb(MOSQ_EVT_TICK, &event_data, cb_base->userdata);
+			}
+		}
 	}else{
 		opts = &db.config->security_options;
 		memset(&event_data, 0, sizeof(event_data));

--- a/test/broker/09-plugin-tick.py
+++ b/test/broker/09-plugin-tick.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Test whether a plugin can subscribe to the tick event
+
+from mosq_test_helper import *
+
+def write_config(filename, port, per_listener_settings="false"):
+    with open(filename, 'w') as f:
+        f.write("per_listener_settings %s\n" % (per_listener_settings))
+        f.write("listener %d\n" % (port))
+        f.write("plugin c/auth_plugin_v5_handle_tick.so\n")
+        f.write("allow_anonymous true\n")
+
+def do_test(per_listener_settings):
+    proto_ver = 5
+    port = mosq_test.get_port()
+    conf_file = os.path.basename(__file__).replace('.py', '.conf')
+    write_config(conf_file, port, per_listener_settings)
+
+    rc = 1
+    keepalive = 10
+    connect_packet = mosq_test.gen_connect("plugin-tick-test", keepalive=keepalive, username="readwrite", clean_session=False, proto_ver=proto_ver)
+    connack_packet = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
+
+    tick_packet = mosq_test.gen_publish("topic/tick", qos=0, payload="test-message", proto_ver=proto_ver)
+
+    broker = mosq_test.start_broker(filename=os.path.basename(__file__), use_conf=True, port=port)
+
+    try:
+        sock = mosq_test.do_client_connect(connect_packet, connack_packet, timeout=10, port=port)
+
+        mosq_test.expect_packet(sock, "tick message", tick_packet)
+        mosq_test.expect_packet(sock, "tick message", tick_packet)
+        mosq_test.expect_packet(sock, "tick message", tick_packet)
+
+        mosq_test.do_ping(sock)
+
+        rc = 0
+        sock.close()
+    except mosq_test.TestError:
+        pass
+    finally:
+        os.remove(conf_file)
+        broker.terminate()
+        broker.wait()
+        (stdo, stde) = broker.communicate()
+        if rc:
+            print(stde.decode('utf-8'))
+            exit(rc)
+
+do_test("false")
+do_test("true")

--- a/test/broker/c/Makefile
+++ b/test/broker/c/Makefile
@@ -18,6 +18,7 @@ PLUGIN_SRC = \
 	auth_plugin_v4.c \
 	auth_plugin_v5.c \
 	auth_plugin_v5_handle_message.c \
+	auth_plugin_v5_handle_tick.c \
 	plugin_control.c
 
 PLUGINS = ${PLUGIN_SRC:.c=.so}

--- a/test/broker/c/auth_plugin_v5_handle_tick.c
+++ b/test/broker/c/auth_plugin_v5_handle_tick.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mosquitto.h>
+#include <mosquitto_broker.h>
+#include <mosquitto_plugin.h>
+
+static int handle_tick(int event, void *event_data, void *user_data);
+
+static mosquitto_plugin_id_t *plg_id;
+
+
+int mosquitto_plugin_version(int supported_version_count, const int *supported_versions)
+{
+	return 5;
+}
+
+int mosquitto_plugin_init(mosquitto_plugin_id_t *identifier, void **user_data, struct mosquitto_opt *auth_opts, int auth_opt_count)
+{
+	plg_id = identifier;
+
+	mosquitto_callback_register(plg_id, MOSQ_EVT_TICK, handle_tick, NULL, NULL);
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+int mosquitto_plugin_cleanup(void *user_data, struct mosquitto_opt *auth_opts, int auth_opt_count)
+{
+	mosquitto_callback_unregister(plg_id, MOSQ_EVT_TICK, handle_tick, NULL);
+
+	return MOSQ_ERR_SUCCESS;
+}
+
+int handle_tick(int event, void *event_data, void *user_data)
+{
+	mosquitto_broker_publish_copy("plugin-tick-test", "topic/tick", strlen("test-message"), "test-message", 0, false, NULL);
+	return MOSQ_ERR_SUCCESS;
+}

--- a/test/broker/test.py
+++ b/test/broker/test.py
@@ -153,6 +153,7 @@ tests = [
     (1, './09-plugin-auth-v2-unpwd-fail.py'),
     (1, './09-plugin-auth-v2-unpwd-success.py'),
     (1, './09-plugin-publish.py'),
+    (1, './09-plugin-tick.py'),
     (1, './09-pwfile-parse-invalid.py'),
 
     (2, './10-listener-mount-point.py'),


### PR DESCRIPTION
This should fix that plugins don't get tick events if the config file has the "per_listener_settings" set to true.

I added some tests for the ticks feature. I hope they match with the code standard.

-----

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
