### PR TITLE
Remove session expiration timer upon setting up bridge connection (fix #2634)

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -84,6 +84,7 @@ int bridge__new(struct mosquitto__bridge *bridge)
 	if(new_context){
 		/* (possible from persistent db) */
 		mosquitto__free(local_id);
+		session_expiry__remove(new_context);
 	}else{
 		/* id wasn't found, so generate a new context */
 		new_context = context__init(INVALID_SOCKET);


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

This fixes #2634 by removing a possibly existing session expiration timer when setting up a bridge connection.

The bug is a side effect of the fix to #2546. Normally session expiration timers are not created for bridge connections. Starting with 2.0.15 the timers are created at startup for all clients found in the persistent database which also has records for bridge connections.

I have not worked with mosquitto code before, but I can see a few potential solutions:

- Don't create session expiration timers for bridge connections found in the persistent database. Unfortunately, there is no way to recognize bridge connections at that point. It would require an additional flag in the database.
- When a bridge connection is being configured and a context for the client ID already existed, remove the corresponding session expiration timer.
- Don't write bridge connections to the persistent database. I'm not completely sure but I think those records are useless for bridge connections anyway (although apparently their existence in the persistent database was a conscious decision).
- Ignore bridge connections when checking session expiration timers.

I have decided to go with option number 2.