### PR TITLE
Fix CMake build for versions <3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,10 +104,8 @@ option(WITH_APPS "Build apps?" ON)
 option(WITH_PLUGINS "Build plugins?" ON)
 option(DOCUMENTATION "Build documentation?" ON)
 
-add_library(config-header
-	INTERFACE
-		config.h
-)
+add_library(config-header INTERFACE)
+target_sources(config-header INTERFACE config.h)
 target_include_directories(config-header
 	INTERFACE
 		${mosquitto_SOURCE_DIR}


### PR DESCRIPTION
CMake <3.19 does not support interface targets with sources.
For better IDE integrations we still can add the config.h using the
`target_sources` command.

Signed-off-by: Kai Buschulte <kai.buschulte@cedalo.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
