### PR TITLE
Add flush_period and page_size options to persist-sqlite

### DIFF
--- a/plugins/persist-sqlite/init.c
+++ b/plugins/persist-sqlite/init.c
@@ -268,11 +268,12 @@ int persist_sqlite__init(struct mosquitto_sqlite *ms)
 				ms->db_file, sqlite3_errstr(rc));
 		return MOSQ_ERR_UNKNOWN;
 	}
+	snprintf(buf, sizeof(buf), "PRAGMA page_size=%u;", ms->page_size);
+	rc = sqlite3_exec(ms->db, buf, NULL, NULL, NULL);
+	if(rc) goto fail;
 	rc = sqlite3_exec(ms->db, "PRAGMA journal_mode=WAL;", NULL, NULL, NULL);
 	if(rc) goto fail;
 	rc = sqlite3_exec(ms->db, "PRAGMA foreign_keys = ON;", NULL, NULL, NULL);
-	if(rc) goto fail;
-	rc = sqlite3_exec(ms->db, "PRAGMA page_size=32768;", NULL, NULL, NULL);
 	if(rc) goto fail;
 	snprintf(buf, sizeof(buf), "PRAGMA synchronous=%d;", ms->synchronous);
 	rc = sqlite3_exec(ms->db, buf, NULL, NULL, NULL);

--- a/plugins/persist-sqlite/persist_sqlite.h
+++ b/plugins/persist-sqlite/persist_sqlite.h
@@ -47,7 +47,9 @@ struct mosquitto_sqlite {
 	sqlite3_stmt *retain_msg_remove_stmt;
 	time_t last_transaction;
 	int synchronous;
-	int event_count;
+	unsigned int event_count;
+	unsigned int flush_period;
+	unsigned int page_size;
 };
 
 int persist_sqlite__init(struct mosquitto_sqlite *ms);

--- a/plugins/persist-sqlite/test.conf
+++ b/plugins/persist-sqlite/test.conf
@@ -1,2 +1,4 @@
 plugin ./mosquitto_persist_sqlite.so
 plugin_opt_db_file test.sqlite3
+plugin_opt_page_size 4096
+plugin_opt_flush_period 5

--- a/plugins/persist-sqlite/tick.c
+++ b/plugins/persist-sqlite/tick.c
@@ -31,8 +31,7 @@ int persist_sqlite__tick_cb(int event, void *event_data, void *userdata)
 	struct mosquitto_sqlite *ms = userdata;
 
 	UNUSED(event);
-
-	if(ed->now_s > ms->last_transaction + 5 && ms->event_count > 0){
+	if(ed->now_s > ms->last_transaction + ms->flush_period && ms->event_count > 0){
 		ms->last_transaction = ed->now_s;
 		ms->event_count = 0;
 		sqlite3_exec(ms->db, "END;", NULL, NULL, NULL);


### PR DESCRIPTION
This PR:
- Adds option to configure the flush period
- Adds option to configure the sqlite3 page size
- Fixes page_size setup by moving `PRAGMA page_size = ...` to it happens before setting the journal_mode to WAL

The default page_size still is 32KB (far from the 4KB SQLite's default). Unless the broker is always writing close to that size continuously, it actually causes 8x flash wear without huge performance improvements. Maybe 4KB should be the default, and can be tuned on an application basis

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
