### PR TITLE
fix: fix daemon not umask

### DIFF
--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -159,7 +159,8 @@ static void mosquitto__daemonise(void)
 		log__printf(NULL, MOSQ_LOG_ERR, "Error in setsid: %s", err);
 		exit(1);
 	}
-
+	umask(0);
+	chdir("/");
 	assert(freopen("/dev/null", "r", stdin));
 	assert(freopen("/dev/null", "w", stdout));
 	assert(freopen("/dev/null", "w", stderr));


### PR DESCRIPTION
In the daemon process, reset the umask to 0, so that the file
           modes passed to open(), mkdir() and suchlike directly control
           the access mode of the created files and directories.

Ref:
https://www.man7.org/linux/man-pages/man7/daemon.7.html