### PR TITLE
Fix engine keyfile support.

### DIFF
--- a/apps/mosquitto_ctrl/options.c
+++ b/apps/mosquitto_ctrl/options.c
@@ -593,6 +593,11 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 		return 1;
 	}
 #ifdef WITH_TLS
+	if(cfg->keyform && mosquitto_string_option(mosq, MOSQ_OPT_TLS_KEYFORM, cfg->keyform)){
+		fprintf(stderr, "Error: Problem setting key form, it must be one of 'pem' or 'engine'.\n");
+		mosquitto_lib_cleanup();
+		return 1;
+	}
 	if(cfg->cafile || cfg->capath){
 		rc = mosquitto_tls_set(mosq, cfg->cafile, cfg->capath, cfg->certfile, cfg->keyfile, NULL);
 		if(rc){
@@ -612,11 +617,6 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 	}
 	if(cfg->tls_engine && mosquitto_string_option(mosq, MOSQ_OPT_TLS_ENGINE, cfg->tls_engine)){
 		fprintf(stderr, "Error: Problem setting TLS engine, is %s a valid engine?\n", cfg->tls_engine);
-		mosquitto_lib_cleanup();
-		return 1;
-	}
-	if(cfg->keyform && mosquitto_string_option(mosq, MOSQ_OPT_TLS_KEYFORM, cfg->keyform)){
-		fprintf(stderr, "Error: Problem setting key form, it must be one of 'pem' or 'engine'.\n");
 		mosquitto_lib_cleanup();
 		return 1;
 	}

--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -1253,6 +1253,11 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 		return 1;
 	}
 #ifdef WITH_TLS
+	if(cfg->keyform && mosquitto_string_option(mosq, MOSQ_OPT_TLS_KEYFORM, cfg->keyform)){
+		err_printf(cfg, "Error: Problem setting key form, it must be one of 'pem' or 'engine'.\n");
+		mosquitto_lib_cleanup();
+		return 1;
+	}
 	if(cfg->cafile || cfg->capath){
 		rc = mosquitto_tls_set(mosq, cfg->cafile, cfg->capath, cfg->certfile, cfg->keyfile, NULL);
 		if(rc){
@@ -1286,11 +1291,6 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 	}
 	if(cfg->tls_engine && mosquitto_string_option(mosq, MOSQ_OPT_TLS_ENGINE, cfg->tls_engine)){
 		err_printf(cfg, "Error: Problem setting TLS engine, is %s a valid engine?\n", cfg->tls_engine);
-		mosquitto_lib_cleanup();
-		return 1;
-	}
-	if(cfg->keyform && mosquitto_string_option(mosq, MOSQ_OPT_TLS_KEYFORM, cfg->keyform)){
-		err_printf(cfg, "Error: Problem setting key form, it must be one of 'pem' or 'engine'.\n");
 		mosquitto_lib_cleanup();
 		return 1;
 	}

--- a/lib/options.c
+++ b/lib/options.c
@@ -179,19 +179,21 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 	mosquitto__free(mosq->tls_keyfile);
 	mosq->tls_keyfile = NULL;
 	if(keyfile){
-		fptr = mosquitto__fopen(keyfile, "rt", false);
-		if(fptr){
-			fclose(fptr);
-		}else{
-			mosquitto__free(mosq->tls_cafile);
-			mosq->tls_cafile = NULL;
+		if(mosq->tls_keyform == mosq_k_pem){
+			fptr = mosquitto__fopen(keyfile, "rt", false);
+			if(fptr){
+				fclose(fptr);
+			}else{
+				mosquitto__free(mosq->tls_cafile);
+				mosq->tls_cafile = NULL;
 
-			mosquitto__free(mosq->tls_capath);
-			mosq->tls_capath = NULL;
+				mosquitto__free(mosq->tls_capath);
+				mosq->tls_capath = NULL;
 
-			mosquitto__free(mosq->tls_certfile);
-			mosq->tls_certfile = NULL;
-			return MOSQ_ERR_INVAL;
+				mosquitto__free(mosq->tls_certfile);
+				mosq->tls_certfile = NULL;
+				return MOSQ_ERR_INVAL;
+			}
 		}
 		mosq->tls_keyfile = mosquitto__strdup(keyfile);
 		if(!mosq->tls_keyfile){
@@ -290,6 +292,11 @@ int mosquitto_string_option(struct mosquitto *mosq, enum mosq_opt_t option, cons
 #if defined(WITH_TLS) && !defined(OPENSSL_NO_ENGINE)
 			mosquitto__free(mosq->tls_engine);
 			if(value){
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+				/* The "Dynamic" OpenSSL engine is not initialized by default but
+				   is required by ENGINE_by_id() to find dynamically loadable engines */
+				OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_DYNAMIC, NULL);
+#endif
 				eng = ENGINE_by_id(value);
 				if(!eng){
 					return MOSQ_ERR_INVAL;

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -1391,9 +1391,12 @@ openssl dhparam -out dhparam.pem 2048</programlisting>
 					<term><option>keyfile</option> <replaceable>file path</replaceable></term>
 					<listitem>
 						<para>
-							Path to the PEM encoded server key. This
-							option and <option>certfile</option> must be present
-							to enable certificate based TLS encryption.
+							If <option>tls_keyform</option> equals "pem" this is the
+							path to the PEM encoded server key. This option
+							and <option>certfile</option> must be present
+							to enable certificate based TLS encryption. If
+							<option>tls_keyform</option> is "engine" this represents
+							the engine handle of the private key.
 						</para>
 						<para>
 							The private key pointed to by this option will be


### PR DESCRIPTION
This small patch fixes two outstanding issues with OpenSSL engine support in the MQTT client:
1. When the tls_keyform is "engine" then the "keyfile" representing the private key is not neccessarily a real file but can be any handle known to the engine (URL, number, ...).
When the keyfile argument is validated in the function `mosquitto_tls_set()` then it should not be tried to open this file unless tls_keyform is "pem".
Because the tls_keyform must be known before calling `mosquitto_tls_set()`, the parsing of this tls_keyform config setting needs to be done before parsing the capath/cafile settings. 
2. Dynamically loadable OpenSSL engines require the `OPENSSL_INIT_ENGINE_DYNAMIC` option to be set or the `ENGINE_by_ID()` call will fail to find the engine in `mosquitto_string_option()`. As indicated in the OpenSSL documentation this option is not set by default.

This fix can also be seen as a lightweight and generic alternative to #719 which is fully oriented towards the pkcs11 engine while there are many other engines out there.
The `mosquitto.conf.5` man page describing the tls_keyfile conf setting has also been updated because the current description is only correct when tls_keyform is "pem".

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
