### PR TITLE
Enable TLS v1.3 with TLS-PSK

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -65,6 +65,7 @@ Broker:
   preferred websockets implementation.
 - Add support for X-Forwarded-For header for built in websockets.
 - Report persistence stats when starting.
+- Enable TLS v1.3 when using TLS-PSK.
 
 Plugins / plugin interface:
 - Add persist-sqlite plugin.
@@ -145,6 +146,7 @@ Client library:
 - `mosquitto_unsubscribe*()` now returns MOSQ_ERR_INVAL if an empty string is
   passed as a topic filter.
 - Add websockets support.
+- Enable TLS v1.3 when using TLS-PSK.
 
 Clients:
 - Add `-W` timeout support to Windows.

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -690,12 +690,6 @@ static int net__init_ssl_ctx(struct mosquitto *mosq)
 			}
 		}
 
-#ifdef SSL_OP_NO_TLSv1_3
-		if(mosq->tls_psk){
-			SSL_CTX_set_options(mosq->ssl_ctx, SSL_OP_NO_TLSv1_3);
-		}
-#endif
-
 		if(!mosq->tls_version){
 			SSL_CTX_set_options(mosq->ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1);
 #ifdef SSL_OP_NO_TLSv1_3

--- a/src/net.c
+++ b/src/net.c
@@ -364,18 +364,6 @@ int net__tls_server_ctx(struct mosquitto__listener *listener)
 		return MOSQ_ERR_TLS;
 	}
 
-#ifdef SSL_OP_NO_TLSv1_3
-	if(db.config->per_listener_settings){
-		if(listener->security_options.psk_file){
-			SSL_CTX_set_options(listener->ssl_ctx, SSL_OP_NO_TLSv1_3);
-		}
-	}else{
-		if(db.config->security_options.psk_file){
-			SSL_CTX_set_options(listener->ssl_ctx, SSL_OP_NO_TLSv1_3);
-		}
-	}
-#endif
-
 	if(listener->tls_version == NULL){
 		SSL_CTX_set_options(listener->ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1);
 #ifdef SSL_OP_NO_TLSv1_3


### PR DESCRIPTION
Signed-off-by: Alex Martens <eclipse@thinglab.org>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

Hi, I am trying to use TLS v1.3 with PSK, which was disabled in ea371564e7bc6e4402ff2a80b768b649644b18f2.  After some research I found this [this discussion](https://www.eclipse.org/lists/mosquitto-dev/msg02722.html) on the mailing list which indicates TLSv1.3-PSK works using the old APIs.  This commit re-enables TLS-PSK with TLS v1.3.