### PR TITLE
Fix mosquitto_passwd backup file

### DIFF
--- a/apps/mosquitto_passwd/mosquitto_passwd.c
+++ b/apps/mosquitto_passwd/mosquitto_passwd.c
@@ -629,13 +629,13 @@ int main(int argc, char *argv[])
 			return 1;
 		}
 
-		backup_file = malloc((size_t)strlen(password_file)+strlen(".backup.XXXXXX"));
+		backup_file = malloc((size_t)strlen(password_file)+strlen(".backup.XXXXXX")+1);
 		if(!backup_file){
 			fprintf(stderr, "Error: Out of memory.\n");
 			free(password_file);
 			return 1;
 		}
-		snprintf(backup_file, strlen(password_file)+5, "%s.backup.XXXXXX", password_file);
+		snprintf(backup_file, strlen(password_file)+strlen(".backup.XXXXXX")+1, "%s.backup.XXXXXX", password_file);
 		free(password_file);
 		password_file = NULL;
 


### PR DESCRIPTION
This fixes an issue with the name of the backup file created when using the `mosquitto_passwd -U password.txt` command. Currently, the command fails with an error that says "Error creating backup password file". Closes #2873.

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
