### PR TITLE
Fix check for existing delayed auth check

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -824,13 +824,6 @@ int handle__connect(struct mosquitto *context)
 		}
 	}
 
-	/* Check for an existing delayed auth check, reject if present */
-	HASH_FIND(hh_id, db.contexts_by_id_delayed_auth, clientid, strlen(clientid), found_context);
-	if(found_context){
-		rc = MOSQ_ERR_UNKNOWN;
-		goto handle_connect_error;
-	}
-
 	if(will){
 		rc = will__read(context, clientid, &will_struct, will_qos, will_retain);
 		if(rc){
@@ -982,6 +975,14 @@ int handle__connect(struct mosquitto *context)
 			goto handle_connect_error;
 		}
 	}
+
+	/* Check for an existing delayed auth check, reject if present */
+	HASH_FIND(hh_id, db.contexts_by_id_delayed_auth, context->id, strlen(context->id), found_context);
+	if(found_context){
+		rc = MOSQ_ERR_UNKNOWN;
+		goto handle_connect_error;
+	}
+
 	context->clean_start = clean_start;
 	context->will = will_struct;
 	will_struct = NULL;


### PR DESCRIPTION
This PR fixes the possibility that multiple clients are connected using the same client id via the `use_username_as_clientid` option. The check for delayed authentication checks is now moved below the last statement that sets the client id.

---

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
