### PR TITLE
More precise constness for topics in mosquitto_subscribe_multiple

### DIFF
--- a/client/sub_client.c
+++ b/client/sub_client.c
@@ -122,7 +122,7 @@ static void my_connect_callback(struct mosquitto *mosq, void *obj, int result, i
 
 	connack_result = result;
 	if(!result){
-		mosquitto_subscribe_multiple(mosq, NULL, cfg.topic_count, cfg.topics, cfg.qos, cfg.sub_opts, cfg.subscribe_props);
+		mosquitto_subscribe_multiple(mosq, NULL, cfg.topic_count, (const char* const*)cfg.topics, cfg.qos, cfg.sub_opts, cfg.subscribe_props);
 
 		for(i=0; i<cfg.unsub_topic_count; i++){
 			mosquitto_unsubscribe_v5(mosq, NULL, cfg.unsub_topics[i], cfg.unsubscribe_props);

--- a/include/mosquitto.h
+++ b/include/mosquitto.h
@@ -1036,7 +1036,7 @@ libmosq_EXPORT int mosquitto_subscribe_v5(struct mosquitto *mosq, int *mid, cons
  *	MOSQ_ERR_OVERSIZE_PACKET - if the resulting packet would be larger than
  *	                           supported by the broker.
  */
-libmosq_EXPORT int mosquitto_subscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, char *const *const sub, int qos, int options, const mosquitto_property *properties);
+libmosq_EXPORT int mosquitto_subscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, const char* const *sub, int qos, int options, const mosquitto_property *properties);
 
 /*
  * Function: mosquitto_unsubscribe
@@ -1135,7 +1135,7 @@ libmosq_EXPORT int mosquitto_unsubscribe_v5(struct mosquitto *mosq, int *mid, co
  *	MOSQ_ERR_OVERSIZE_PACKET - if the resulting packet would be larger than
  *	                           supported by the broker.
  */
-libmosq_EXPORT int mosquitto_unsubscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, char *const *const sub, const mosquitto_property *properties);
+libmosq_EXPORT int mosquitto_unsubscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, const char* const *sub, const mosquitto_property *properties);
 
 
 /* ======================================================================

--- a/lib/actions.c
+++ b/lib/actions.c
@@ -166,17 +166,17 @@ int mosquitto_publish_v5(struct mosquitto *mosq, int *mid, const char *topic, in
 
 int mosquitto_subscribe(struct mosquitto *mosq, int *mid, const char *sub, int qos)
 {
-	return mosquitto_subscribe_multiple(mosq, mid, 1, (char *const *const)&sub, qos, 0, NULL);
+	return mosquitto_subscribe_multiple(mosq, mid, 1, &sub, qos, 0, NULL);
 }
 
 
 int mosquitto_subscribe_v5(struct mosquitto *mosq, int *mid, const char *sub, int qos, int options, const mosquitto_property *properties)
 {
-	return mosquitto_subscribe_multiple(mosq, mid, 1, (char *const *const)&sub, qos, options, properties);
+	return mosquitto_subscribe_multiple(mosq, mid, 1, &sub, qos, options, properties);
 }
 
 
-int mosquitto_subscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, char *const *const sub, int qos, int options, const mosquitto_property *properties)
+int mosquitto_subscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, const char* const *sub, int qos, int options, const mosquitto_property *properties)
 {
 	const mosquitto_property *outgoing_properties = NULL;
 	mosquitto_property local_property;
@@ -227,15 +227,15 @@ int mosquitto_subscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count
 
 int mosquitto_unsubscribe(struct mosquitto *mosq, int *mid, const char *sub)
 {
-	return mosquitto_unsubscribe_multiple(mosq, mid, 1, (char *const *const)&sub, NULL);
+	return mosquitto_unsubscribe_multiple(mosq, mid, 1, &sub, NULL);
 }
 
 int mosquitto_unsubscribe_v5(struct mosquitto *mosq, int *mid, const char *sub, const mosquitto_property *properties)
 {
-	return mosquitto_unsubscribe_multiple(mosq, mid, 1, (char *const *const)&sub, properties);
+	return mosquitto_unsubscribe_multiple(mosq, mid, 1, &sub, properties);
 }
 
-int mosquitto_unsubscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, char *const *const sub, const mosquitto_property *properties)
+int mosquitto_unsubscribe_multiple(struct mosquitto *mosq, int *mid, int sub_count, const char* const *sub, const mosquitto_property *properties)
 {
 	const mosquitto_property *outgoing_properties = NULL;
 	mosquitto_property local_property;

--- a/lib/send_mosq.h
+++ b/lib/send_mosq.h
@@ -34,7 +34,7 @@ int send__pubcomp(struct mosquitto *mosq, uint16_t mid, const mosquitto_property
 int send__publish(struct mosquitto *mosq, uint16_t mid, const char *topic, uint32_t payloadlen, const void *payload, uint8_t qos, bool retain, bool dup, const mosquitto_property *cmsg_props, const mosquitto_property *store_props, uint32_t expiry_interval);
 int send__pubrec(struct mosquitto *mosq, uint16_t mid, uint8_t reason_code, const mosquitto_property *properties);
 int send__pubrel(struct mosquitto *mosq, uint16_t mid, const mosquitto_property *properties);
-int send__subscribe(struct mosquitto *mosq, int *mid, int topic_count, char *const *const topic, int topic_qos, const mosquitto_property *properties);
-int send__unsubscribe(struct mosquitto *mosq, int *mid, int topic_count, char *const *const topic, const mosquitto_property *properties);
+int send__subscribe(struct mosquitto *mosq, int *mid, int topic_count, const char* const *topic, int topic_qos, const mosquitto_property *properties);
+int send__unsubscribe(struct mosquitto *mosq, int *mid, int topic_count, const char* const *topic, const mosquitto_property *properties);
 
 #endif

--- a/lib/send_subscribe.c
+++ b/lib/send_subscribe.c
@@ -36,7 +36,7 @@ Contributors:
 #include "util_mosq.h"
 
 
-int send__subscribe(struct mosquitto *mosq, int *mid, int topic_count, char *const *const topic, int topic_qos, const mosquitto_property *properties)
+int send__subscribe(struct mosquitto *mosq, int *mid, int topic_count, const char* const *topic, int topic_qos, const mosquitto_property *properties)
 {
 	struct mosquitto__packet *packet = NULL;
 	uint32_t packetlen;

--- a/lib/send_unsubscribe.c
+++ b/lib/send_unsubscribe.c
@@ -35,7 +35,7 @@ Contributors:
 #include "util_mosq.h"
 
 
-int send__unsubscribe(struct mosquitto *mosq, int *mid, int topic_count, char *const *const topic, const mosquitto_property *properties)
+int send__unsubscribe(struct mosquitto *mosq, int *mid, int topic_count, const char* const *topic, const mosquitto_property *properties)
 {
 	struct mosquitto__packet *packet = NULL;
 	uint32_t packetlen;

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -546,12 +546,12 @@ int bridge__on_connect(struct mosquitto *context)
 					| MQTT_SUB_OPT_RETAIN_AS_PUBLISHED
 					| MQTT_SUB_OPT_SEND_RETAIN_ALWAYS;
 			}
-			if(send__subscribe(context, NULL, 1, &context->bridge->topics[i].remote_topic, sub_opts, NULL)){
+			if(send__subscribe(context, NULL, 1, (const char* const*)&context->bridge->topics[i].remote_topic, sub_opts, NULL)){
 				return 1;
 			}
 		}else{
 			if(context->bridge->attempt_unsubscribe){
-				if(send__unsubscribe(context, NULL, 1, &context->bridge->topics[i].remote_topic, NULL)){
+				if(send__unsubscribe(context, NULL, 1, (const char* const*)&context->bridge->topics[i].remote_topic, NULL)){
 					/* direction = inwards only. This means we should not be subscribed
 					* to the topic. It is possible that we used to be subscribed to
 					* this topic so unsubscribe. */


### PR DESCRIPTION
`mosquitto_subscribe_multiple` and `mosquitto_unsubscribe_multiple` do not need to change the characters in the list of topics. Make the signature more precise to reflect that.

Now works without cast array of `const char*`, particularly useful for C++ or Rust bindings.

---

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] ~~If you are contributing a new feature, is your work based off the develop branch?~~
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?