### PR TITLE
Add yaml support

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,5 +1,6 @@
 DIRS= \
 		auth-by-ip \
+		auth-by-hmac \
 		deny-protocol-version \
 		dynamic-security \
 		message-timestamp \

--- a/plugins/auth-by-hmac/CMakeLists.txt
+++ b/plugins/auth-by-hmac/CMakeLists.txt
@@ -1,0 +1,11 @@
+include_directories(${mosquitto_SOURCE_DIR} ${mosquitto_SOURCE_DIR}/include
+			${OPENSSL_INCLUDE_DIR} ${STDBOOL_H_PATH} ${STDINT_H_PATH})
+
+add_library(mosquitto_auth_by_hmac MODULE mosquitto_auth_by_hmac.c)
+set_target_properties(mosquitto_auth_by_hmac PROPERTIES
+	POSITION_INDEPENDENT_CODE 1
+)
+set_target_properties(mosquitto_auth_by_hmac PROPERTIES PREFIX "")
+
+# Don't install, these are example plugins only.
+#install(TARGETS mosquitto_auth_by_hmac RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/plugins/auth-by-hmac/Makefile
+++ b/plugins/auth-by-hmac/Makefile
@@ -1,0 +1,27 @@
+include ../../config.mk
+
+.PHONY : all binary check clean reallyclean test install uninstall
+
+PLUGIN_NAME=mosquitto_auth_by_hmac
+
+all : binary
+
+binary : ${PLUGIN_NAME}.so
+
+${PLUGIN_NAME}.so : ${PLUGIN_NAME}.c
+	$(CROSS_COMPILE)$(CC) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) $(PLUGIN_LDFLAGS) -fPIC -shared $< -o $@
+
+reallyclean : clean
+clean:
+	-rm -f *.o ${PLUGIN_NAME}.so *.gcda *.gcno
+
+check: test
+test:
+
+install: ${PLUGIN_NAME}.so
+	# Don't install, these are examples only.
+	#$(INSTALL) -d "${DESTDIR}$(libdir)"
+	#$(INSTALL) ${STRIP_OPTS} ${PLUGIN_NAME}.so "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"
+
+uninstall :
+	-rm -f "${DESTDIR}${libdir}/${PLUGIN_NAME}.so"

--- a/plugins/auth-by-hmac/mosquitto_auth_by_hmac.c
+++ b/plugins/auth-by-hmac/mosquitto_auth_by_hmac.c
@@ -1,0 +1,282 @@
+/*
+Copyright (c) 2023 Akos Vandra-Meyer <akos@vandra.hu>
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   https://www.eclipse.org/legal/epl-2.0/
+and the Eclipse Distribution License is available at
+  http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: EPL-2.0 OR EDL-1.0
+
+Contributors:
+   Akos Vandra-Meyer - initial implementation and documentation.
+*/
+
+/*
+ * This is an example plugin showing how to use the basic authentication
+ * callback to allow/disallow client connections based on a HMAC-derived secret.
+ *
+ * This is useful for new clients to be able to connect to the broker without having
+ * to change the configuration of the broker (the broker does not have to be aware or
+ * keep a list of all users, and the users are able to be provided with a psk that they
+ * can use to connect to the broker under their assigned username only).
+ *
+ * This is similar to a certificate, but without having to toss around large blobs of data,
+ * which can be problematic in an embedded environment.
+
+ * Passwords for usernames are derived by base64(HMAC_SHA256(noprefix_supersecret, username))
+ * This can be done in the command line using: `echo -n "username" | openssl dgst -sha256 -hmac "supersecret" -binary | base64`
+ *
+ * Configuration:
+ *   plugin_opt_hmac_secret - default supersecret for all users (optional)
+ *   plugin_opt_hmac_secret_XXX - default supersecret for all usernames prefixed with XXX-
+ *   plugin_opt_hmac_secret_YYY - default supersecret for all usernames prefixed with YYY-
+ *
+ *   prefixes MAY NOT contain the '-' to make the prefixes mutually exclusive and
+ *   avoid a bunch of issues with ordering and precedence.
+ *
+ * Caveats:
+ *  - passwords cannot be changed (could add a salt in the password to generate new hashes, but old ones would still be valid)
+ *  - once a user/pass is delivered, it cannot be revoked, even if the password is leaked (could implement a blacklist)
+ *  - passwords currently never expire (although one could encode expiry it in the username / password as a salt, and check that when connecting)
+ *  - probably good for users with very limited/segregated access.
+
+
+ This is an extremely basic type of access control, password based or similar
+ * authentication is preferred.
+ *
+ * Compile with:
+ *   gcc -I<path to mosquitto-repo/include> -fPIC -shared mosquitto_auth_by_ip.c -o mosquitto_auth_by_ip.so
+ *
+ * Use in config with:
+ *
+ *   plugin /path/to/mosquitto_auth_by_ip.so
+ *
+ * Note that this only works on Mosquitto 2.0 or later.
+ */
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "mosquitto_broker.h"
+#include "mosquitto_plugin.h"
+#include "mosquitto.h"
+#include "mqtt_protocol.h"
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/buffer.h>
+
+struct keyval {
+	char *key;
+	char *value;
+};
+
+struct plugin_config {
+	//A hash would probably be a good choice as well,
+	//but it is not expected to have more than a few items in this list,
+	//so it would be more of an overhead than a benefit.
+	struct keyval* prefixes;
+	char* noprefix;
+};
+
+static void free_plugin_cfg(struct plugin_config* cfg) {
+	if (cfg == NULL) {
+		return;
+	}
+
+	int i = 0;
+
+	while(cfg->prefixes && cfg->prefixes[i].key && cfg->prefixes[i].value) {
+		mosquitto_free(cfg->prefixes[i].key);
+		mosquitto_free(cfg->prefixes[i].value);
+		i++;
+	}
+
+	mosquitto_free(cfg->prefixes);
+	mosquitto_free(cfg->noprefix);
+	mosquitto_free(cfg);
+}
+
+
+static mosquitto_plugin_id_t *mosq_pid = NULL;
+
+char* base64_encode(const unsigned char* buffer, int length) { //Encodes a binary safe base 64 string
+	BIO *bio, *b64;
+	BUF_MEM *bufferPtr;
+
+	char* b64text;
+
+	b64 = BIO_new(BIO_f_base64());
+	bio = BIO_new(BIO_s_mem());
+	bio = BIO_push(b64, bio);
+
+	BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL); //Ignore newlines - write everything in one line
+	BIO_write(bio, buffer, length);
+	BIO_flush(bio);
+	BIO_get_mem_ptr(bio, &bufferPtr);
+	BIO_set_close(bio, BIO_NOCLOSE);
+
+	b64text = (char*) mosquitto_malloc((bufferPtr->length + 1) * sizeof(char));
+	memcpy(b64text, bufferPtr->data, bufferPtr->length);
+	b64text[bufferPtr->length] = '\0';
+
+	BIO_free_all(bio);
+
+	return b64text;
+}
+
+static int basic_auth_callback(int event, void *event_data, void *userdata)
+{
+	UNUSED(event);
+
+	struct mosquitto_evt_basic_auth *ed = event_data;
+	struct plugin_config *cfg = userdata;
+
+	mosquitto_log_printf(MOSQ_LOG_WARNING, "basic_auth_callback %p %p", cfg->prefixes, cfg->noprefix);
+
+	if (ed->password == NULL) {
+		mosquitto_log_printf(MOSQ_LOG_DEBUG, "auth_by_hmac: no password received, deferring authentication");
+		return MOSQ_ERR_PLUGIN_DEFER;
+	}
+
+
+	unsigned int hmaclen = 32;
+	unsigned char* hmac = mosquitto_calloc(sizeof(unsigned char), hmaclen);
+
+	int i = 0;
+
+	while(cfg->prefixes && cfg->prefixes[i].key && cfg->prefixes[i].value) {
+		if (strstr(ed->username, cfg->prefixes[i].key) && ed->username[strlen(cfg->prefixes[i].key)] == '-') {
+			break;
+		}
+
+		i++;
+	}
+
+	char* supersecret = NULL;
+
+	if (cfg->prefixes && cfg->prefixes[i].value) {
+		 supersecret = cfg->prefixes[i].value;
+   } else {
+		 supersecret = cfg->noprefix;
+   }
+
+   if (supersecret == NULL) {
+		mosquitto_log_printf(MOSQ_LOG_DEBUG, "auth_by_hmac: no supersecret found, deferring authentication");
+		return MOSQ_ERR_PLUGIN_DEFER;
+   }
+
+	HMAC(EVP_sha256(), supersecret, (int)strlen(supersecret), (const unsigned char*)ed->username, strlen(ed->username), hmac, &hmaclen);
+	char* hmac_b64 = base64_encode(hmac, (int)hmaclen);
+
+	// mosquitto_log_printf(MOSQ_LOG_DEBUG, "Supersecret is %s, expected %s, Got %s", supersecret, hmac_b64, ed->password);
+
+	int ret = strcmp(hmac_b64, ed->password) == 0 ? MOSQ_ERR_SUCCESS : MOSQ_ERR_PLUGIN_DEFER;
+
+	mosquitto_free(hmac_b64);
+
+	return ret;
+}
+
+int mosquitto_plugin_version(int supported_version_count, const int *supported_versions)
+{
+	int i;
+
+	for(i=0; i<supported_version_count; i++){
+		if(supported_versions[i] == 5){
+			return 5;
+		}
+	}
+	return -1;
+}
+
+int mosquitto_plugin_init(mosquitto_plugin_id_t *identifier, void **user_data, struct mosquitto_opt *opts, int opt_count)
+{
+	UNUSED(user_data);
+
+	struct plugin_config* cfg = mosquitto_calloc(sizeof(struct plugin_config), 1);
+
+	if (!cfg) {
+		return MOSQ_ERR_NOMEM;
+	}
+
+	unsigned int prefix_count = 0;
+
+	for(int i=0; i<opt_count; i++) {
+		if (strstr(opts[i].key, "hmac_secret_")) { prefix_count++; }
+
+		// Disallow the '-' character in the prefixes to prevent a bunch of problems with ordering and precedence.
+		if (strstr(opts[i].key, "-")) {
+			mosquitto_log_printf(MOSQ_LOG_WARNING, "WARNING: auth_by_hmac: It is not allowed to have a '-' character in the prefix, ignoring %s", opts[i].key);
+			prefix_count--;
+		}
+	}
+
+	if (prefix_count > 0) {
+		cfg->prefixes = mosquitto_calloc(sizeof(struct keyval), prefix_count + 1);
+	}
+
+	for(int i=0; i<opt_count; i++){
+		if(strcmp(opts[i].key, "hmac_secret") == 0) {
+			cfg->noprefix = mosquitto_strdup(opts[i].value);
+
+			if(cfg->noprefix == NULL){
+				free_plugin_cfg(cfg);
+				return MOSQ_ERR_NOMEM;
+			}
+
+			mosquitto_log_printf(MOSQ_LOG_DEBUG, "auth_by_hmac: registering global hmac_secret");
+		} else if (strstr(opts[i].key, "hmac_secret_")) {
+
+			// Disallow the '-' character in the prefixes to prevent a bunch of problems with ordering and precedence.
+			if (strstr(opts[i].key, "-")) { continue; }
+
+			// Fill from back because the order of prefixes does not count,
+			// as they are mutually exclusive, because it is not allowed to have a '-' character in the prefix.
+
+			prefix_count--;
+			cfg->prefixes[prefix_count].key = mosquitto_strdup(opts[i].key + strlen("hmac_secret_"));
+
+			if (cfg->prefixes[prefix_count].key == NULL) {
+				free_plugin_cfg(cfg);
+				return MOSQ_ERR_NOMEM;
+			}
+
+			cfg->prefixes[prefix_count].value = mosquitto_strdup(opts[i].value);
+
+			if (cfg->prefixes[prefix_count].value == NULL) {
+				free_plugin_cfg(cfg);
+				return MOSQ_ERR_NOMEM;
+			}
+
+			mosquitto_log_printf(MOSQ_LOG_DEBUG, "auth_by_hmac: registering hmac_secret for prefix %s", cfg->prefixes[prefix_count].key);
+		}
+	}
+
+	if(cfg->prefixes == NULL && cfg->noprefix == NULL){
+		mosquitto_log_printf(MOSQ_LOG_WARNING, "WARNING: Auth by HMAC has no global or prefixed hmac secrets defined. The plugin will not be activated.");
+		free_plugin_cfg(cfg);
+		return MOSQ_ERR_SUCCESS;
+	}
+
+	*user_data = cfg;
+
+	mosq_pid = identifier;
+	return mosquitto_callback_register(mosq_pid, MOSQ_EVT_BASIC_AUTH, basic_auth_callback, NULL, cfg);
+}
+
+int mosquitto_plugin_cleanup(void *user_data, struct mosquitto_opt *opts, int opt_count)
+{
+	free_plugin_cfg(user_data);
+	UNUSED(opts);
+	UNUSED(opt_count);
+
+	return mosquitto_callback_unregister(mosq_pid, MOSQ_EVT_BASIC_AUTH, basic_auth_callback, NULL);
+}

--- a/plugins/dynamic-security/CMakeLists.txt
+++ b/plugins/dynamic-security/CMakeLists.txt
@@ -25,7 +25,8 @@ if (CJSON_FOUND AND WITH_TLS)
 		plugin.c
 		roles.c
 		rolelist.c
-		sub_matches_sub.c)
+		sub_matches_sub.c
+		yaml_help.c)
 
 	set_target_properties(mosquitto_dynamic_security PROPERTIES
 		POSITION_INDEPENDENT_CODE 1

--- a/plugins/dynamic-security/Makefile
+++ b/plugins/dynamic-security/Makefile
@@ -16,7 +16,8 @@ OBJS=	\
 		plugin.o \
 		roles.o \
 		rolelist.o \
-		sub_matches_sub.o
+		sub_matches_sub.o \
+		yaml_help.o
 
 ifeq ($(WITH_CJSON),yes)
 ifeq ($(WITH_TLS),yes)
@@ -32,7 +33,7 @@ all : ${ALL_DEPS}
 binary : ${PLUGIN_NAME}.so
 
 ${PLUGIN_NAME}.so : ${OBJS}
-	${CROSS_COMPILE}${CC} $(PLUGIN_LDFLAGS) -fPIC -shared $^ -o $@ -lcjson
+	${CROSS_COMPILE}${CC} $(PLUGIN_LDFLAGS) -fPIC -shared $^ -o $@ -lcjson -lyaml
 
 acl.o : acl.c dynamic_security.h
 	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
@@ -66,6 +67,10 @@ rolelist.o : rolelist.c dynamic_security.h
 
 sub_matches_sub.o : sub_matches_sub.c dynamic_security.h
 	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
+
+yaml_help.o : yaml_help.c dynamic_security.h
+	${CROSS_COMPILE}${CC} $(LOCAL_CPPFLAGS) $(PLUGIN_CPPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@
+
 
 reallyclean : clean
 clean:

--- a/plugins/dynamic-security/clientlist.c
+++ b/plugins/dynamic-security/clientlist.c
@@ -27,6 +27,8 @@ Contributors:
 #include "json_help.h"
 
 #include "dynamic_security.h"
+#include "yaml.h"
+#include "yaml_help.h"
 
 /* ################################################################
  * #
@@ -96,6 +98,88 @@ cJSON *dynsec_clientlist__all_to_json(struct dynsec__clientlist *base_clientlist
 		}
 	}
 	return j_clients;
+}
+
+int dynsec_clientlist__all_to_yaml(struct dynsec__clientlist *base_clientlist, yaml_emitter_t* emitter, yaml_event_t *event)
+{
+    struct dynsec__clientlist *clientlist, *clientlist_tmp;
+
+    yaml_sequence_start_event_initialize(event, NULL, (yaml_char_t *)YAML_SEQ_TAG,
+                                         1, YAML_ANY_SEQUENCE_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+    HASH_ITER(hh, base_clientlist, clientlist, clientlist_tmp){
+        yaml_mapping_start_event_initialize(event, NULL, (yaml_char_t *)YAML_MAP_TAG,
+                                            1, YAML_ANY_MAPPING_STYLE);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+
+        if (!yaml_emit_string_field(emitter, event, "username", clientlist->client->username)) return 0;
+        if (clientlist->priority != -1 && !yaml_emit_int_field(emitter, event, "priority", clientlist->priority)) return 0;
+
+        yaml_mapping_end_event_initialize(event);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+        printf("%s:%d\n", __FILE__, __LINE__);
+
+    }
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+    yaml_sequence_end_event_initialize(event);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+    return 1;
+}
+
+int dynsec_clientlist__load_from_yaml(yaml_parser_t *parser, yaml_event_t *event, struct dynsec__clientlist **clientlist)
+{
+    YAML_PARSER_SEQUENCE_FOR_ALL(parser, event, { goto error; }, {
+        printf("%s:%d\n", __FILE__, __LINE__);
+        char* username = NULL;
+        long int priority = -1;
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+        YAML_PARSER_MAPPING_FOR_ALL(parser, event, key, { goto error; }, {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                if (strcmp(key, "username") == 0) {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    YAML_EVENT_INTO_SCALAR_STRING(event, &username, { goto error; });
+                } else if (strcmp(key, "priority") == 0) {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    YAML_EVENT_INTO_SCALAR_LONG_INT(event, &priority, { goto error; });
+                } else {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    mosquitto_log_printf(MOSQ_LOG_ERR, "Unexpected key for role config %s \n", key);
+                    yaml_dump_block(parser, event);
+                }
+        });
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+
+        if (username) {
+            printf("un = %s\n", username);
+            struct dynsec__client *client = dynsec_clients__find_or_create(username);
+            if (client) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                dynsec_clientlist__add(clientlist, client, (int)priority);
+            } else {
+                printf("OUT OF MEMORY %s:%d\n", __FILE__, __LINE__);
+                free(username);
+                goto error;
+            }
+        }
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+    });
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+
+    return 1;
+    error:
+    dynsec_clientlist__cleanup(clientlist);
+    return 0;
 }
 
 

--- a/plugins/dynamic-security/clients.c
+++ b/plugins/dynamic-security/clients.c
@@ -27,6 +27,8 @@ Contributors:
 #include "json_help.h"
 
 #include "dynamic_security.h"
+#include "yaml_help.h"
+#include "yaml.h"
 
 /* ################################################################
  * #
@@ -62,12 +64,33 @@ static int client_cmp(void *a, void *b)
 
 struct dynsec__client *dynsec_clients__find(const char *username)
 {
+    if (!username) return NULL;
+
 	struct dynsec__client *client = NULL;
 
-	if(username){
-		HASH_FIND(hh, local_clients, username, strlen(username), client);
-	}
+    HASH_FIND(hh, local_clients, username, strlen(username), client);
+
 	return client;
+}
+
+struct dynsec__client *dynsec_clients__find_or_create(const char *username)
+{
+    if (!username) return NULL;
+
+    struct dynsec__client *client = dynsec_clients__find(username);
+
+    if(!client) {
+        client = mosquitto_calloc(sizeof(struct dynsec__client), 1);
+        if(!client) return NULL;
+
+        client->username = mosquitto_strdup(username);
+        client->disabled = 1;
+        client->pw.valid = 0; //Technically should already be 0.
+
+        HASH_ADD_KEYPTR_INORDER(hh, local_clients, client->username, strlen(client->username), client, client_cmp);
+    }
+
+    return client;
 }
 
 
@@ -169,6 +192,7 @@ int dynsec_clients__config_load(cJSON *tree)
 				if(dynsec_auth__base64_decode(j_salt->valuestring, &buf, &buf_len) != MOSQ_ERR_SUCCESS
 						|| buf_len != sizeof(client->pw.salt)){
 
+                    mosquitto_free(buf);
 					mosquitto_free(client->username);
 					mosquitto_free(client);
 					continue;
@@ -179,6 +203,7 @@ int dynsec_clients__config_load(cJSON *tree)
 				if(dynsec_auth__base64_decode(j_password->valuestring, &buf, &buf_len) != MOSQ_ERR_SUCCESS
 						|| buf_len != sizeof(client->pw.password_hash)){
 
+                    mosquitto_free(buf);
 					mosquitto_free(client->username);
 					mosquitto_free(client);
 					continue;
@@ -241,12 +266,233 @@ int dynsec_clients__config_load(cJSON *tree)
 				}
 			}
 
-			HASH_ADD_KEYPTR(hh, local_clients, client->username, strlen(client->username), client);
+            HASH_ADD_KEYPTR(hh, local_clients, client->username, strlen(client->username), client);
 		}
 	}
 	HASH_SORT(local_clients, client_cmp);
 
 	return 0;
+}
+
+int dynsec_clients__config_load_yaml(yaml_parser_t *parser, yaml_event_t *event)
+{
+    unsigned char *buf = NULL;
+    int buf_len;
+
+    struct dynsec__client *client = NULL;
+    bool disabled = 1;
+    char* clientid;
+    char* textname;
+    char* textdescription;
+    char *salt;
+    char *pw;
+    long int iterations;
+    struct dynsec__rolelist *rolelist;
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+    YAML_PARSER_SEQUENCE_FOR_ALL(parser, event, { goto error; }, {
+        printf("%s:%d\n", __FILE__, __LINE__);
+
+        client = NULL;
+        disabled = 0;
+        clientid = textname = textdescription = salt = pw = NULL;
+        iterations = 0;
+        rolelist = NULL;
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+        YAML_PARSER_MAPPING_FOR_ALL(parser, event, key, { goto error; }, {
+                printf("%s:%d\n", __FILE__, __LINE__);
+            if (strcmp(key, "username") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                char *username;
+                YAML_EVENT_INTO_SCALAR_STRING(event, &username, { goto error; });
+                client = dynsec_clients__find_or_create(username);
+                mosquitto_free(username);
+            } else if (strcmp(key, "disabled") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                YAML_EVENT_INTO_SCALAR_BOOL(event, &disabled, { goto error; });
+            } else if (strcmp(key, "clientid") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                YAML_EVENT_INTO_SCALAR_STRING(event, &clientid, { goto error; });
+            } else if (strcmp(key, "textname") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                YAML_EVENT_INTO_SCALAR_STRING(event, &textname, { goto error; });
+            } else if (strcmp(key, "textdescription") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                YAML_EVENT_INTO_SCALAR_STRING(event, &textdescription, { goto error; });
+            } else if (strcmp(key, "salt") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                YAML_EVENT_INTO_SCALAR_STRING(event, &salt, { goto error; });
+            } else if (strcmp(key, "password") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                YAML_EVENT_INTO_SCALAR_STRING(event, &pw, { goto error; });
+            } else if (strcmp(key, "iterations") == 0) {
+                printf("%s:%d\n", __FILE__, __LINE__);
+                YAML_EVENT_INTO_SCALAR_LONG_INT(event, &iterations, { goto error; });
+            } else if (strcmp(key, "roles") == 0) {
+                if (!dynsec_rolelist__load_from_yaml(parser, event, &rolelist)) goto error;
+
+                printf("%s:%d\n", __FILE__, __LINE__);
+            } else {
+                yaml_dump_block(parser, event);
+                printf("%s:%d\n", __FILE__, __LINE__);
+                mosquitto_log_printf(MOSQ_LOG_ERR, "Unexpected key for client config %s \n", key);
+            }
+                printf("%s:%d\n", __FILE__, __LINE__);
+        });
+
+        if (client) {
+            client->clientid = clientid;
+            client->text_name = textname;
+            client->text_description = textdescription;
+            client->disabled = disabled;
+
+            if (rolelist) {
+                struct dynsec__rolelist *iter;
+                struct dynsec__rolelist *tmp;
+
+                printf("%s:%d\n", __FILE__, __LINE__);
+                HASH_ITER(hh, rolelist, iter, tmp){
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    dynsec_rolelist__add(&client->rolelist, iter->role, iter->priority);
+                    dynsec_clientlist__add(&iter->role->clientlist, client, iter->priority);
+                    iter->role = NULL;
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                }
+
+                dynsec_rolelist__cleanup(&rolelist);
+            }
+
+            if (salt && pw && iterations > 0) {
+                printf("PW VALID FOR %s\n", client->username);
+                client->pw.valid = 1;
+                client->pw.iterations = (int)iterations;
+
+                if(dynsec_auth__base64_decode(salt, &buf, &buf_len) == MOSQ_ERR_SUCCESS && buf_len == sizeof(client->pw.salt)) {
+                    memcpy(client->pw.salt, buf, (size_t)buf_len);
+                    mosquitto_free(buf);
+                    buf = NULL;
+                } else {
+                    client->pw.valid = 0;
+                    mosquitto_free(buf);
+                    buf = NULL;
+                }
+
+                if(dynsec_auth__base64_decode(pw, &buf, &buf_len) == MOSQ_ERR_SUCCESS && buf_len == sizeof(client->pw.password_hash)) {
+                    memcpy(client->pw.password_hash, buf, (size_t)buf_len);
+                    mosquitto_free(buf);
+                    buf = NULL;
+                } else {
+                    mosquitto_free(buf);
+                    buf = NULL;
+                    client->pw.valid = 0;
+                }
+            } else {
+                printf("PW NOT VALID FOR %s\n", client->username);
+                client->pw.valid = 0;
+            }
+
+            mosquitto_free(salt);
+            mosquitto_free(pw);
+
+        } else {
+            mosquitto_free(clientid);
+            mosquitto_free(textname);
+            mosquitto_free(textdescription);
+            dynsec_rolelist__cleanup(&rolelist);
+        }
+
+printf("%s:%d\n", __FILE__, __LINE__);
+
+    });
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+
+    return 1;
+error:
+    mosquitto_free(clientid);
+    mosquitto_free(textname);
+    mosquitto_free(textdescription);
+    dynsec_rolelist__cleanup(&rolelist);
+    mosquitto_free(salt);
+    mosquitto_free(pw);
+    return 0;
+}
+
+static int dynsec__config_add_clients_yaml(yaml_emitter_t* emitter, yaml_event_t* event)
+{
+
+
+    struct dynsec__client *client, *client_tmp;
+    char *buf;
+    printf("%s:%d\n", __FILE__, __LINE__);
+
+    yaml_sequence_start_event_initialize(event, NULL, (yaml_char_t *)YAML_SEQ_TAG,
+                                         1, YAML_ANY_SEQUENCE_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    HASH_ITER(hh, local_clients, client, client_tmp){
+        yaml_mapping_start_event_initialize(event, NULL, (yaml_char_t *)YAML_MAP_TAG,
+                                            1, YAML_ANY_MAPPING_STYLE);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+
+        if (!yaml_emit_string_field(emitter, event, "username", client->username)) return 0;
+
+        if (client->clientid && !yaml_emit_string_field(emitter, event, "clientid", client->clientid)) return 0;
+        if (client->text_name && !yaml_emit_string_field(emitter, event, "textname", client->text_name)) return 0;
+        if (client->text_description && !yaml_emit_string_field(emitter, event, "textdescription", client->text_description)) return 0;
+        if (client->disabled && !yaml_emit_string_field(emitter, event, "disabled", "true")) return 0;
+
+
+        yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                     (yaml_char_t *)"roles", strlen("roles"), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+
+        if (!dynsec_rolelist__all_to_yaml(client->rolelist, emitter, event)) return 0;
+
+        if(client->pw.valid){
+            if(dynsec_auth__base64_encode(client->pw.password_hash, sizeof(client->pw.password_hash), &buf) != MOSQ_ERR_SUCCESS){
+                mosquitto_log_printf(MOSQ_LOG_ERR, "dynsec: error encoding password hash to base64");
+                return 0;
+            }
+
+            if (!yaml_emit_string_field(emitter, event, "password", buf)) {
+                mosquitto_free(buf);
+                return 0;
+            }
+
+            mosquitto_free(buf);
+
+            if(dynsec_auth__base64_encode(client->pw.salt, sizeof(client->pw.salt), &buf) != MOSQ_ERR_SUCCESS){
+                mosquitto_log_printf(MOSQ_LOG_ERR, "dynsec: error encoding password salt to base64");
+                return 0;
+            }
+
+            if (!yaml_emit_string_field(emitter, event, "salt", buf)) {
+                mosquitto_free(buf);
+                return 0;
+            }
+
+            mosquitto_free(buf);
+
+            if (!yaml_emit_int_field(emitter, event, "iterations", client->pw.iterations)) {
+                mosquitto_free(buf);
+                return 0;
+            }
+        }
+
+        yaml_mapping_end_event_initialize(event);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    }
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+
+    yaml_sequence_end_event_initialize(event);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+
+    return 1;
 }
 
 
@@ -302,6 +548,17 @@ static int dynsec__config_add_clients(cJSON *j_clients)
 	}
 
 	return 0;
+}
+
+int dynsec_clients__config_save_yaml(yaml_emitter_t* emitter, yaml_event_t* event)
+{
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                 (yaml_char_t *)"clients", strlen("clients"), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    if(!dynsec__config_add_clients_yaml(emitter, event)) return 0;
+
+    return 1;
 }
 
 

--- a/plugins/dynamic-security/dynamic_security.h
+++ b/plugins/dynamic-security/dynamic_security.h
@@ -22,6 +22,7 @@ Contributors:
 #include <uthash.h>
 #include "mosquitto.h"
 #include "password_mosq.h"
+#include "yaml.h"
 
 /* ################################################################
  * #
@@ -172,7 +173,9 @@ int dynsec_auth__basic_auth_callback(int event, void *event_data, void *userdata
 
 void dynsec_clients__cleanup(void);
 int dynsec_clients__config_load(cJSON *tree);
+int dynsec_clients__config_load_yaml(yaml_parser_t *parser, yaml_event_t *event);
 int dynsec_clients__config_save(cJSON *tree);
+int dynsec_clients__config_save_yaml(yaml_emitter_t *emitter, yaml_event_t *event);
 int dynsec_clients__process_add_role(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_clients__process_create(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_clients__process_delete(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
@@ -185,6 +188,7 @@ int dynsec_clients__process_remove_role(cJSON *j_responses, struct mosquitto *co
 int dynsec_clients__process_set_id(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_clients__process_set_password(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 struct dynsec__client *dynsec_clients__find(const char *username);
+struct dynsec__client *dynsec_clients__find_or_create(const char *username);
 
 
 /* ################################################################
@@ -194,10 +198,12 @@ struct dynsec__client *dynsec_clients__find(const char *username);
  * ################################################################ */
 
 cJSON *dynsec_clientlist__all_to_json(struct dynsec__clientlist *base_clientlist);
+int dynsec_clientlist__all_to_yaml(struct dynsec__clientlist *base_clientlist, yaml_emitter_t* emitter, yaml_event_t *event);
 int dynsec_clientlist__add(struct dynsec__clientlist **base_clientlist, struct dynsec__client *client, int priority);
 void dynsec_clientlist__cleanup(struct dynsec__clientlist **base_clientlist);
 void dynsec_clientlist__remove(struct dynsec__clientlist **base_clientlist, struct dynsec__client *client);
 void dynsec_clientlist__kick_all(struct dynsec__clientlist *base_clientlist);
+int dynsec_clientlist__load_from_yaml(yaml_parser_t *parser, yaml_event_t *event, struct dynsec__clientlist **clientlist);
 
 
 /* ################################################################
@@ -208,8 +214,10 @@ void dynsec_clientlist__kick_all(struct dynsec__clientlist *base_clientlist);
 
 void dynsec_groups__cleanup(void);
 int dynsec_groups__config_load(cJSON *tree);
+int dynsec_groups__config_load_yaml(yaml_parser_t *parser, yaml_event_t *event);
 int dynsec_groups__add_client(const char *username, const char *groupname, int priority, bool update_config);
 int dynsec_groups__config_save(cJSON *tree);
+int dynsec_groups__config_save_yaml(yaml_emitter_t* emitter, yaml_event_t* event);
 int dynsec_groups__process_add_client(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_groups__process_add_role(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_groups__process_create(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
@@ -223,6 +231,7 @@ int dynsec_groups__process_get_anonymous_group(cJSON *j_responses, struct mosqui
 int dynsec_groups__process_set_anonymous_group(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_groups__remove_client(const char *username, const char *groupname, bool update_config);
 struct dynsec__group *dynsec_groups__find(const char *groupname);
+struct dynsec__group *dynsec_groups__find_or_create(const char *groupname);
 
 
 /* ################################################################
@@ -245,7 +254,9 @@ void dynsec_grouplist__remove(struct dynsec__grouplist **base_grouplist, struct 
 
 void dynsec_roles__cleanup(void);
 int dynsec_roles__config_load(cJSON *tree);
+int dynsec_roles__config_load_from_yaml(yaml_parser_t *parser, yaml_event_t *event);
 int dynsec_roles__config_save(cJSON *tree);
+int dynsec_roles__config_save_yaml(yaml_emitter_t *emitter, yaml_event_t *event);
 int dynsec_roles__process_add_acl(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_roles__process_create(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_roles__process_delete(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
@@ -254,6 +265,7 @@ int dynsec_roles__process_list(cJSON *j_responses, struct mosquitto *context, cJ
 int dynsec_roles__process_modify(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 int dynsec_roles__process_remove_acl(cJSON *j_responses, struct mosquitto *context, cJSON *command, char *correlation_data);
 struct dynsec__role *dynsec_roles__find(const char *rolename);
+struct dynsec__role *dynsec_roles__find_or_create(const char *rolename);
 
 
 /* ################################################################
@@ -262,12 +274,16 @@ struct dynsec__role *dynsec_roles__find(const char *rolename);
  * #
  * ################################################################ */
 
+int dynsec_rolelist__add(struct dynsec__rolelist **base_rolelist, struct dynsec__role *role, int priority);
+int dynsec_rolelist__remove_role(struct dynsec__rolelist **base_rolelist, const struct dynsec__role *role);
 int dynsec_rolelist__client_add(struct dynsec__client *client, struct dynsec__role *role, int priority);
 int dynsec_rolelist__client_remove(struct dynsec__client *client, struct dynsec__role *role);
 int dynsec_rolelist__group_add(struct dynsec__group *group, struct dynsec__role *role, int priority);
 void dynsec_rolelist__group_remove(struct dynsec__group *group, struct dynsec__role *role);
 int dynsec_rolelist__load_from_json(cJSON *command, struct dynsec__rolelist **rolelist);
+int dynsec_rolelist__load_from_yaml(yaml_parser_t *parser, yaml_event_t *event, struct dynsec__rolelist **rolelist);
 void dynsec_rolelist__cleanup(struct dynsec__rolelist **base_rolelist);
 cJSON *dynsec_rolelist__all_to_json(struct dynsec__rolelist *base_rolelist);
+int dynsec_rolelist__all_to_yaml(struct dynsec__rolelist *base_rolelist, yaml_emitter_t *emitter, yaml_event_t *event);
 
 #endif

--- a/plugins/dynamic-security/groups.c
+++ b/plugins/dynamic-security/groups.c
@@ -27,6 +27,8 @@ Contributors:
 #include "json_help.h"
 
 #include "dynamic_security.h"
+#include "yaml.h"
+#include "yaml_help.h"
 
 /* ################################################################
  * #
@@ -83,12 +85,30 @@ static int group_cmp(void *a, void *b)
 
 struct dynsec__group *dynsec_groups__find(const char *groupname)
 {
+    if (!groupname) return NULL;
+
 	struct dynsec__group *group = NULL;
 
-	if(groupname){
-		HASH_FIND(hh, local_groups, groupname, strlen(groupname), group);
-	}
+    HASH_FIND(hh, local_groups, groupname, strlen(groupname), group);
 	return group;
+}
+
+struct dynsec__group *dynsec_groups__find_or_create(const char *groupname)
+{
+    if (!groupname) return NULL;
+
+    struct dynsec__group *group = dynsec_groups__find(groupname);
+
+    if(!group) {
+        group = mosquitto_calloc(sizeof(struct dynsec__group), 1);
+        if(!group) return NULL;
+
+        group->groupname = mosquitto_strdup(groupname);
+
+        HASH_ADD_KEYPTR_INORDER(hh, local_groups, group->groupname, strlen(group->groupname), group, group_cmp);
+    }
+
+    return group;
 }
 
 static void group__free_item(struct dynsec__group *group)
@@ -191,6 +211,106 @@ void dynsec_groups__cleanup(void)
  * # Config file load
  * #
  * ################################################################ */
+
+int dynsec_groups__config_load_yaml(yaml_parser_t *parser, yaml_event_t *event)
+{
+    struct dynsec__group *group;
+    char *textname, *textdescription;
+
+    struct dynsec__rolelist *rolelist;
+    struct dynsec__clientlist *clientlist;
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+    YAML_PARSER_SEQUENCE_FOR_ALL(parser, event, { goto error; }, {
+        group = NULL;
+        textname = textdescription = NULL;
+        rolelist = NULL;
+        clientlist = NULL;
+
+        YAML_PARSER_MAPPING_FOR_ALL(parser, event, key, { goto error; }, {
+                if (strcmp(key, "groupname") == 0) {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    char *groupname;
+                    YAML_EVENT_INTO_SCALAR_STRING(event, &groupname, { goto error; });
+                    group = dynsec_groups__find_or_create(groupname);
+                    mosquitto_free(groupname);
+                } else if (strcmp(key, "textname") == 0) {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    YAML_EVENT_INTO_SCALAR_STRING(event, &textname, { goto error; });
+                } else if (strcmp(key, "textdescription") == 0) {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    YAML_EVENT_INTO_SCALAR_STRING(event, &textdescription, { goto error; });
+                } else if (strcmp(key, "roles") == 0) {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    if (!dynsec_rolelist__load_from_yaml(parser, event, &rolelist)) goto error;
+                } else if (strcmp(key, "clients") == 0) {
+                    if (!dynsec_clientlist__load_from_yaml(parser, event, &clientlist)) goto error;
+                } else {
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    mosquitto_log_printf(MOSQ_LOG_ERR, "Unexpected key for group config %s \n", key);
+                    yaml_dump_block(parser, event);
+                }
+                printf("%s:%d\n", __FILE__, __LINE__);
+
+
+        });
+
+        if (group) {
+            group->text_description = textdescription;
+            group->text_name = textname;
+
+            if (clientlist) {
+                struct dynsec__clientlist *iter;
+                struct dynsec__clientlist *tmp;
+
+                printf("%s:%d\n", __FILE__, __LINE__);
+                HASH_ITER(hh, clientlist, iter, tmp){
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                    dynsec_clientlist__add(&group->clientlist, iter->client, iter->priority);
+                    dynsec_grouplist__add(&iter->client->grouplist, group, iter->priority);
+                    iter->client = NULL;
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                }
+                dynsec_clientlist__cleanup(&clientlist);
+                printf("%s:%d\n", __FILE__, __LINE__);
+            }
+
+            if (rolelist) {
+                struct dynsec__rolelist *iter;
+                struct dynsec__rolelist *tmp;
+
+                printf("%s:%d\n", __FILE__, __LINE__);
+                HASH_ITER(hh, rolelist, iter, tmp){
+                    printf("%s:%d\n", __FILE__, __LINE__);
+
+                    dynsec_rolelist__add(&group->rolelist, iter->role, iter->priority);
+                    dynsec_grouplist__add(&iter->role->grouplist, group, iter->priority);
+                    iter->role = NULL;
+                    printf("%s:%d\n", __FILE__, __LINE__);
+                }
+                dynsec_rolelist__cleanup(&rolelist);
+                printf("%s:%d\n", __FILE__, __LINE__);
+            }
+        } else {
+            mosquitto_free(textname);
+            mosquitto_free(textdescription);
+
+            dynsec_rolelist__cleanup(&rolelist);
+            dynsec_clientlist__cleanup(&clientlist);
+        }
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+    });
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+    return 1;
+error:
+    mosquitto_free(textname);
+    mosquitto_free(textdescription);
+    dynsec_rolelist__cleanup(&rolelist);
+    dynsec_clientlist__cleanup(&clientlist);
+    return 0;
+}
 
 int dynsec_groups__config_load(cJSON *tree)
 {
@@ -340,6 +460,71 @@ static int dynsec__config_add_groups(cJSON *j_groups)
 	return 0;
 }
 
+static int dynsec__config_add_groups_yaml(yaml_emitter_t *emitter, yaml_event_t *event)
+{
+    struct dynsec__group *group, *group_tmp = NULL;
+
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+
+    yaml_sequence_start_event_initialize(event, NULL, (yaml_char_t *)YAML_SEQ_TAG,
+                                         1, YAML_ANY_SEQUENCE_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+
+    HASH_ITER(hh, local_groups, group, group_tmp){
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+
+        yaml_mapping_start_event_initialize(event, NULL, (yaml_char_t *)YAML_MAP_TAG,
+                                            1, YAML_ANY_MAPPING_STYLE);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+
+        if (!yaml_emit_string_field(emitter, event, "groupname", group->groupname)) return 0;
+        if (group->text_name && !yaml_emit_string_field(emitter, event, "textname", group->text_name)) return 0;
+        if (group->text_description && !yaml_emit_string_field(emitter, event, "textdescription", group->text_description)) return 0;
+
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+        yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                     (yaml_char_t *)"roles", strlen("roles"), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+
+        printf("%s:%d\n", __FILE__, __LINE__);
+        if (!dynsec_rolelist__all_to_yaml(group->rolelist, emitter, event)) return 0;
+
+        yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                     (yaml_char_t *)"clients", strlen("clients"), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+        printf("%s:%d\n", __FILE__, __LINE__);
+
+        if (!dynsec_clientlist__all_to_yaml(group->clientlist, emitter, event)) return 0;
+
+        yaml_mapping_end_event_initialize(event);
+        if (!yaml_emitter_emit(emitter, event)) return 0;
+    }
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+    yaml_sequence_end_event_initialize(event);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    printf("%s:%d\n", __FILE__, __LINE__);
+
+    return 1;
+}
+
+int dynsec_groups__config_save_yaml(yaml_emitter_t *emitter, yaml_event_t *event)
+{
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                 (yaml_char_t *)"groups", strlen("groups"), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+    if (!dynsec__config_add_groups_yaml(emitter, event)) return 0;
+
+    if (dynsec_anonymous_group && !yaml_emit_string_field(emitter, event, "anonymousGroup", dynsec_anonymous_group->groupname)) return 0;
+
+    return 1;
+}
 
 int dynsec_groups__config_save(cJSON *tree)
 {

--- a/plugins/dynamic-security/yaml_help.c
+++ b/plugins/dynamic-security/yaml_help.c
@@ -1,0 +1,200 @@
+//
+// Created by Akos Vandra on 2023-01-20.
+//
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "yaml_help.h"
+#include "yaml.h"
+#include <string.h>
+#include "mosquitto.h"
+#include "mosquitto_broker.h"
+
+
+void indent(int level)
+{
+    int i;
+    for (i = 0; i < level; i++) {
+        printf("%s", "  ");
+    }
+}
+
+char* yaml_event_type_name(yaml_event_type_t t) {
+    switch(t) {
+        case YAML_NO_EVENT: return "no-event";
+        case YAML_STREAM_START_EVENT: return "stream-start-event";
+        case YAML_STREAM_END_EVENT: return "stream-end-event";
+        case YAML_DOCUMENT_START_EVENT: return "document-start-event";
+        case YAML_DOCUMENT_END_EVENT: return "document-end-event";
+        case YAML_ALIAS_EVENT: return "alias-event";
+        case YAML_SCALAR_EVENT: return "scalar-event";
+        case YAML_SEQUENCE_START_EVENT: return "sequence-start-event";
+        case YAML_SEQUENCE_END_EVENT: return "sequence-end-event";
+        case YAML_MAPPING_START_EVENT: return "mapping-start-event";
+        case YAML_MAPPING_END_EVENT: return "mapping-end-event";
+    }
+
+    return "invalid value!";
+}
+
+void yaml_print_event(yaml_event_t *event, int level)
+{
+    switch (event->type) {
+        case YAML_NO_EVENT:
+            indent(level);
+            printf("no-event (%d)\n", event->type);
+            break;
+        case YAML_STREAM_START_EVENT:
+            indent(level++);
+            printf("stream-start-event (%d)\n", event->type);
+            break;
+        case YAML_STREAM_END_EVENT:
+            indent(--level);
+            printf("stream-end-event (%d)\n", event->type);
+            break;
+        case YAML_DOCUMENT_START_EVENT:
+            indent(level++);
+            printf("document-start-event (%d)\n", event->type);
+            break;
+        case YAML_DOCUMENT_END_EVENT:
+            indent(--level);
+            printf("document-end-event (%d)\n", event->type);
+            break;
+        case YAML_ALIAS_EVENT:
+            indent(level);
+            printf("alias-event (%d)\n", event->type);
+            break;
+        case YAML_SCALAR_EVENT:
+            indent(level);
+            printf("scalar-event (%d) = {value=\"%s\", length=%d}\n",
+                   event->type,
+                   (char*)event->data.scalar.value,
+                   (int)event->data.scalar.length);
+            break;
+        case YAML_SEQUENCE_START_EVENT:
+            indent(level++);
+            printf("sequence-start-event (%d)\n", event->type);
+            break;
+        case YAML_SEQUENCE_END_EVENT:
+            indent(--level);
+            printf("sequence-end-event (%d)\n", event->type);
+            break;
+        case YAML_MAPPING_START_EVENT:
+            indent(level++);
+            printf("mapping-start-event (%d)\n", event->type);
+            break;
+        case YAML_MAPPING_END_EVENT:
+            indent(--level);
+            printf("mapping-end-event (%d)\n", event->type);
+            break;
+    }
+    if (level < 0) {
+        printf("indentation underflow!\n");
+        level = 0;
+    }
+}
+
+int yaml_parse_string_scalar(yaml_event_t *event, char** value) {
+    int ret = 1;
+
+    PARSER_EXPECT_EVENT_TYPE(event, YAML_SCALAR_EVENT, { ret = 0; });
+
+    *value = mosquitto_strdup((char*)event->data.scalar.value);
+
+    yaml_event_delete(event);
+    return ret;
+}
+
+long int yaml_parse_long_int_scalar(yaml_event_t *event, long int* value, char* file, int line) {
+    int ret = 1;
+    char* endptr;
+
+    PARSER_EXPECT_EVENT_TYPE(event, YAML_SCALAR_EVENT, { ret = 0; });
+
+    *value = strtol((char*)event->data.scalar.value, &endptr, 10);
+
+    if (strlen(endptr) > 0) {
+        mosquitto_log_printf(MOSQ_LOG_ERR, "Error parsing Dynamic security plugin config. Expected integer value, but got %s on line %d:%d at %s:%d", event->data.scalar.value, event->start_mark.line, event->start_mark.column, file, line);
+        ret = 0;
+    }
+
+    yaml_event_delete(event);
+    return ret;
+}
+
+
+int yaml_parse_bool_scalar(yaml_event_t *event, bool* value, char* file, int line) {
+    int ret = 1;
+
+    PARSER_EXPECT_EVENT_TYPE(event, YAML_SCALAR_EVENT, { ret = 0; });
+
+    if (strcmp((char*)event->data.scalar.value, "true") == 0) {
+        *value = true;
+    } else if (strcmp((char*)event->data.scalar.value, "false") == 0) {
+        *value = false;
+    } else {
+        mosquitto_log_printf(MOSQ_LOG_ERR, "Error parsing Dynamic security plugin config. Expected boolean value (true,false), but got %s on line %d:%d at %s:%d", event->data.scalar.value, event->type, event->start_mark.line, event->start_mark.column, file, line);              \
+        ret = 0;
+    }
+
+    yaml_event_delete(event);
+    return ret;
+}
+
+
+
+int yaml_emit_string_field(yaml_emitter_t *emitter, yaml_event_t *event, const char* field, const char* value) {
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                 (yaml_char_t *)field, (int)strlen(field), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                 (yaml_char_t *)value, (int)strlen(value), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    return 1;
+}
+
+int yaml_emit_int_field(yaml_emitter_t *emitter, yaml_event_t *event, const char* field, int value) {
+    char buf[33] = { '\0' };
+    snprintf(buf, 32, "%d", value);
+
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                 (yaml_char_t *)field, (int)strlen(field), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_INT_TAG,
+                                 (yaml_char_t *)buf, (int)strlen(buf), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    return 1;
+}
+
+int yaml_emit_bool_field(yaml_emitter_t *emitter, yaml_event_t *event, const char* field, int value) {
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_STR_TAG,
+                                 (yaml_char_t *)field, (int)strlen(field), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    yaml_scalar_event_initialize(event, NULL, (yaml_char_t *)YAML_BOOL_TAG,
+                                 (yaml_char_t *)(value ? "true" : "false"), (int)strlen(value ? "true" : "false"), 1, 0, YAML_PLAIN_SCALAR_STYLE);
+    if (!yaml_emitter_emit(emitter, event)) return 0;
+
+    return 1;
+}
+
+int yaml_dump_block(yaml_parser_t *parser, yaml_event_t *event) {
+    int nest = 0;
+
+    do {
+        yaml_print_event(event, nest);
+
+        if (event->type == YAML_MAPPING_START_EVENT || event->type == YAML_SEQUENCE_START_EVENT) nest++;
+        if (event->type == YAML_MAPPING_END_EVENT || event->type == YAML_SEQUENCE_END_EVENT) nest--;
+
+        if (nest == 0) break;
+        if (!yaml_parser_parse(parser, event)) return 0;
+    } while (nest > 0);
+
+    return 1;
+}

--- a/plugins/dynamic-security/yaml_help.h
+++ b/plugins/dynamic-security/yaml_help.h
@@ -1,0 +1,63 @@
+//
+// Created by Akos Vandra on 2023-01-20.
+//
+
+#ifndef MOSQUITTO_UTIL_H
+#define MOSQUITTO_UTIL_H
+
+#include "yaml.h"
+#include <stdbool.h>
+
+#define PARSER_EXPECT_EVENT_TYPE(event, event_type, on_error) \
+    if ((event)->type != event_type) { \
+        mosquitto_log_printf(MOSQ_LOG_ERR, "Error parsing Dynamic security plugin config: Expected event %s, but got %s on line %d:%d at %s:%d\n", yaml_event_type_name(event_type), yaml_event_type_name((event)->type), (event)->start_mark.line, (event)->start_mark.column, __FILE__, __LINE__);    \
+        do { on_error; } while (0);                                                                                                                                                                                                                            \
+    }
+
+#define YAML_CHECK_RESULT(block, on_error, msg, ...) \
+    if (!(block)) { \
+        mosquitto_log_printf(MOSQ_LOG_ERR, "Error parsing Dynamic security plugin config: " msg " from %s:%d\n" __VA_OPT__(,) __VA_ARGS__, __FILE__, __LINE__); \
+        do { on_error; } while (0); \
+    }
+
+#define YAML_EVENT_INTO_SCALAR_BOOL(event, out, on_err) YAML_CHECK_RESULT(yaml_parse_bool_scalar(event, out, __FILE__, __LINE__), { do { on_err } while(0); }, "Could not parse boolean value from %s", event->data.scalar.value)
+#define YAML_EVENT_INTO_SCALAR_STRING(event, out, on_err) YAML_CHECK_RESULT(yaml_parse_string_scalar(event, out), on_err, "Could not read string value")
+#define YAML_EVENT_INTO_SCALAR_LONG_INT(event, out, on_err) YAML_CHECK_RESULT(yaml_parse_long_int_scalar(event, out, __FILE__, __LINE__),  { do { on_err } while(0); }, "Could not read integer value from %s", event->data.scalar.value)
+
+#define YAML_PARSER_FOR_ALL(parser, event, start_event, end_event, on_error, ...) \
+    {                                                                               \
+        PARSER_EXPECT_EVENT_TYPE(event, start_event, on_error);                     \
+        while(true) {                                                               \
+            if (!yaml_parser_parse(parser, event)) on_error;                        \
+            if ((event)->type == end_event) break;                                  \
+            do { __VA_ARGS__; } while (0);                                          \
+            yaml_event_delete(event);                                               \
+        };                                                                          \
+        yaml_event_delete(event);                                                   \
+    }
+
+#define YAML_PARSER_SEQUENCE_FOR_ALL(parser, event, on_error, ...)  YAML_PARSER_FOR_ALL(parser, event, YAML_SEQUENCE_START_EVENT, YAML_SEQUENCE_END_EVENT, on_error, __VA_ARGS__)
+#define YAML_PARSER_MAPPING_FOR_ALL(parser, event, key, on_error, ...)  YAML_PARSER_FOR_ALL(parser, event, YAML_MAPPING_START_EVENT, YAML_MAPPING_END_EVENT, on_error, { \
+    printf("1\n");                                                                                                                                                                         \
+    PARSER_EXPECT_EVENT_TYPE(event, YAML_SCALAR_EVENT, on_error);                                                                                                        \
+    printf("2\n");                                                                                                                                                                         \
+    char *key = mosquitto_strdup((char*)(event)->data.scalar.value);                                                                                                       \
+    yaml_event_delete(event);                                               \
+    if (!yaml_parser_parse(parser, event)) on_error;                                                                                                                     \
+    printf("3\n");                                                                                                                                                                         \
+    do { __VA_ARGS__; } while (0);                                                                                                                                               \
+    printf("4\n");                                                                                                                                                                         \
+    mosquitto_free(key);                                                                                                                                                 \
+})
+
+char* yaml_event_type_name(yaml_event_type_t t);
+void yaml_print_event(yaml_event_t *event, int level);
+int yaml_emit_string_field(yaml_emitter_t *emitter, yaml_event_t *event, const char* field, const char* value);
+int yaml_emit_int_field(yaml_emitter_t *emitter, yaml_event_t *event, const char* field, int value);
+int yaml_emit_bool_field(yaml_emitter_t *emitter, yaml_event_t *event, const char* field, int value);
+int yaml_parse_bool_scalar(yaml_event_t *event, bool* value, char* file, int line);
+int yaml_parse_string_scalar(yaml_event_t *event, char** value);
+long int yaml_parse_long_int_scalar(yaml_event_t *event, long int* value, char* file, int line);
+int yaml_dump_block(yaml_parser_t *parser, yaml_event_t *event);
+
+#endif //MOSQUITTO_UTIL_H


### PR DESCRIPTION
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----

Adds yaml serialization / deserialization to the dynamic-security-plugin so that the config file can be more easily be understood and modified by a human in case one does not actually want to use the dynamic part of the plugin (or not exclusively).

This is a PoC, would appreciate some preliminary feedback.

A lot of debug/trace code is still there and it needs a lot of cleanup, but it's enough to get some idea on what I'm trying to do.

Some notes / open questions / TODOs:

  - [ ] Makefile changes need to be done - No guards yet for the availability of the YAML library.
  - [ ] The plugin auto-guesses the format based on the file extension, although this could be an (optional) plugin parameter as well. I don't see why having to suffix yaml files with .yaml or .yml would pose an issue, but it might, so it might be worthwile to add an ovveride parameter.
  - [ ] One could argue to remove the json loaders, since the yaml parser can parse the json files, however this would mean that in order to use the plugin, one would need the yaml library.
  - [ ] The yaml parser can only parse the data in the order they appear in the file. Some changes needed to be made in case the client and group lists appear earlier than the roles in the file, as otherwise the system would err out with role not found errors.
  - [ ] Error handling need to be cleaned up, and corrected, currently all yaml functions return 1 for success, 0 for error. The parse errors themselves are written to the log more-or-less correcly.
  - [ ] No testing yet, manually checked that a few json files are read (by the yaml deserializer!) and written back to yaml correctly. Some mosquitto_ctrl commands have been issued.
the initialization of the plugin is currently written out as json, and I don't intend to change that. The yaml parser will parse that json file correctly anyways.
  - [ ] Probably a lot of memory handling issues are still present, will need to verify that no memory is leaked. Gah, I hate C.

My plans in the future (not part of this effort):

  - Answer the question on what happens if another auth plugin accepts a user that is not registered as a client in the dynamic security plugin. (currently have an hmac authentication plugin where the broker doesn't need to know about all its clients beforehand, so no configuration is needed on the broker to have a new client connect - same case with signed client certificates)
  - Add the ability to encode groups in usernames (any user connectiong with g1-foo will be part of the group g1 if it exists.). This will allow other plugins to authorize users, and still have the dynamic security plugin work for them. (Or another smart way to handle these)