### PR TITLE
fix more memory leaks on plugin payload modification

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -157,23 +157,29 @@ int plugin__handle_message(struct mosquitto *context, struct mosquitto_msg_store
 
 	DL_FOREACH(opts->plugin_callbacks.message, cb_base){
 		rc = cb_base->cb(MOSQ_EVT_MESSAGE, &event_data, cb_base->userdata);
+
+		if(stored->topic != event_data.topic){
+			mosquitto__free(stored->topic);
+			stored->topic = event_data.topic;
+		}
+
+		if(stored->payload != event_data.payload){
+			mosquitto__free(stored->payload);
+			stored->payload = event_data.payload;
+			stored->payloadlen = event_data.payloadlen;
+		}
+
+		if(stored->properties != event_data.properties){
+			mosquitto_property_free_all(stored->properties);
+			stored->properties = event_data.properties;
+		}
+
 		if(rc != MOSQ_ERR_SUCCESS){
 			break;
 		}
 	}
 
-	if(stored->topic != event_data.topic){
-		mosquitto__free(stored->topic);
-		stored->topic = event_data.topic;
-	}
-
-	if(stored->payload != event_data.payload){
-		mosquitto__free(stored->payload);
-		stored->payload = event_data.payload;
-		stored->payloadlen = event_data.payloadlen;
-	}
 	stored->retain = event_data.retain;
-	stored->properties = event_data.properties;
 
 	return rc;
 }


### PR DESCRIPTION
A while ago I was using the payload modification functionality, and spotted a memory leak. Completely missed other 2 leaks:
- If the plugin replaces the list of properties
- If there is more than one plugin chained

This PR fixes those leaks.

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
