### PR TITLE
OpenSSL: fix spurious SSL connection aborts

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -976,6 +976,7 @@ ssize_t net__read(struct mosquitto *mosq, void *buf, size_t count)
 	errno = 0;
 #ifdef WITH_TLS
 	if(mosq->ssl){
+		ERR_clear_error();
 		ret = SSL_read(mosq->ssl, buf, (int)count);
 		if(ret <= 0){
 			ret = net__handle_ssl(mosq, ret);
@@ -1008,6 +1009,7 @@ ssize_t net__write(struct mosquitto *mosq, const void *buf, size_t count)
 #ifdef WITH_TLS
 	if(mosq->ssl){
 		mosq->want_write = false;
+		ERR_clear_error();
 		ret = SSL_write(mosq->ssl, buf, (int)count);
 		if(ret < 0){
 			ret = net__handle_ssl(mosq, ret);


### PR DESCRIPTION
### Description

Was seeing spurious SSL connection aborts using libmosquitto and OpenSSL. I tracked it down to uncleared error state on the OpenSSL error stack - patch attached deals with that.

### Rough idea of problem:

Code that uses libmosquitto calls some library that uses OpenSSL but don't clear the OpenSSL error stack after an error. lib/net_mosq.c calls SSL_read which eventually gets an EWOULDBLOCK from the OS. Returns -1 to indicate an error lib/net_mosq.c calls SSL_get_error. First thing, SSL_get_error calls ERR_get_error to check the OpenSSL error stack, finds an old error and returns SSL_ERROR_SSL instead of SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE.

lib/net_mosq.c returns an error and aborts the connection

### Solution:
Clear the openssl error stack before calling SSL_* operation if we're going to call SSL_get_error afterwards.

### Notes:
This is much more likely to happen with multi because it's easier to intersperse other calls to the OpenSSL library in the same thread.

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [-] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

The problem appears after [#commit.](https://github.com/eclipse/mosquitto/commit/47dadb902dacb4d963ba9ec34803f62ea418e964)
