### PR TITLE
Add mosquitto_get_retained function

### DIFF
--- a/include/mosquitto.h
+++ b/include/mosquitto.h
@@ -121,6 +121,7 @@ enum mosq_err_t {
 	MOSQ_ERR_OVERSIZE_PACKET = 25,
 	MOSQ_ERR_OCSP = 26,
 	MOSQ_ERR_TIMEOUT = 27,
+	MOSQ_ERR_BUFFER_FULL = 28,
 	/* 28, 29, 30 - was internal only, moved to MQTT v5 section. */
 	MOSQ_ERR_ALREADY_EXISTS = 31,
 	MOSQ_ERR_PLUGIN_IGNORE = 32,
@@ -140,6 +141,7 @@ enum mosq_err_t {
 	MOSQ_ERR_ADMINISTRATIVE_ACTION = 152,
 	MOSQ_ERR_RETAIN_NOT_SUPPORTED = 154,
 	MOSQ_ERR_CONNECTION_RATE_EXCEEDED = 159,
+	
 };
 
 /* Option values */
@@ -3399,6 +3401,42 @@ libmosq_EXPORT const char *mosquitto_property_identifier_to_string(int identifie
  * (end)
  */
 libmosq_EXPORT int mosquitto_string_to_property_info(const char *propname, int *identifier, int *type);
+
+/*
+ * Function: mosquitto_get_retained
+ *
+ * Function to get matching retained messages from the database in a blocking manner.
+ *
+ *
+ * This connects to a broker, subscribes to a topic, waits for msg_count
+ * messages to be received, then returns after disconnecting cleanly.
+ *
+ * Parameters:
+ *   sub - pointer to a subscription topic with or without wildcards + or # in a
+ *   	   		normal subscription manner
+ *
+ * 	 buffer - pointer to a "struct mosquitto_message *". The received
+ *              messages will be returned here.
+ *
+ *   buffer_size - the size of the buffer.
+ *
+ *   messages_found - pointer to a size_t where the number of found messages will be
+ * 				 written. If the buffer gets full then it will contain that same value
+ * 				 and the function return value will indicate that there were more
+ * 				 messages available
+ *
+ * Returns:
+ *   MOSQ_ERR_SUCCESS - 	   on success
+ *	 MOSQ_ERR_SUCCESS -        on success.
+ * 	 MOSQ_ERR_INVAL -          if the input parameters were invalid.
+ * 	 MOSQ_ERR_NOMEM -          if an out of memory condition occurred.
+ *	 MOSQ_ERR_PROTOCOL -       if there is a protocol error communicating with the
+ *                            broker.
+ *   MOSQ_ERR_BUFFER_FULL -    if there were more messages that matches the topic than
+ * 							   could fit in the given buffer. The buffer will contain 
+ * 							   the valid messages that could fit,
+ */
+libmosq_EXPORT int mosquitto_get_retained(const char *sub, struct mosquitto_message *const *buf, size_t *buf_size, size_t *messages_found);
 
 
 #ifdef __cplusplus

--- a/src/linker.syms
+++ b/src/linker.syms
@@ -75,4 +75,5 @@
 	mosquitto_topic_matches_sub;
 	mosquitto_topic_matches_sub_with_pattern;
 	mosquitto_validate_utf8;
+	mosquitto_get_retained;
 };

--- a/src/retain.c
+++ b/src/retain.c
@@ -351,3 +351,175 @@ void retain__clean(struct mosquitto__retainhier **retainhier)
 	}
 }
 
+static int buffer_add_msg(struct mosquitto_msg_store *retained, struct mosquitto_message **buffer, size_t buffer_size, int *index)
+{
+
+	if (*index >= buffer_size)
+	{
+		log__printf(NULL, MOSQ_LOG_ERR, "buffer_add_msg(): overflow index: %d, buffer_size: %d", *index, buffer_size);
+		return -1;
+	}
+
+	if (buffer[*index] == NULL)
+	{
+		return MOSQ_ERR_NOMEM;
+	}
+	struct mosquitto_message *msg = buffer[*index];
+	(*msg).mid = 0;
+	(*msg).payload = retained->payload;			   // does this need to be copied?
+	(*msg).payloadlen = (int)retained->payloadlen; // cast could be bad if payloadlen is big
+	(*msg).qos = 0;
+	(*msg).topic = retained->topic;
+	(*msg).retain = true;
+
+	struct mosquitto_message message = *buffer[*index];
+
+	*index = *index + 1;
+	return 0;
+}
+
+static int retain__search2(struct mosquitto__retainhier *retainhier, char **split_topics, const char *sub, struct mosquitto_message *const *buffer, size_t buffer_size, int level,
+						   int *index)
+{
+	struct mosquitto__retainhier *branch, *branch_tmp;
+	int flag = 0;
+
+	if (!strcmp(split_topics[0], "#") && split_topics[1] == NULL)
+	{
+		HASH_ITER(hh, retainhier->children, branch, branch_tmp)
+		{
+			/* Set flag to indicate that we should check for retained messages
+			 * on "foo" when we are subscribing to e.g. "foo/#" and then exit
+			 * this function and return to an earlier retain__search().
+			 */
+			flag = -1;
+			if (branch->retained)
+			{
+				int rc = buffer_add_msg(branch->retained, buffer, buffer_size, index);
+				if (rc == MOSQ_ERR_BUFFER_FULL)
+				{
+					return rc;
+				}
+			}
+
+			if (branch->children)
+			{
+				int rc = retain__search2(branch, split_topics, sub, buffer, buffer_size, level + 1, index);
+				if (rc == MOSQ_ERR_BUFFER_FULL)
+				{
+					return rc;
+				}
+			}
+		}
+	}
+	else
+	{
+		if (!strcmp(split_topics[0], "+"))
+		{
+			HASH_ITER(hh, retainhier->children, branch, branch_tmp)
+			{
+				if (split_topics[1] != NULL)
+				{
+					int rc = retain__search2(branch, &(split_topics[1]), sub, buffer, buffer_size, level + 1, index);
+					if (rc == -1 || (split_topics[1] != NULL && !strcmp(split_topics[1], "#") && level > 0))
+					{
+
+						if (branch->retained)
+						{
+
+							int rc = buffer_add_msg(branch->retained, buffer, buffer_size, index);
+							if (rc == MOSQ_ERR_BUFFER_FULL)
+							{
+								return rc;
+							}
+						}
+					}
+					else if (rc == MOSQ_ERR_BUFFER_FULL)
+					{
+						return rc;
+					}
+				}
+				else
+				{
+					if (branch->retained)
+					{
+
+						int rc = buffer_add_msg(branch->retained, buffer, buffer_size, index);
+						if (rc == MOSQ_ERR_BUFFER_FULL)
+						{
+							return rc;
+						}
+					}
+				}
+			}
+		}
+		else
+		{
+			HASH_FIND(hh, retainhier->children, split_topics[0], strlen(split_topics[0]), branch);
+			if (branch)
+			{
+				if (split_topics[1] != NULL)
+				{
+					if (retain__search2(branch, &(split_topics[1]), sub, buffer, buffer_size, level + 1, index) == -1 || (split_topics[1] != NULL && !strcmp(split_topics[1], "#") && level > 0))
+					{
+
+						if (branch->retained)
+						{
+							int rc = buffer_add_msg(branch->retained, buffer, buffer_size, index);
+							if (rc == MOSQ_ERR_BUFFER_FULL)
+							{
+								return rc;
+							}
+						}
+					}
+				}
+				else
+				{
+					if (branch->retained)
+					{
+						int rc = buffer_add_msg(branch->retained, buffer, buffer_size, index);
+						if (rc == MOSQ_ERR_BUFFER_FULL)
+						{
+							return rc;
+						}
+					}
+				}
+			}
+		}
+	}
+	return flag;
+}
+
+libmosq_EXPORT int mosquitto_get_retained(const char *sub, struct mosquitto_message *const *buffer, size_t *buffer_size, size_t *messages_found)
+{
+	struct mosquitto__retainhier *retainhier = db.retains;
+	char *local_sub;
+	char **split_topics;
+	int rc;
+
+	assert(sub);
+	rc = sub__topic_tokenise(sub, &local_sub, &split_topics, NULL);
+	if (rc)
+		return rc;
+
+	HASH_FIND(hh, db.retains, split_topics[0], strlen(split_topics[0]), retainhier);
+	int *index = mosquitto_malloc(sizeof(int));
+	if(index == NULL){
+		return MOSQ_ERR_NOMEM;
+	}
+
+	*index = 0;
+	rc = MOSQ_ERR_SUCCESS;
+	if (retainhier)
+	{
+		if (retain__search2(retainhier, split_topics, sub, buffer, *buffer_size, 0, index) == MOSQ_ERR_BUFFER_FULL) {
+			rc = MOSQ_ERR_BUFFER_FULL;
+		};
+	}
+
+	// set number of elements found for caller
+	*messages_found = *index;
+
+	mosquitto_free(index);
+	return rc;
+}


### PR DESCRIPTION
This function will search the retained database and give the caller
messages that match to the given subscription topic. No breaking
changes. Duplicates some code from retain_queue.

Happy to receive feedback on how to improve this PR. Below a few points of uncertainty:

- Header file, currently the function is declared in mosquitto.h, but i suspect that it is only useful for plugins, so I thought i should put it in mosquitto_broker.h or mosquitto_plugin.h, but i also want to use the mosquitto_message struct so i decided to put it in mosquitto.h
- Allocations: i tried to make as few allocations as possible and let the caller make the necessary allocations, this makes the function a bit cumbersome to use, any feedback on how to handle the size of the buffer vs the number of messages found would be appreciated. If mosquitto handles the memory then it return a null-terminated list of pointers to mosquitto_message.
- Thread safety: i'm not vell versed in mosquitto multithreading or whether it's even used, i suspect that this feature is not thread-safe.

I am also contemplating the adding a helper function "int mosquitto_retain_count(char* sub)" that returns how many retained messages that match such that a caller can allocate a sufficiently big buffer. I suppose more messages could have been added between calls, so maybe tell the user to overshoot a bit. Let me know if you think this would be a good idea.

I also created another branch that includes a script for testing this code with a rust plugin project see link: 
https://github.com/Fritiofhedstrom/mosquitto/tree/mosquitto_get_retained_test
requires rust to be installed https://www.rust-lang.org/tools/install

Signed-off-by: Fritiof Hedström <fritiof.hedstrom@navico.com>
