### PR TITLE
Link correctly with shared websockets library if needed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,7 +200,7 @@ if (WITH_WEBSOCKETS)
 			link_directories(${mosquitto_SOURCE_DIR})
 		endif (WIN32)
 	else (STATIC_WEBSOCKETS)
-		set (MOSQ_LIBS ${MOSQ_LIBS} websockets)
+		set (MOSQ_LIBS ${MOSQ_LIBS} websockets_shared)
 	endif (STATIC_WEBSOCKETS)
 endif (WITH_WEBSOCKETS)
 


### PR DESCRIPTION
see: https://github.com/eclipse/mosquitto/pull/2751

Patch contributed by Joachim Zobel <jz-2017@heute-morgen.de> and  Daniel Engberg <daniel.engberg.lists@pyret.net>
