### PR TITLE
Add android logd logging support

### DIFF
--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -524,6 +524,9 @@
 # The dlt destination is for the automotive `Diagnostic Log and Trace` tool.
 # This requires that Mosquitto has been compiled with DLT support.
 #
+# The android destination is for logging into the Android logd logging daemon.
+# This options is only available when building for the Android target.
+#
 # Note that if the broker is running as a Windows service it will default to
 # "log_dest none" and neither stdout nor stderr logging is available.
 # Use "log_dest none" if you wish to disable logging.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,10 @@ if(WITH_WEBSOCKETS)
 	endif()
 endif()
 
+if (ANDROID)
+	set (MOSQ_LIBS ${MOSQ_LIBS} log)
+endif (ANDROID)
+
 add_executable(mosquitto ${MOSQ_SRCS})
 
 if(WITH_WEBSOCKETS)

--- a/src/conf.c
+++ b/src/conf.c
@@ -1810,6 +1810,10 @@ static int config__read_file_core(struct mosquitto__config *config, bool reload,
 							cr->log_dest |= MQTT3_LOG_TOPIC;
 						}else if(!strcmp(token, "dlt")){
 							cr->log_dest |= MQTT3_LOG_DLT;
+#ifdef ANDROID
+						}else if(!strcmp(token, "android")){
+							cr->log_dest |= MQTT3_LOG_ANDROID;
+#endif
 						}else if(!strcmp(token, "file")){
 							cr->log_dest |= MQTT3_LOG_FILE;
 							if(config->log_fptr || config->log_file){

--- a/src/logging.c
+++ b/src/logging.c
@@ -44,6 +44,11 @@ Contributors:
 HANDLE syslog_h;
 #endif
 
+#ifdef ANDROID
+#include <android/log.h>
+static const char* LOG_TAG = "mosquitto";
+#endif
+
 static char log_fptr_buffer[BUFSIZ];
 
 /* Options for logging should be:
@@ -183,6 +188,28 @@ DltLogLevelType get_dlt_level(unsigned int priority)
 			return DLT_LOG_VERBOSE;
 		default:
 			return DLT_LOG_DEFAULT;
+	}
+}
+#endif
+
+#ifdef ANDROID
+android_LogPriority get_android_level(unsigned int priority)
+{
+	switch (priority) {
+		case MOSQ_LOG_ERR:
+			return ANDROID_LOG_ERROR;
+		case MOSQ_LOG_WARNING:
+			return ANDROID_LOG_WARN;
+		case MOSQ_LOG_INFO:
+			return ANDROID_LOG_INFO;
+		case MOSQ_LOG_DEBUG:
+			return ANDROID_LOG_DEBUG;
+		case MOSQ_LOG_NOTICE:
+		case MOSQ_LOG_SUBSCRIBE:
+		case MOSQ_LOG_UNSUBSCRIBE:
+			return ANDROID_LOG_VERBOSE;
+		default:
+			return ANDROID_LOG_DEBUG;
 	}
 }
 #endif
@@ -332,6 +359,11 @@ static int log__vprintf(unsigned int priority, const char *fmt, va_list va)
 #ifdef WITH_DLT
 		if(log_destinations & MQTT3_LOG_DLT && priority != MOSQ_LOG_INTERNAL){
 			DLT_LOG_STRING(dltContext, get_dlt_level(priority), log_line);
+		}
+#endif
+#ifdef ANDROID
+		if(log_destinations & MQTT3_LOG_ANDROID && priority != MOSQ_LOG_INTERNAL){
+			__android_log_write(get_android_level(priority), LOG_TAG, log_line);
 		}
 #endif
 	}

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -55,6 +55,9 @@ Contributors:
 #define MQTT3_LOG_STDERR 0x08
 #define MQTT3_LOG_TOPIC 0x10
 #define MQTT3_LOG_DLT 0x20
+#ifdef ANDROID
+#define MQTT3_LOG_ANDROID 0x40
+#endif
 #define MQTT3_LOG_ALL 0xFF
 
 #define CMD_PORT_LIMIT 10


### PR DESCRIPTION
Add `log_dest` `android` in order to forward logs into the Android logging system (`logd`). Link `liblog` (included in each Android NDK) if building for Android. Add configuration note about log_dest android to configuration template.

Signed-off-by: Felix Obenhuber <felix.obenhuber@esrlabs.com>