### PR TITLE
Add option to disable block buffering of stdout log

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -280,6 +280,7 @@ static void config__init_reload(struct mosquitto__config *config)
 		config->log_type = MOSQ_LOG_ERR | MOSQ_LOG_WARNING | MOSQ_LOG_NOTICE | MOSQ_LOG_INFO;
 	}
 #endif
+	config->log_stdout_unbuffered = false;
 	config->log_timestamp = true;
 	mosquitto__FREE(config->log_timestamp_format);
 	config->global_max_clients = -1;
@@ -629,6 +630,7 @@ static void config__copy(struct mosquitto__config *src, struct mosquitto__config
 	dest->log_dest = src->log_dest;
 	dest->log_facility = src->log_facility;
 	dest->log_type = src->log_type;
+	dest->log_stdout_unbuffered = src->log_stdout_unbuffered;
 	dest->log_timestamp = src->log_timestamp;
 
 	mosquitto__FREE(dest->log_timestamp_format);
@@ -1808,6 +1810,13 @@ static int config__read_file_core(struct mosquitto__config *config, bool reload,
 						cr->log_dest |= MQTT3_LOG_SYSLOG;
 					}else if(!strcmp(token, "stdout")){
 						cr->log_dest |= MQTT3_LOG_STDOUT;
+						token = &token[strlen(token)+1];
+						while(token[0] == ' ' || token[0] == '\t'){
+							token++;
+						}
+						if(!strcmp(token, "unbuffered")){
+							config->log_stdout_unbuffered = true;
+						}
 					}else if(!strcmp(token, "stderr")){
 						cr->log_dest |= MQTT3_LOG_STDERR;
 					}else if(!strcmp(token, "topic")){

--- a/src/logging.c
+++ b/src/logging.c
@@ -224,11 +224,13 @@ static int log__vprintf(unsigned int priority, const char *fmt, va_list va)
 #ifdef WIN32
 	char *sp;
 #endif
+	bool log_stdout_unbuffered = false;
 	bool log_timestamp = true;
 	char *log_timestamp_format = NULL;
 	FILE *log_fptr = NULL;
 
 	if(db.config){
+		log_stdout_unbuffered = db.config->log_stdout_unbuffered;
 		log_timestamp = db.config->log_timestamp;
 		log_timestamp_format = db.config->log_timestamp_format;
 		log_fptr = db.config->log_fptr;
@@ -335,6 +337,9 @@ static int log__vprintf(unsigned int priority, const char *fmt, va_list va)
 
 		if(log_destinations & MQTT3_LOG_STDOUT){
 			fprintf(stdout, "%s\n", log_line);
+			if(log_stdout_unbuffered){
+				fflush(stdout);
+			}
 		}
 		if(log_destinations & MQTT3_LOG_STDERR){
 			fprintf(stderr, "%s\n", log_line);

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -324,6 +324,7 @@ struct mosquitto__config {
 	unsigned int log_dest;
 	int log_facility;
 	unsigned int log_type;
+	bool log_stdout_unbuffered;
 	bool log_timestamp;
 	char *log_timestamp_format;
 	char *log_file;


### PR DESCRIPTION
This fixes the issue outlined in #2354 by providing a configuration option that reenables the explicit fflush for stdout.
I decided to make it optional (and disabled by default) because buffering might be desirable if theres a lot of logging and enabling fflush by default would cause a performance degredation in those cases. It is also exclusive to stdout logging, because stderr is unbuffered by default.

Then please check the following list of things we ask for in your pull request:

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?
