### PR TITLE
Unix Domain Sockets support for websockets listener

### DIFF
--- a/src/websockets.c
+++ b/src/websockets.c
@@ -688,8 +688,13 @@ void mosq_websockets_init(struct mosquitto__listener *listener, const struct mos
 
 	memset(&info, 0, sizeof(info));
 	if(listener->port == 0){
+#ifdef WITH_UNIX_SOCKETS
 		info.iface = listener->unix_socket_path;
 		info.options |= LWS_SERVER_OPTION_UNIX_SOCK;
+#else
+		log__printf(NULL, MOSQ_LOG_ERR, "Unix Domain Sockets are disabled");
+		return;
+#endif
 	}else{
 		info.iface = listener->host;
 	}

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -687,7 +687,12 @@ void mosq_websockets_init(struct mosquitto__listener *listener, const struct mos
 	}
 
 	memset(&info, 0, sizeof(info));
-	info.iface = listener->host;
+	if(listener->port == 0){
+		info.iface = listener->unix_socket_path;
+		info.options |= LWS_SERVER_OPTION_UNIX_SOCK;
+	}else{
+		info.iface = listener->host;
+	}
 	info.port = listener->port;
 	info.protocols = p;
 	info.gid = -1;


### PR DESCRIPTION
### Description

It looks like mosquitto listeners support Unix Domain Sockets to serve mqtt over TCP, while using them with websockets fails.  
`libwebsockets` has a compile option named `LWS_UNIX_SOCK` that enables `UDS` support.
Suggested change uses the same configuration syntax for websockets listener:
```
listener 0 /path/to/unix.sock
protocol websockets
```
but obtains the file name from another `unix_socket_path` listener property.
It also enables UDS support for `lws_context` instance by appending `LWS_SERVER_OPTION_UNIX_SOCK` options flag.

### Note

I had tried the version of the patch that used `LWS_USE_UNIX_SOCK` definition to test if `libwebsockets` support UDS, but it should work only when compiling, while at runtime the dynamic library could be replaced with another instance, so I thought it doesn't make any sense. Haven't found any runtime test for UDS support in `libwebsockets`.

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?