### PR TITLE
Fix build error: expected ‘)’ before ‘PRIu64’

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -20,6 +20,7 @@ Contributors:
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 #ifndef WIN32
 #include <syslog.h>
 #endif

--- a/src/sys_tree.c
+++ b/src/sys_tree.c
@@ -23,6 +23,7 @@ Contributors:
 #include <math.h>
 #include <stdio.h>
 #include <limits.h>
+#include <inttypes.h>
 
 #include "mosquitto_broker_internal.h"
 #include "memory_mosq.h"


### PR DESCRIPTION
system with 'make WITH_TLS=no WITH_CJSON=no WITH_DOCS=no'

Signed-off-by: Rob Swindell <rob@synchro.net>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
