### PR TITLE
Add errorcodes to mosquitto_strerror. Closes #2799

### DIFF
--- a/lib/strings_mosq.c
+++ b/lib/strings_mosq.c
@@ -75,6 +75,10 @@ const char *mosquitto_strerror(int mosq_errno)
 			return "Proxy error.";
 		case MOSQ_ERR_MALFORMED_UTF8:
 			return "Malformed UTF-8";
+		case MOSQ_ERR_KEEPALIVE:
+			return "Keepalive ping timeout.";
+		case MOSQ_ERR_LOOKUP:
+			return "DNS lookup error.";
 		case MOSQ_ERR_DUPLICATE_PROPERTY:
 			return "Duplicate property in property list";
 		case MOSQ_ERR_TLS_HANDSHAKE:


### PR DESCRIPTION
Add string representations for MOSQ_ERR_KEEPALIVE and MOSQ_ERR_LOOKUP. Closes #2799

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
