### PR TITLE
Fix memory leak in mosquitto_tls_opts_set()

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -228,19 +228,23 @@ int mosquitto_tls_opts_set(struct mosquitto *mosq, int cert_reqs, const char *tl
 				|| !strcasecmp(tls_version, "tlsv1.2")
 				|| !strcasecmp(tls_version, "tlsv1.1")){
 
+			mosquitto__free(mosq->tls_version);
 			mosq->tls_version = mosquitto__strdup(tls_version);
 			if(!mosq->tls_version) return MOSQ_ERR_NOMEM;
 		}else{
 			return MOSQ_ERR_INVAL;
 		}
 	}else{
+		mosquitto__free(mosq->tls_version);
 		mosq->tls_version = mosquitto__strdup("tlsv1.2");
 		if(!mosq->tls_version) return MOSQ_ERR_NOMEM;
 	}
 	if(ciphers){
+		mosquitto__free(mosq->tls_ciphers);
 		mosq->tls_ciphers = mosquitto__strdup(ciphers);
 		if(!mosq->tls_ciphers) return MOSQ_ERR_NOMEM;
 	}else{
+		mosquitto__free(mosq->tls_ciphers);
 		mosq->tls_ciphers = NULL;
 	}
 


### PR DESCRIPTION
When calling mosquitto_tls_opts_set() multiple time in a row on the same mosquitto context (Example: trying to reconnect to mqtt broker), some of the tls options are not free, resulting in a memory leak.

The TLS options (tls_version, tls_ciphers) must be free before being set.


- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?