### PR TITLE
fix default bridge backoff periods (scale seconds to milliseconds)

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -889,7 +889,7 @@ static void bridge__update_backoff(struct mosquitto__bridge *bridge)
 
 	bridge->connected_at = 0;
 
-	log__printf(NULL, MOSQ_LOG_INFO, "Bridge %s next backoff will be %d", bridge->name, bridge->restart_timeout);
+	log__printf(NULL, MOSQ_LOG_INFO, "Bridge %s next backoff will be %d ms", bridge->name, bridge->restart_timeout);
 }
 
 static void bridge_check_pending(struct mosquitto *context)

--- a/src/conf.c
+++ b/src/conf.c
@@ -1509,8 +1509,8 @@ static int config__read_file_core(struct mosquitto__config *config, bool reload,
 						cur_bridge->start_type = bst_automatic;
 						cur_bridge->idle_timeout = 60;
 						cur_bridge->restart_timeout = 0;
-						cur_bridge->backoff_base = 5;
-						cur_bridge->backoff_cap = 30;
+						cur_bridge->backoff_base = 5 * 1000;
+						cur_bridge->backoff_cap = 30 * 1000;
 						cur_bridge->stable_connection_period = 0;
 						cur_bridge->threshold = 10;
 						cur_bridge->try_private = true;


### PR DESCRIPTION
Pull request #2422 changed bridge backoff to count time in milliseconds. Though the configuration file parser was modified to take this into account, the default values were forgotten.

This PR fixes that change, which is currently only on develop

-----

Signed-off-by: Abilio Marques <abiliojr@gmail.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
