### PR TITLE
Allow empty passwords in dynamic security plugin.

### DIFF
--- a/plugins/dynamic-security/clients.c
+++ b/plugins/dynamic-security/clients.c
@@ -187,7 +187,12 @@ int dynsec_clients__config_load(cJSON *tree)
 				mosquitto_free(buf);
 				client->pw.valid = true;
 			}else{
-				client->pw.valid = false;
+				client->pw.valid = allow_empty_passwords && !j_salt && !j_password && !j_iterations;
+				if (allow_empty_passwords){
+					memset(client->pw.password_hash, 0, sizeof(client->pw.password_hash));
+					memset(client->pw.salt, 0, sizeof(client->pw.salt));
+					client->pw.iterations = 0;
+				}
 			}
 
 			/* Client id */

--- a/plugins/dynamic-security/dynamic_security.h
+++ b/plugins/dynamic-security/dynamic_security.h
@@ -130,6 +130,7 @@ struct dynsec__acl_default_access{
 
 extern struct dynsec__group *dynsec_anonymous_group;
 extern struct dynsec__acl_default_access default_access;
+extern bool allow_empty_passwords;
 
 /* ################################################################
  * #

--- a/plugins/dynamic-security/plugin.c
+++ b/plugins/dynamic-security/plugin.c
@@ -36,6 +36,7 @@ Contributors:
 static mosquitto_plugin_id_t *plg_id = NULL;
 static char *config_file = NULL;
 struct dynsec__acl_default_access default_access = {false, false, false, false};
+bool allow_empty_passwords = false;
 
 void dynsec__command_reply(cJSON *j_responses, struct mosquitto *context, const char *command, const char *error, const char *correlation_data)
 {
@@ -288,7 +289,7 @@ int mosquitto_plugin_version(int supported_version_count, const int *supported_v
 
 static int dynsec__general_config_load(cJSON *tree)
 {
-	cJSON *j_default_access, *jtmp;
+	cJSON *j_default_access, *jtmp, *j_allow_empty_passwords;
 
 	j_default_access = cJSON_GetObjectItem(tree, "defaultACLAccess");
 	if(j_default_access && cJSON_IsObject(j_default_access)){
@@ -319,6 +320,12 @@ static int dynsec__general_config_load(cJSON *tree)
 		}else{
 			default_access.unsubscribe = false;
 		}
+	}
+	j_allow_empty_passwords = cJSON_GetObjectItem(tree, "allowEmptyPasswords");
+	if(j_allow_empty_passwords && cJSON_IsBool(j_allow_empty_passwords)){
+		allow_empty_passwords = cJSON_IsTrue(j_allow_empty_passwords);
+	}else{
+		allow_empty_passwords = false;
 	}
 	return MOSQ_ERR_SUCCESS;
 }


### PR DESCRIPTION
We use certificates to encrypt communication with a broker, and use empty passwords, since they don't provide that much difference in security beyond encryption.
We would like to use dynamic security plugin and not have to update all of the application clients on running systems to provide passwords, we woud still like to use empty passwords.
That's why I implemented a configurable option to allow this.