### PR TITLE
fix CLOCK_BOOTTIME use on kernels not having it

### DIFF
--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -38,6 +38,7 @@ Contributors:
 #include "mqtt_protocol.h"
 #include "net_mosq.h"
 #include "packet_mosq.h"
+#include "time_mosq.h"
 #include "will_mosq.h"
 
 static unsigned int init_refcount = 0;
@@ -57,15 +58,15 @@ int mosquitto_lib_init(void)
 	int rc;
 
 	if (init_refcount == 0) {
+		mosquitto_time_init();
 #ifdef WIN32
 		srand((unsigned int)GetTickCount64());
 #elif _POSIX_TIMERS>0 && defined(_POSIX_MONOTONIC_CLOCK)
 		struct timespec tp;
 #ifdef CLOCK_BOOTTIME
-		clock_gettime(CLOCK_BOOTTIME, &tp);
-#else
-		clock_gettime(CLOCK_MONOTONIC, &tp);
+		if (clock_gettime(CLOCK_BOOTTIME, &tp) != 0)
 #endif
+		clock_gettime(CLOCK_MONOTONIC, &tp);
 		srand((unsigned int)tp.tv_nsec);
 #elif defined(__APPLE__)
 		uint64_t ticks;

--- a/lib/time_mosq.h
+++ b/lib/time_mosq.h
@@ -19,6 +19,7 @@ Contributors:
 #ifndef TIME_MOSQ_H
 #define TIME_MOSQ_H
 
+void mosquitto_time_init(void);
 time_t mosquitto_time(void);
 
 #endif


### PR DESCRIPTION
When the libc headers used to build mosquitto define CLOCK_BOOTTIME but the kernel where mosquitto runs does not implement CLOCK_BOOTTIME, all timestamps are wrong (uninitialized data), because there is no check for the success of the clock_gettime() calls.

This adds probing for the availability of CLOCK_BOOTTIME from mosquitto_lib_init(), falling back to CLOCK_MONOTONIC, and then modifies mosquitto_time() to use the selected clock. Probing at init time avoids having to do two clock_gettime() calls for every timestamp if CLOCK_BOOTTIME is not available.

It also fixes a similar problem in mosquitto_lib_init().

This fixes #3089 

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
