### PR TITLE
man: Fix typo-in-manual-page noticable noticeable

### DIFF
--- a/man/mosquitto_ctrl.1.xml
+++ b/man/mosquitto_ctrl.1.xml
@@ -319,7 +319,7 @@
 				<listitem>
 					<para>Disable Nagle's algorithm for the socket. This means
 						that latency of sent messages is reduced, which is
-						particularly noticable for small, reasonably infrequent
+						particularly noticeable for small, reasonably infrequent
 						messages. Using this option may result in more packets
 						being sent than would normally be necessary.</para>
 				</listitem>


### PR DESCRIPTION
This was reported by debian lintian checker

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
