### PR TITLE
Add support for X-Forwarded-For LWS

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -133,6 +133,7 @@ static int callback_mqtt(
 	uint8_t *buf;
 	int rc;
 	uint8_t byte;
+	char ip_addr_buff[1024];
 
 	switch (reason) {
 		case LWS_CALLBACK_ESTABLISHED:
@@ -157,7 +158,12 @@ static int callback_mqtt(
 			}else{
 				return -1;
 			}
-			easy_address(lws_get_socket_fd(wsi), mosq);
+
+			if (lws_hdr_copy(wsi, ip_addr_buff, sizeof(ip_addr_buff), WSI_TOKEN_X_FORWARDED_FOR) > 0) {
+				mosq->address = mosquitto__strdup(ip_addr_buff);
+			} else {
+				easy_address(lws_get_socket_fd(wsi), mosq);
+			}
 			if(!mosq->address){
 				/* getpeername and inet_ntop failed and not a bridge */
 				mosquitto__free(mosq);


### PR DESCRIPTION
I know you've added this for the **next** release, but here is a fix for LWS, just in case there are any more 2.0.x releases.

It does leave the incoming port as 0 but as this is pretty meaningless for a proxied connection I think it's probably ok.

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
