### PR TITLE
use CLOCK_BOOTTIME when available.

### DIFF
--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -61,8 +61,11 @@ int mosquitto_lib_init(void)
 		srand((unsigned int)GetTickCount64());
 #elif _POSIX_TIMERS>0 && defined(_POSIX_MONOTONIC_CLOCK)
 		struct timespec tp;
-
-		clock_gettime(CLOCK_MONOTONIC, &tp);
+#ifdef CLOCK_BOOTTIME
+        clock_gettime(CLOCK_BOOTTIME, &tp);
+#else
+        clock_gettime(CLOCK_MONOTONIC, &tp);
+#endif
 		srand((unsigned int)tp.tv_nsec);
 #elif defined(__APPLE__)
 		uint64_t ticks;

--- a/lib/time_mosq.c
+++ b/lib/time_mosq.c
@@ -43,7 +43,11 @@ time_t mosquitto_time(void)
 #elif _POSIX_TIMERS>0 && defined(_POSIX_MONOTONIC_CLOCK)
 	struct timespec tp;
 
+#ifdef CLOCK_BOOTTIME
+    clock_gettime(CLOCK_BOOTTIME, &tp);
+#else
 	clock_gettime(CLOCK_MONOTONIC, &tp);
+#endif
 	return tp.tv_sec;
 #elif defined(__APPLE__)
 	static mach_timebase_info_data_t tb;


### PR DESCRIPTION
This is just a minor fix for #2760