### PR TITLE
Support abstract namespace for unix domain sockets

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -1301,7 +1301,7 @@ accept_protocol_versions 3, 4</programlisting>
 					</listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>listener</option> <replaceable>port</replaceable> <replaceable><optional>bind address/host/unix socket path</optional></replaceable></term>
+					<term><option>listener</option> &lt; <replaceable>port</replaceable> <optional><replaceable>bind address/host</replaceable></optional> | 0 <replaceable>unix socket path</replaceable> &gt;</term>
 					<listitem>
 						<para>Listen for incoming network connection on the
 							specified port. A second optional argument allows
@@ -1311,7 +1311,7 @@ accept_protocol_versions 3, 4</programlisting>
 							nor <option>port</option> options are used then the
 							default listener will not be started.</para>
 
-						<para>The <option>bind address/host</option> option
+						<para>The <replaceable>bind address/host</replaceable> option
 							allows this listener to be bound to a specific IP
 							address by passing an IP address or hostname. For
 							websockets listeners, it is only possible to pass
@@ -1320,7 +1320,9 @@ accept_protocol_versions 3, 4</programlisting>
 						<para>On systems that support Unix Domain Sockets, this
 							option can also be used to create a Unix socket rather
 							than opening a TCP socket. In this case, the port must
-							be set to 0, and the unix socket path must be given.</para>
+							be set to 0, and the <replaceable>unix socket path</replaceable>
+							must be given. A path starting with @ is placed
+							in the abstract namespace.</para>
 
 						<para>This option may be specified multiple times. See
 							also the <option>mount_point</option>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -244,10 +244,12 @@
 # name.
 #
 # On systems that support Unix Domain Sockets, it is also possible
-# to create a # Unix socket rather than opening a TCP socket. In
+# to create a Unix socket rather than opening a TCP socket. In
 # this case, the port number should be set to 0 and a unix socket
-# path must be provided, e.g.
+# path must be provided. A path starting with @ is placed in the abstract
+# namespace. Examples:
 # listener 0 /tmp/mosquitto.sock
+# listener 0 @mosquitto
 #
 # listener port-number [ip address/host name/unix socket path]
 #listener

--- a/src/listeners.c
+++ b/src/listeners.c
@@ -286,11 +286,7 @@ void listeners__stop(void)
 		}
 		mosquitto__FREE(db.config->listeners[i].ws_protocol);
 #endif
-#ifdef WITH_UNIX_SOCKETS
-		if(db.config->listeners[i].unix_socket_path != NULL){
-			unlink(db.config->listeners[i].unix_socket_path);
-		}
-#endif
+		net__socket_unlink(&db.config->listeners[i]);
 	}
 
 	for(i=0; i<g_listensock_count; i++){

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -678,6 +678,7 @@ int send__auth(struct mosquitto *context, uint8_t reason_code, const void *auth_
  * ============================================================ */
 void net__broker_init(void);
 void net__broker_cleanup(void);
+void net__socket_unlink(struct mosquitto__listener *listener);
 struct mosquitto *net__socket_accept(struct mosquitto__listener_sock *listensock);
 int net__socket_listen(struct mosquitto__listener *listener);
 int net__socket_get_address(mosq_sock_t sock, char *buf, size_t len, uint16_t *remote_address);

--- a/test/broker/01-connect-unix-socket.py
+++ b/test/broker/01-connect-unix-socket.py
@@ -6,7 +6,8 @@ from mosq_test_helper import *
 
 def write_config(filename, port):
     with open(filename, 'w') as f:
-        f.write("listener 0 %d.sock\n" % (port))
+        f.write(f"listener 0 {port}.sock\n")
+        f.write(f"listener 0 @mosquitto-{port}\n")
         f.write("allow_anonymous true\n")
 
 def do_test():
@@ -25,7 +26,11 @@ def do_test():
             time.sleep(0.1)
         else:
             time.sleep(2)
+
         sock = mosq_test.do_client_connect_unix(connect_packet, connack_packet, path=f"{port}.sock")
+        sock.close()
+
+        sock = mosq_test.do_client_connect_unix(connect_packet, connack_packet, path=f"\x00mosquitto-{port}")
         sock.close()
 
         rc = 0


### PR DESCRIPTION
On Linux, sockaddr_un.sun_path starting with a null byte places the socket into the abstract namespace. A common convention (systemd, upstart) to configure this is to start the path with @.

This avoids file system accesses for linking/unlinking on the server, and opening on clients, and is useful in chroot environments.

---

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] ~If you are contributing a bugfix, is your work based off the fixes branch?~
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?