### PR TITLE
Fix keep-alive disconnects on system time changes

### DIFF
--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -446,6 +446,7 @@ static int pid__write(void)
 
 int main(int argc, char *argv[])
 {
+	mosquitto_time_init();
 	struct mosquitto__config config;
 #ifdef WITH_BRIDGE
 	int i;


### PR DESCRIPTION
Treat this as a request for comments for now. Potentially mosquitto_lib_init should be called instead and not just mosqutitto_time_init.

Calling mosqutitto_time_init seems to fix issues with changing system time back and forth one hour on Linux resulting in all clients with keep-alive being kicked instantly.

mosquitto_time_init must be called before calling mosquitto_time, otherwise time_clock will be 0 in mosquitto_time (per C99 standard initialized to 0 since there is no explicit init value) which will cause the realtime clock to be used when the intention seems to be to use the best monotonic clock supported by the platform.

That in turn causes the broker to kick clients when system time is changed because it's misinterpreted as clients failing on their keep-alive promises.

I need to check with my employer if I can sign the below referenced agreement.

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
