### PR TITLE
Fix missing dependencies when statically linking OpenSSL

### DIFF
--- a/apps/mosquitto_ctrl/CMakeLists.txt
+++ b/apps/mosquitto_ctrl/CMakeLists.txt
@@ -43,7 +43,7 @@ if (WITH_TLS AND CJSON_FOUND)
 		endif (APPLE)
 	endif (UNIX)
 
-	target_link_libraries(mosquitto_ctrl ${OPENSSL_LIBRARIES} ${CJSON_LIBRARIES})
+	target_link_libraries(mosquitto_ctrl OpenSSL::SSL ${CJSON_LIBRARIES})
 
 	install(TARGETS mosquitto_ctrl RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif (WITH_TLS AND CJSON_FOUND)

--- a/apps/mosquitto_passwd/CMakeLists.txt
+++ b/apps/mosquitto_passwd/CMakeLists.txt
@@ -13,6 +13,6 @@ if (WITH_TLS)
 		)
 
 
-	target_link_libraries(mosquitto_passwd ${OPENSSL_LIBRARIES})
+	target_link_libraries(mosquitto_passwd OpenSSL::SSL)
 	install(TARGETS mosquitto_passwd RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif (WITH_TLS)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,7 +60,7 @@ set(C_SRC
 	util_mosq.c util_topic.c util_mosq.h
 	will_mosq.c will_mosq.h)
 
-set (LIBRARIES ${OPENSSL_LIBRARIES})
+set (LIBRARIES OpenSSL::SSL)
 
 if (UNIX AND NOT APPLE AND NOT ANDROID)
 	find_library(LIBRT rt)

--- a/plugins/dynamic-security/CMakeLists.txt
+++ b/plugins/dynamic-security/CMakeLists.txt
@@ -32,7 +32,7 @@ if (CJSON_FOUND AND WITH_TLS)
 	)
 	set_target_properties(mosquitto_dynamic_security PROPERTIES PREFIX "")
 
-	target_link_libraries(mosquitto_dynamic_security ${CJSON_LIBRARIES} ${OPENSSL_LIBRARIES})
+	target_link_libraries(mosquitto_dynamic_security ${CJSON_LIBRARIES} OpenSSL::SSL)
 	if(WIN32)
 		target_link_libraries(mosquitto_dynamic_security mosquitto)
 		install(TARGETS mosquitto_dynamic_security

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,7 +157,7 @@ if (WITH_DLT)
     set (MOSQ_LIBS ${MOSQ_LIBS} ${DLT_LIBRARIES})
 endif (WITH_DLT)
 
-set (MOSQ_LIBS ${MOSQ_LIBS} ${OPENSSL_LIBRARIES})
+set (MOSQ_LIBS ${MOSQ_LIBS} OpenSSL::SSL)
 # Check for getaddrinfo_a
 include(CheckLibraryExists)
 check_library_exists(anl getaddrinfo_a  "" HAVE_GETADDRINFO_A)


### PR DESCRIPTION
I'm working on a project that needs to statically link all dependencies.

I'm building Mosquitto like this:
```
cmake -B build -S . \
    -DWITH_STATIC_LIBRARIES=ON \
    -DWITH_PIC=ON \
    -DWITH_THREADING=OFF \
    -DOPENSSL_USE_STATIC_LIBS=ON

cmake --build build --config Release -j
```

Linking directly to `${OPENSSL_LIBRARIES}` breaks because of missing link-time dependencies (defined via `INTERFACE_LINK_LIBRARIES` on the OpenSSL target).

<details>
  <summary>build.log</summary>

```
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.19044.
-- The C compiler identification is MSVC 19.43.34810.0
-- The CXX compiler identification is MSVC 19.43.34810.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenSSL: optimized;C:/Users/peelz/scoop/apps/openssl/current/lib/VC/x64/MD/libcrypto_static.lib;debug;C:/Users/peelz/scoop/apps/openssl/current/lib/VC/x64/MDd/libcrypto_static.lib (found version "3.5.0")
-- WITH_DLT = OFF
-- Could NOT find cJSON (missing: CJSON_INCLUDE_DIR CJSON_LIBRARY) 
-- Optional dependency cJSON not found. Some features will be disabled.
-- Looking for getaddrinfo_a in anl
-- Looking for getaddrinfo_a in anl - not found
CMake Warning at man/CMakeLists.txt:44 (message):
  xsltproc not found: manpages cannot be built


-- Configuring done (4.8s)
-- Generating done (0.3s)
-- Build files have been written to: C:/Users/peelz/code/public/mosquitto/build
MSBuild version 17.13.19+0d9f5a35a for .NET Framework

  1>Checking Build System
  Building Custom Rule C:/Users/peelz/code/public/mosquitto/src/CMakeLists.txt
  alias_mosq.c
  bridge.c
  bridge_topic.c
  conf.c
  conf_includedir.c
  context.c
  control.c
  database.c
  handle_auth.c
  handle_connack.c
  handle_connect.c
  handle_disconnect.c
  handle_ping.c
  handle_pubackcomp.c
  handle_publish.c
  handle_pubrec.c
  handle_pubrel.c
  handle_suback.c
  handle_subscribe.c
  handle_unsuback.c
  Generating Code...
  Compiling...
  handle_unsubscribe.c
  keepalive.c
  logging.c
  loop.c
  memory_mosq.c
  memory_public.c
  mosquitto.c
  misc_mosq.c
  mux.c
  mux_epoll.c
  mux_poll.c
  net.c
  net_mosq_ocsp.c
C:\Users\peelz\code\public\mosquitto\src\net.c(764,53): warning C4133: 'function': incompatible types - from 'int *' to 'const char *' [C:\Users\peelz\code\public\mosquitto\build\src\mosquitto.vcxproj]
  net_mosq.c
  packet_datatypes.c
  packet_mosq.c
  password_mosq.c
  persist_read_v234.c
  persist_read_v5.c
  persist_read.c
  Generating Code...
  Compiling...
  persist_write_v5.c
  persist_write.c
  plugin.c
  plugin_public.c
  property_broker.c
  property_mosq.c
  read_handle.c
  retain.c
  security.c
  security_default.c
  send_mosq.c
  send_auth.c
  send_connack.c
  send_connect.c
  send_disconnect.c
  send_publish.c
  send_suback.c
  signals.c
  send_subscribe.c
  send_unsuback.c
  Generating Code...
  Compiling...
  send_unsubscribe.c
  session_expiry.c
  strings_mosq.c
  subs.c
  sys_tree.c
  time_mosq.c
  tls_mosq.c
  topic_tok.c
  util_mosq.c
  util_topic.c
  utf8_mosq.c
  websockets.c
  will_delay.c
  will_mosq.c
  service.c
  Generating Code...
     Creating library C:/Users/peelz/code/public/mosquitto/build/src/Release/mosquitto.lib and object C:/Users/peelz/code/public/mosquitto/build/src/Release/mosquitto.exp
libcrypto_static.lib(libdefault-lib-winstore_store.obj) : error LNK2019: unresolved external symbol __imp_CertCloseStore referenced in function winstore_close [C:\Users\peelz\code\public\mosquitto\build\src\mosquitto.vcxproj]
libcrypto_static.lib(libdefault-lib-winstore_store.obj) : error LNK2019: unresolved external symbol __imp_CertFindCertificateInStore referenced in function winstore_set_ctx_params [C:\Users\peelz\code\public\mosquitto\build\src\mosquitto.vcxproj]
libcrypto_static.lib(libdefault-lib-winstore_store.obj) : error LNK2019: unresolved external symbol __imp_CertFreeCertificateContext referenced in function winstore_close [C:\Users\peelz\code\public\mosquitto\build\src\mosquitto.vcxproj]
libcrypto_static.lib(libdefault-lib-winstore_store.obj) : error LNK2019: unresolved external symbol __imp_CertOpenSystemStoreW referenced in function winstore_open [C:\Users\peelz\code\public\mosquitto\build\src\mosquitto.vcxproj]
C:\Users\peelz\code\public\mosquitto\build\src\Release\mosquitto.exe : fatal error LNK1120: 4 unresolved externals [C:\Users\peelz\code\public\mosquitto\build\src\mosquitto.vcxproj]
```
</details>

BTW I tried signing the ECA, but the Eclipse account registration form doesn't accept email addresses with dots in them??? Hopefully you're able to accept this PR regardless.
![image](https://github.com/user-attachments/assets/497837c4-3129-4110-874c-854daadef169)