### PR TITLE
fix: add missing entries in linker.syms

### DIFF
--- a/src/linker.syms
+++ b/src/linker.syms
@@ -61,6 +61,7 @@
 	mosquitto_property_read_string;
 	mosquitto_property_read_string_pair;
 	mosquitto_property_read_varint;
+	mosquitto_property_remove
 	mosquitto_pub_topic_check2;
 	mosquitto_pub_topic_check;
 	mosquitto_realloc;
@@ -78,4 +79,6 @@
 	mosquitto_topic_matches_sub;
 	mosquitto_topic_matches_sub_with_pattern;
 	mosquitto_validate_utf8;
+	mosquitto_pre_connect_callback_set;
+	mosquitto_unsubscribe2_v5_callback_set
 };


### PR DESCRIPTION
Some functions have been added to `mosquitto.h` but they were not added to linker.syms. This PR fixes that.


Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
