### PR TITLE
Created new helper function mosquitto_write_file to consolidate file writing

### DIFF
--- a/apps/mosquitto_ctrl/Makefile
+++ b/apps/mosquitto_ctrl/Makefile
@@ -96,9 +96,6 @@ memory_public.o : ${R}/src/memory_public.c
 options.o : options.c mosquitto_ctrl.h
 	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(APP_CPPFLAGS) $(APP_CFLAGS) -c $< -o $@
 
-misc_mosq.o : ${R}/lib/misc_mosq.c ${R}/lib/misc_mosq.h
-	${CROSS_COMPILE}${CC} $(APP_CPPFLAGS) $(APP_CFLAGS) -c $< -o $@
-
 password_mosq.o : ${R}/common/password_mosq.c ${R}/common/password_mosq.h
 	${CROSS_COMPILE}${CC} $(APP_CPPFLAGS) $(APP_CFLAGS) -c $< -o $@
 

--- a/common/misc_mosq.h
+++ b/common/misc_mosq.h
@@ -25,4 +25,6 @@ FILE *mosquitto__fopen(const char *path, const char *mode, bool restrict_read);
 char *misc__trimblanks(char *str);
 char *fgets_extending(char **buf, int *buflen, FILE *stream);
 
+int mosquitto_write_file(const char* target_path, bool restrict_read, int (*write_fn)(FILE* fptr, void* user_data), void* user_data, void (*log_fn)(const char* msg));
+
 #endif


### PR DESCRIPTION
Implemented helper function to avoid double implementation of failsafe creation of data files. In the redundant implementation in the dynamic security plugin not all error cases were handled.

Signed-off-by: Norbert Heusser <norbert.heusser@cedalo.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
