### PR TITLE
Suppress warning on NetBSD

### DIFF
--- a/lib/strings_mosq.c
+++ b/lib/strings_mosq.c
@@ -20,6 +20,9 @@ Contributors:
 
 #include <errno.h>
 #include <string.h>
+#if defined(__NetBSD__)
+#include <strings.h>
+#endif
 
 #include "mosquitto.h"
 #include "mqtt_protocol.h"


### PR DESCRIPTION
On NetBSD, strcasecmp(3) is defined in strings.h.

Signed-off-by: Frédéric Fauberteau <frederic@fauberteau.org>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
