### PR TITLE
CMake: Use PROJECT_SOURCE_DIR to improve using mosquitto as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_policy(SET CMP0042 NEW)
 project(mosquitto)
 set (VERSION 2.0.14)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
 add_definitions (-DCMAKE -DVERSION=\"${VERSION}\")
 

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -8,10 +8,10 @@ if(NOT WIN32)
 	find_program(XSLTPROC xsltproc OPTIONAL)
 	if(XSLTPROC)
 		function(compile_manpage page)
-			add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/man/${page}
-				COMMAND xsltproc ${CMAKE_SOURCE_DIR}/man/${page}.xml -o ${CMAKE_SOURCE_DIR}/man/
-				MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/man/${page}.xml)
-			add_custom_target(${page} ALL DEPENDS ${CMAKE_SOURCE_DIR}/man/${page})
+			add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/man/${page}
+				COMMAND xsltproc ${PROJECT_SOURCE_DIR}/man/${page}.xml -o ${PROJECT_SOURCE_DIR}/man/
+				MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/man/${page}.xml)
+			add_custom_target(${page} ALL DEPENDS ${PROJECT_SOURCE_DIR}/man/${page})
 		endfunction()
 
 		compile_manpage("mosquitto_ctrl.1")


### PR DESCRIPTION
When mosquitto is included as subdirectory, `CMAKE_SOURCE_DIR` does not refer to the mosquitto top level CMake file, but to the whole project top level CMake.
Use `PROJECT_SOURCE_DIR` instead to refer to the right CMake in both contextes.

Signed-off-by: Pierre Hallot <hallotpierre@gmail.com>

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?