### PR TITLE
t/Makefile: Generate test certs if not present in sources

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,17 +1,23 @@
 include ../config.mk
 
-.PHONY: all check test ptest clean
+.PHONY: all check test ptest clean ssl
 
 all :
 
 check : test
 
-test : utest
+ssl: ssl/all-ca.crt
+
+ssl/all-ca.crt: ssl/gen.sh
+	cd "${<D}" && "${CURDIR}/${<}"
+	test -e "$@"
+
+test : utest ssl
 	$(MAKE) -C broker test
 	$(MAKE) -C lib test
 	$(MAKE) -C client test
 
-ptest : utest
+ptest : utest ssl
 	$(MAKE) -C broker ptest
 	$(MAKE) -C lib ptest
 	$(MAKE) -C client test


### PR DESCRIPTION
Since generated keys have expiration date,
it means that the tests are not reproductible over time. Integrator may be tempted to not rely on upstream files and generate them on the fly at built time.

This change was motivated for maintenance of 2.0.11 in Debian 12 (stable).

I noticed that upstream regerated certs in master branch since, but still they will expire in future.

Relate-to: https://salsa.debian.org/debian-iot-team/mosquitto/-/merge_requests/21

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
