### PR TITLE
Increase logging of errors

### DIFF
--- a/lib/strings_mosq.c
+++ b/lib/strings_mosq.c
@@ -90,7 +90,13 @@ const char *mosquitto_strerror(int mosq_errno)
 		case MOSQ_ERR_OCSP:
 			return "OCSP error.";
 		default:
-			return "Unknown error.";
+			if(mosq_errno >= 128) {
+				// If mosq_errno is greater than 127,
+				// a mqtt5_return_code error was used
+				return mosquitto_reason_string(mosq_errno);
+			} else {
+				return "Unknown error.";
+			}
 	}
 }
 


### PR DESCRIPTION
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

fix #2579

Commit 6113eac95a9df634fbc858be542c4a0456bfe7b9 started using MQTT_RC_* enums as a handle__publish return value, which typically were MOSQ_ERR_* values. I personally think this is a good use, however the logging system should comply with it.
