### PR TITLE
fix custom message id when unsubscribing

### DIFF
--- a/lib/send_unsubscribe.c
+++ b/lib/send_unsubscribe.c
@@ -73,7 +73,7 @@ int send__unsubscribe(struct mosquitto *mosq, int *mid, int topic_count, char *c
 
 	/* Variable header */
 	local_mid = mosquitto__mid_generate(mosq);
-	if(mid) *mid = (int)local_mid;
+	if(mid) local_mid = (uint16_t)(*mid & 0xFFFF);
 	packet__write_uint16(packet, local_mid);
 
 	if(mosq->protocol == mosq_p_mqtt5){


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
On `/lib/send_unsubscribe.c` the function `packet__write_uint16`  ignores the contents of `mid` even when it exists. This code fixes that issue.

Note: I am using the `master` branch as a base but I checked and this issue is also present on `fixes`. 

