### PR TITLE
Add list of connections to dynsec plugin listClients/getClient response

### DIFF
--- a/include/mosquitto_broker.h
+++ b/include/mosquitto_broker.h
@@ -651,6 +651,18 @@ mosq_EXPORT int mosquitto_kick_client_by_clientid(const char *clientid, bool wit
  */
 mosq_EXPORT int mosquitto_kick_client_by_username(const char *username, bool with_will);
 
+/* Function: mosquitto_apply_on_all_clients
+ *
+ * Apply a given functor to all clients
+ *
+ * The functor will be applied to all existing client structures. If the functor
+ * returns an error code the iteration over the clients will be stopped. The
+ * functor_context pointer maybe used to pass additional data structures into
+ * the functor as second argument.
+ *
+ * The result value will be the result of the last functor invoked.
+ */
+mosq_EXPORT int mosquitto_apply_on_all_clients(int (*FUNC_client_functor)(const struct mosquitto *, void *), void *functor_context);
 
 /* =========================================================================
  *

--- a/man/Makefile
+++ b/man/Makefile
@@ -57,37 +57,7 @@ uninstall :
 	-rm -f "${DESTDIR}${mandir}/man7/mosquitto-tls.7"
 	-rm -f "${DESTDIR}${mandir}/man3/libmosquitto.3"
 
-mosquitto.8 : mosquitto.8.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto.conf.5 : mosquitto.conf.5.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto_ctrl.1 : mosquitto_ctrl.1.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto_ctrl_dynsec.1 : mosquitto_ctrl_dynsec.1.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto_passwd.1 : mosquitto_passwd.1.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto_pub.1 : mosquitto_pub.1.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto_sub.1 : mosquitto_sub.1.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto_rr.1 : mosquitto_rr.1.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mqtt.7 : mqtt.7.xml manpage.xsl
-	$(XSLTPROC) $<
-
-mosquitto-tls.7 : mosquitto-tls.7.xml manpage.xsl
-	$(XSLTPROC) $<
-
-libmosquitto.3 : libmosquitto.3.xml manpage.xsl
+% : %.xml %.meta manpage.xsl
 	$(XSLTPROC) $<
 
 html : *.xml

--- a/plugins/common/plugin_common.c
+++ b/plugins/common/plugin_common.c
@@ -1,5 +1,9 @@
-#include <cjson/cJSON.h>
 #include "plugin_common.h"
+#include <mqtt_protocol.h>
+#include <mosquitto_broker.h>
+
+#include <stdlib.h>
+#include <string.h>
 
 void plugin__command_reply(struct plugin_cmd *cmd, const char *error)
 {
@@ -19,3 +23,21 @@ void plugin__command_reply(struct plugin_cmd *cmd, const char *error)
 
 	cJSON_AddItemToArray(cmd->j_responses, j_response);
 }
+
+void plugin_send_response(cJSON *tree, const char* topic)
+{
+	char *payload;
+	size_t payload_len;
+
+	payload = cJSON_PrintUnformatted(tree);
+	cJSON_Delete(tree);
+	if(payload == NULL) return;
+
+	payload_len = strlen(payload);
+	if(payload_len > MQTT_MAX_PAYLOAD){
+		free(payload);
+		return;
+	}
+	mosquitto_broker_publish(NULL, topic, (int)payload_len, payload, 0, 0, NULL);
+}
+

--- a/plugins/common/plugin_common.h
+++ b/plugins/common/plugin_common.h
@@ -12,4 +12,6 @@ struct plugin_cmd{
 
 void plugin__command_reply(struct plugin_cmd *cmd, const char *error);
 
+void plugin_send_response(cJSON *tree, const char* topic);
+
 #endif

--- a/plugins/dynamic-security/Makefile
+++ b/plugins/dynamic-security/Makefile
@@ -94,7 +94,7 @@ password_mosq.o : ${R}/common/password_mosq.c ${R}/common/password_mosq.h
 plugin.o : plugin.c dynamic_security.h
 	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
 
-plugin_common.o : ${R}/plugins/common/plugin_common.c dynamic_security.h
+plugin_common.o : ${R}/plugins/common/plugin_common.c ${R}/plugins/common/plugin_common.h
 	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
 
 roles.o : roles.c dynamic_security.h

--- a/plugins/dynamic-security/control.c
+++ b/plugins/dynamic-security/control.c
@@ -35,20 +35,7 @@ Contributors:
 
 static void send_response(cJSON *tree)
 {
-	char *payload;
-	size_t payload_len;
-
-	payload = cJSON_PrintUnformatted(tree);
-	cJSON_Delete(tree);
-	if(payload == NULL) return;
-
-	payload_len = strlen(payload);
-	if(payload_len > MQTT_MAX_PAYLOAD){
-		free(payload);
-		return;
-	}
-	mosquitto_broker_publish(NULL, "$CONTROL/dynamic-security/v1/response",
-			(int)payload_len, payload, 0, 0, NULL);
+	plugin_send_response(tree, "$CONTROL/dynamic-security/v1/response");
 }
 
 

--- a/src/linker.syms
+++ b/src/linker.syms
@@ -20,6 +20,7 @@
 	mosquitto_free;
 	mosquitto_kick_client_by_clientid;
 	mosquitto_kick_client_by_username;
+	mosquitto_apply_on_all_clients;
 	mosquitto_log_printf;
 	mosquitto_malloc;
 	mosquitto_persist_client_add;

--- a/src/plugin_public.c
+++ b/src/plugin_public.c
@@ -400,6 +400,20 @@ int mosquitto_kick_client_by_username(const char *username, bool with_will)
 	return MOSQ_ERR_SUCCESS;
 }
 
+int mosquitto_apply_on_all_clients(int (*FUNC_client_functor)(const struct mosquitto *, void *), void *functor_context)
+{
+	int rc = MOSQ_ERR_SUCCESS;
+	struct mosquitto *ctxt, *ctxt_tmp;
+
+	HASH_ITER(hh_id, db.contexts_by_id, ctxt, ctxt_tmp){
+		rc = (*FUNC_client_functor)(ctxt, functor_context);
+		if(rc != MOSQ_ERR_SUCCESS){
+			break;
+		}
+	}
+
+	return rc;
+}
 
 int mosquitto_persist_client_add(struct mosquitto_evt_persist_client *client)
 {

--- a/test/broker/14-dynsec-client.py
+++ b/test/broker/14-dynsec-client.py
@@ -44,15 +44,15 @@ list_clients_verbose_command = { "commands": [{
             "command": "listClients", "verbose": True, "correlationData": "20"}]
 }
 list_clients_verbose_response = {'responses':[{"command": "listClients", "data":{"totalCount":2, "clients":[
-    {'username': 'admin', 'textname': 'Dynsec admin user', 'roles': [{'rolename': 'admin'}], 'groups': []},
+    {'username': 'admin', 'textname': 'Dynsec admin user', 'roles': [{'rolename': 'admin'}], 'groups': [], 'connections': [{'address': '127.0.0.1'}]},
     {"username":"user_one", "clientid":"cid", "textname":"Name", "textdescription":"Description",
-        "roles":[], "groups":[]}]}, "correlationData":"20"}]}
+        "roles":[], "groups":[], 'connections': []}]}, "correlationData":"20"}]}
 
 
 get_client_command = { "commands": [{
     "command": "getClient", "username": "user_one", "correlationData": "42"}]}
 get_client_response = {'responses':[{'command': 'getClient', 'data': {'client': {'username': 'user_one', 'clientid': 'cid',
-    'textname': 'Name', 'textdescription': 'Description', 'groups': [], 'roles': []}}, "correlationData":"42"}]}
+    'textname': 'Name', 'textdescription': 'Description', 'groups': [], 'connections': [], 'roles': []}}, "correlationData":"42"}]}
 
 set_client_password_command = {"commands": [{
     "command": "setClientPassword", "username": "user_one", "password": "password"}]}

--- a/test/broker/14-dynsec-disable-client.py
+++ b/test/broker/14-dynsec-disable-client.py
@@ -38,9 +38,9 @@ add_client_repeat_response = {'responses':[{"command":"createClient","error":"Cl
 get_client_command = { "commands": [{
             "command": "getClient", "username": "user_one"}]}
 get_client_response1 = {'responses':[{'command': 'getClient', 'data': {'client': {'username': 'user_one', 'clientid': 'cid',
-    'textname': 'Name', 'textdescription': 'Description', 'groups': [], 'roles': []}}}]}
+            'textname': 'Name', 'textdescription': 'Description', 'groups': [], 'roles': [], 'connections': []}}}]}
 get_client_response2 = {'responses':[{'command': 'getClient', 'data': {'client': {'username': 'user_one', 'clientid': 'cid',
-    'textname': 'Name', 'textdescription': 'Description', 'disabled':True, 'groups': [], 'roles': []}}}]}
+            'textname': 'Name', 'textdescription': 'Description', 'disabled':True, 'groups': [], 'roles': [], 'connections': []}}}]}
 
 disable_client_command = { "commands": [{
             "command": "disableClient", "username": "user_one"}]}

--- a/test/broker/14-dynsec-group.py
+++ b/test/broker/14-dynsec-group.py
@@ -70,11 +70,11 @@ list_groups_verbose_response = {'responses':[{'command': 'listGroups', 'data': {
 list_clients_verbose_command = { "commands": [{
             "command": "listClients", "verbose": True, "correlationData": "20"}]}
 list_clients_verbose_response = {'responses':[{"command": "listClients", "data":{"totalCount":3, "clients":[
-            {'username': 'admin', 'textname': 'Dynsec admin user', 'roles': [{'rolename': 'admin'}], 'groups': []},
+            {'username': 'admin', 'textname': 'Dynsec admin user', 'roles': [{'rolename': 'admin'}], 'groups': [], 'connections': [{'address': '127.0.0.1'}]},
             {"username":"user_one", "clientid":"cid", "textname":"Name", "textdescription":"description",
-            "groups":[{"groupname":"group_one"}, {"groupname":"group_two"}], "roles":[]},
+             "groups":[{"groupname":"group_one"}, {"groupname":"group_two"}], "roles":[], 'connections': []},
             {"username":"user_two", "textname":"Name", "textdescription":"description",
-            "groups":[{"groupname":"group_one"}], "roles":[]},
+             "groups":[{"groupname":"group_one"}], "roles":[],  'connections': []},
             ]}, "correlationData":"20"}]}
 
 get_group_command = { "commands": [{"command": "getGroup", "groupname":"group_one"}]}

--- a/test/broker/14-dynsec-modify-client.py
+++ b/test/broker/14-dynsec-modify-client.py
@@ -109,6 +109,7 @@ get_client_response1 = {'responses':[{'command': 'getClient', 'data': {'client':
     'textname': 'Name', 'textdescription': 'Description',
     'roles': [],
     'groups': [],
+    'connections': []
     }}}]}
 
 get_client_command2 = { "commands": [{
@@ -122,8 +123,9 @@ get_client_response2 = {'responses':[{'command': 'getClient', 'data': {'client':
     ],
     'groups': [
         {'groupname':'group_two', 'priority':8},
-        {'groupname':'group_one', 'priority':3}
-    ]}}}]}
+        {'groupname':'group_one', 'priority':3}],
+    'connections': []
+    }}}]}
 
 get_client_command3 = { "commands": [{
             "command": "getClient", "username": "user_one"}]}
@@ -133,8 +135,9 @@ get_client_response3 = {'responses':[{'command': 'getClient', 'data': {'client':
     'roles': [
         {'rolename':'role_three', 'priority':10},
         {'rolename':'role_one', 'priority':2},
-        {'rolename':'role_two'}
-    ]}}}]}
+        {'rolename':'role_two'}],
+     'connections': []
+    }}}]}
 
 
 

--- a/test/broker/14-dynsec-role.py
+++ b/test/broker/14-dynsec-role.py
@@ -148,11 +148,11 @@ list_clients_verbose_command = { "commands": [{
     "command": "listClients", "verbose": True, "correlationData": "20"}]
 }
 list_clients_verbose_response = {'responses':[{"command": "listClients", "data":{'totalCount':3, "clients":[
-    {'username': 'admin', 'textname': 'Dynsec admin user', 'roles': [{'rolename': 'admin'}], 'groups': []},
+    {'username': 'admin', 'textname': 'Dynsec admin user', 'roles': [{'rolename': 'admin'}], 'groups': [],  'connections': [{'address': '127.0.0.1'}]},
     {"username":"user_one", "clientid":"cid", "textname":"Name", "textdescription":"Description",
-    "groups":[], "roles":[{'rolename':'basic'}, {'rolename':'basic2'}]},
+     "groups":[], "roles":[{'rolename':'basic'}, {'rolename':'basic2'}],  'connections': []},
     {"username":"user_two", "textname":"Name", "textdescription":"Description",
-    "groups":[], "roles":[]}]}, "correlationData":"20"}]}
+     "groups":[], "roles":[], 'connections': []}]}, "correlationData":"20"}]}
 
 list_groups_verbose_command = { "commands": [{
     "command": "listGroups", "verbose": True, "correlationData": "20"}]


### PR DESCRIPTION
For the dynsec plugin it would be helpfull to get a list of the connections for a given username. This way it's possible to check, which connections are using a give username (e.g will be disconnected when changing this user)

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
