### PR TITLE
support colon in username in pwfile via double colon

### DIFF
--- a/apps/mosquitto_passwd/mosquitto_passwd.c
+++ b/apps/mosquitto_passwd/mosquitto_passwd.c
@@ -179,7 +179,7 @@ static int pwfile_iterate(FILE *fptr, FILE *ftmp,
 	int lbuflen;
 	int rc = 1;
 	int line = 0;
-	char *username, *password;
+	char *colon, *username, *password;
 
 	buf = malloc((size_t)buflen);
 	if(buf == NULL){
@@ -207,14 +207,16 @@ static int pwfile_iterate(FILE *fptr, FILE *ftmp,
 		}
 		memcpy(lbuf, buf, (size_t)buflen);
 		line++;
-		username = strtok(buf, ":");
-		password = strtok(NULL, ":");
-		if(username == NULL || password == NULL){
+		colon = strrchr(buf, ':');
+		*colon = 0;
+		if(colon == NULL){
 			fprintf(stderr, "Error: Corrupt password file at line %d.\n", line);
 			free(lbuf);
 			free(buf);
 			return 1;
 		}
+		username = buf;
+		password = colon + 1;
 		username = misc__trimblanks(username);
 		password = misc__trimblanks(password);
 
@@ -409,10 +411,6 @@ static bool is_username_valid(const char *username)
 				fprintf(stderr, "Error: Username must not contain control characters.\n");
 				return false;
 			}
-		}
-		if(strchr(username, ':')){
-			fprintf(stderr, "Error: Username must not contain the ':' character.\n");
-			return false;
 		}
 	}
 	return true;


### PR DESCRIPTION
There are smart IoT devices that use the string represeantation of the MAC address as MQTT user name, i.e., a user name containing colon characters. In basic setups of Mosquitto with authentication based on pwfile, user names could not contain colon characters, because the colon is used as a delimiter.

This commit adds supports for colon characters in user names in pwfile, by interpreting the last colon in the pwline as the delimiter and the part in font of it as user name. This works because the hased password never contains a colon.

This approach has been suggested by Rob Swindell as response to PR#2619, which suggested a more complicated approach.

Signed-off-by: Stefan Schuermans <stefan@schuermans.info>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] ~If you are contributing a bugfix, is your work based off the fixes branch?~
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
