### PR TITLE
Enable CMake LTO/IPO support (WITH_LTO option)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,17 @@ if(WITH_CJSON)
 	endif()
 endif()
 
+option(WITH_LTO "Build with link time optimizations (IPO) / interprocedural optimization (IPO) enabled." ON)
+if(WITH_LTO)
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT is_ipo_supported OUTPUT output)
+	if(is_ipo_supported)
+		set_property(TARGET common-options PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+	else()
+		message(WARNING "LTO/IPO is not supported: ${output}")
+	endif()
+endif()
+
 # ========================================
 # Include projects
 # ========================================

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -158,6 +158,7 @@ Clients:
 Build:
 - Increased CMake minimal required version to 3.14, which is required for the
   preinstalled SQLite3 find module.
+- Add an CMake option `WITH_LTO` to enable/disable link time optimization.
 
 
 2.0.14 - 2021-11-17


### PR DESCRIPTION
Makefiles already support an option to enable link time optimizations.
This is now also possible in CMake by using the WITH_LTO option.
It's turned on by default if the compiler supports these flags.
Note: LTO is part of the inter-procedural optimization (IPO).

Signed-off-by: Kai Buschulte <kai.buschulte@cedalo.com>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
