### PR TITLE
Use thread-safe/reentrant version of gmtime(): gmtime_r()

### DIFF
--- a/plugins/message-timestamp/mosquitto_message_timestamp.c
+++ b/plugins/message-timestamp/mosquitto_message_timestamp.c
@@ -44,15 +44,15 @@ static int callback_message(int event, void *event_data, void *userdata)
 {
 	struct mosquitto_evt_message *ed = event_data;
 	struct timespec ts;
-	struct tm *ti;
+	struct tm ti;
 	char time_buf[25];
 
 	UNUSED(event);
 	UNUSED(userdata);
 
 	clock_gettime(CLOCK_REALTIME, &ts);
-	ti = gmtime(&ts.tv_sec);
-	strftime(time_buf, sizeof(time_buf), "%Y-%m-%dT%H:%M:%SZ", ti);
+	gmtime_r(&ts.tv_sec, &ti);
+	strftime(time_buf, sizeof(time_buf), "%Y-%m-%dT%H:%M:%SZ", &ti);
 
 	return mosquitto_property_add_string_pair(&ed->properties, MQTT_PROP_USER_PROPERTY, "timestamp", time_buf);
 }


### PR DESCRIPTION
gmtime() is not thread-safe.

Ideally, this code would check the return value of gmtime_r() for NULL (indication of failure), but since this wasn't being done before, I didn't want to overload this commmit with an extra "feature".

Signed-off-by: Rob Swindell <rob@synchro.net>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

No, the "fixes" branch currently doesn't actually build for me (logging.c:294:96: error: expected ‘)’ before ‘PRIu64’) - a different issue.
-----
