### PR TITLE
Fix memory leak when modifying topics using the plugin API

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -162,7 +162,11 @@ int plugin__handle_message(struct mosquitto *context, struct mosquitto_msg_store
 		}
 	}
 
-	stored->topic = event_data.topic;
+	if(stored->topic != event_data.topic){
+		mosquitto__free(stored->topic);
+		stored->topic = event_data.topic;
+	}
+
 	if(stored->payload != event_data.payload){
 		mosquitto__free(stored->payload);
 		stored->payload = event_data.payload;


### PR DESCRIPTION
The MOSQ_EVT_MESSAGE callback offers the flexibility to modify not only the payload, but also the topic. I might be missing something, but I believe the topic should receive the same treatment as the payload. Old memory should be freed in cases where the plugin intends to replace the topic. This PR implements that change.

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
