### PR TITLE
Memory leak with per listener setting

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -213,10 +213,10 @@ static void config__cleanup_plugins(struct mosquitto__config *config)
 {
 	int i, j, l;
 	struct mosquitto__auth_plugin_config *plug;
-	if(config->per_listener_settings) {
+	if(config->per_listener_settings && config->listeners) {
 		for(l=0; l<config->listener_count; l++){
 			struct mosquitto__auth_plugin_config *plug;
-			if(config->listeners[i].security_options.auth_plugin_configs){
+			if(config->listeners[l].security_options.auth_plugin_configs){
 				for(i=0; i<config->listeners[l].security_options.auth_plugin_config_count; i++){
 					plug = &config->listeners[l].security_options.auth_plugin_configs[i];
 					mosquitto__free(plug->path);
@@ -328,6 +328,7 @@ void config__cleanup(struct mosquitto__config *config)
 #endif
 		}
 		mosquitto__free(config->listeners);
+		config->listeners = NULL;
 	}
 #ifdef WITH_BRIDGE
 	if(config->bridges){


### PR DESCRIPTION
When per_listener_settings is turned on then for every plugin configured there is some memory leak, though this leak is small and constant but it will increase with number of plugin configured.

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
