### PR TITLE
CMake: introduce a coverage target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,10 @@ add_subdirectory(broker)
 add_subdirectory(client)
 add_subdirectory(lib)
 add_subdirectory(unit)
+
+add_custom_target(coverage
+    COMMAND lcov --quiet --capture --directory . --output-file ${PROJECT_BINARY_DIR}/coverage.info --no-external
+    COMMAND genhtml --quiet ${PROJECT_BINARY_DIR}/coverage.info --output-directory ${PROJECT_BINARY_DIR}/coverage
+    COMMENT "Generating coverage.info and coverage/index.html in ${PROJECT_BINARY_DIR}"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)


### PR DESCRIPTION
to produce coverage information while running the tests, call cmake with
the following options:

cmake -DCMAKE_C_FLAGS=-coverage -DCMAKE_CXX_FLAGS=-coverage <build-dir>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
