### PR TITLE
Fix install path to mosquittopp.h

### DIFF
--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -69,4 +69,4 @@ if(WITH_STATIC_LIBRARIES)
 	)
 endif()
 
-install(FILES mosquittopp.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES ../../mosquittopp.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")


### PR DESCRIPTION
Signed-off-by: Alex Martens <eclipse@thinglab.org>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
  - No, because this change is only on the develop branch.
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

The path to `mosquittopp.h` was updated in 5fcb2bc13fed3f440390ee03eee22035da51b1c6 for `CPP_SRC`, but not for `install`.

Without this change an install will fail with this message:
```txt
CMake Error at lib/cpp/cmake_install.cmake:115 (file):
 file INSTALL cannot find "/build/source/lib/cpp/mosquittopp.h": No such
 file or directory.
```