### PR TITLE
Fix mismatched free for cJSON-generated string in dynsec__config_save

### DIFF
--- a/plugins/dynamic-security/plugin.c
+++ b/plugins/dynamic-security/plugin.c
@@ -629,7 +629,7 @@ void dynsec__config_save(void)
 		return;
 	}
 	fwrite(json_str, 1, json_str_len, fptr);
-	mosquitto_free(json_str);
+	cJSON_free(json_str);
 	fclose(fptr);
 
 	/* Everything is ok, so move new file over proper file */


### PR DESCRIPTION
### Summary

This PR changes the deallocation of the JSON string returned by `cJSON_Print()` from `mosquitto_free()` to `cJSON_free()`, fixing a memory‐tracking underflow caused by mixing allocators. This underflow makes the tracking subsystem thinks that it has a lot of GB reserved, and any subsequent call to `mosquitto_malloc()` returns "out of memory" which leaves the broker unusable after a few operations with the Dynamic Security Plugin. The only way of recovering it is restarting Mosquitto.

### Background & Problem

In `dynsec__config_save()`, the code currently does:

```c
json_str = cJSON_Print(tree);
/* … */
mosquitto_free(json_str);
```

However:

* `cJSON_Print()` internally allocates with `cJSON_malloc()`.
* Freeing that memory with `mosquitto_free()` (instead of `cJSON_free()`) decrements Mosquitto’s own allocation counter (memory_mosq.c) for a pointer that was never allocated and counted by `mosquitto_malloc()`, causing the counter to underflow.
* On the next `mosquitto_malloc()` this counter appears “too large,” causing subsequent allocations to spuriously fail with “out of memory,” rendering the broker unusable until restart.

### How to reproduce

Set a `memory_limit` in mosquitto.conf

Using the dynamic security plugin perform a few operations of adding and/or removing users to/from ACL rules. The counter of the memory tracker will decrease with each operation until it underflows.

---


- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
