### PR TITLE
Correct a wrong example

### DIFF
--- a/plugins/dynamic-security/README.md
+++ b/plugins/dynamic-security/README.md
@@ -244,7 +244,7 @@ Command:
 
 mosquitto_ctrl example:
 ```
-mosquitto_ctrl dynsec setClientPassword username password
+mosquitto_ctrl dynsec setClientId username clientId
 ```
 
 ## Set Client Password


### PR DESCRIPTION
mosquitto_ctrl example for setClientId was provided with wrong example (duplicate of setClientPassword).

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
