### PR TITLE
Revert setting bridge session_expiry_interval change

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -128,9 +128,6 @@ static struct mosquitto *bridge__new(struct mosquitto__bridge *bridge)
 	}
 	new_context->retain_available = bridge->outgoing_retain;
 	new_context->protocol = bridge->protocol_version;
-	if(!bridge->clean_start_local){
-		new_context->session_expiry_interval = UINT32_MAX;
-	}
 
 	bridges = mosquitto__realloc(db.bridges, (size_t)(db.bridge_count+1)*sizeof(struct mosquitto *));
 	if(bridges){


### PR DESCRIPTION
Revert 68cfec3cddbec7a11c7c354c3bbd614edd993ce9 commit.
It looks like the intention of this change was to make bridge client connection similar to client API,
but for bridges it doesn't look correct.
For bridges there is "bridge_session_expiry_interval" options which is 0 by default.