### PR TITLE
Let systemd create directories

### DIFF
--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -5,15 +5,14 @@ After=network.target
 Wants=network.target
 
 [Service]
+User=mosquitto
 Type=notify
 NotifyAccess=main
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
-ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /var/log/mosquitto
-ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /run/mosquitto
+RuntimeDirectory=mosquitto
+LogsDirectory=mosquitto
 
 [Install]
 WantedBy=multi-user.target

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -5,13 +5,12 @@ After=network.target
 Wants=network.target
 
 [Service]
+User=mosquitto
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
-ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /var/log/mosquitto
-ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /run/mosquitto
+RuntimeDirectory=mosquitto
+LogsDirectory=mosquitto
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Context

Manually creating directories conflicts with systemd service hardening features. Particularly, `ProtectSystem=strict` mounts the filesystem has read-only for the processes started by the unit which leads to `mkdir` failing.

By setting `User=mosquitto` and adding `RuntimeDirectory` and `LogsDirectory`, systemd creates `/run/mosquitto` and `/var/log/mosquitto` with the right permissions even `ProtectSystem=strict` is used.

Adding `User=mosquitto` also has the side effect of running the daemon as the user `mosquitto`. I 

### Checklist

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
https://accounts.eclipse.org/users/gchamp20, submitted, appears to be pending? I can still re-submit but I now get an error.

- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?
