### PR TITLE
broker: add command line argument to test configuration and exit

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -55,6 +55,8 @@ Broker:
 - Bridge reconnection backoff improvements.
 - Add bridge_tls_use_os_certs option to allow bridges to be easily configured
   to trust default CA certificates. Closes #2473.
+- Add `--test-config` option which can be used to test a configuration file
+  before trying to use it in a live broker. Closes #2521.
 
 Plugins / plugin interface:
 - Add persist-sqlite plugin.

--- a/src/conf.c
+++ b/src/conf.c
@@ -387,9 +387,10 @@ static void print_usage(void)
 	printf("      Not recommended in conjunction with the -c option.\n");
 	printf(" -v : verbose mode - enable all logging types. This overrides\n");
 	printf("      any logging options given in the config file.\n");
-	printf(" --tls-keylog : Log TLS connection information to a file, to allow\n");
+	printf(" --tls-keylog : log TLS connection information to a file, to allow\n");
 	printf("      debugging with e.g. wireshark. Do not use on a production\n");
 	printf("      server.\n");
+	printf(" --test-config : test config file and exit\n");
 	printf("\nSee https://mosquitto.org/ for more information.\n\n");
 }
 
@@ -454,6 +455,8 @@ int config__parse_args(struct mosquitto__config *config, int argc, char *argv[])
 #endif
 		}else if(!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")){
 			db.verbose = true;
+		}else if(!strcmp(argv[i], "--test-config")){
+			config->test_configuration = true;
 		}else{
 			fprintf(stderr, "Error: Unknown option '%s'.\n",argv[i]);
 			print_usage();

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -264,6 +264,16 @@ int main(int argc, char *argv[])
 	rc = config__parse_args(&config, argc, argv);
 	if(rc != MOSQ_ERR_SUCCESS) return rc;
 
+	if(config.test_configuration){
+		if(!db.config_file){
+			log__printf(NULL, MOSQ_LOG_ERR, "Please provide a configuration file to test.");
+			return MOSQ_ERR_INVAL;
+		}else{
+			log__printf(NULL, MOSQ_LOG_INFO, "Configuration file is OK.");
+			return MOSQ_ERR_SUCCESS;
+		}
+	}
+
 	rc = keepalive__init();
 	if(rc != MOSQ_ERR_SUCCESS) return rc;
 

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -306,6 +306,7 @@ struct mosquitto__config {
 	uint16_t cmd_port[CMD_PORT_LIMIT];
 	int cmd_port_count;
 	bool daemon;
+	bool test_configuration;
 	bool enable_control_api;
 	int global_max_clients;
 	int global_max_connections;


### PR DESCRIPTION
Allow broker users to test their configuration file before they reload it, by using the command line switch `--test-config`. This was requested by a user in  #2521.

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
