### PR TITLE
Rename DOCUMENTATION option to WITH_DOCS in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ option(WITH_CLIENTS "Build clients?" ON)
 option(WITH_BROKER "Build broker?" ON)
 option(WITH_APPS "Build apps?" ON)
 option(WITH_PLUGINS "Build plugins?" ON)
-option(DOCUMENTATION "Build documentation?" ON)
+option(WITH_DOCS "Build documentation?" ON)
 
 add_subdirectory(lib)
 if (WITH_CLIENTS)
@@ -122,9 +122,9 @@ if (WITH_PLUGINS)
 	add_subdirectory(plugins)
 endif (WITH_PLUGINS)
 
-if (DOCUMENTATION)
+if (WITH_DOCS)
 	add_subdirectory(man)
-endif (DOCUMENTATION)
+endif (WITH_DOCS)
 
 # ========================================
 # Install config file


### PR DESCRIPTION
## Problem

Fixes #3381

The CMakeLists.txt used `DOCUMENTATION` as the option name, while the README.md and config.mk consistently use `WITH_DOCS`. This naming inconsistency made it confusing for users who want to disable documentation building.

### Current State
- **CMakeLists.txt**: Uses `DOCUMENTATION` option
- **config.mk**: Uses `WITH_DOCS` variable  
- **README.md**: Documents `make WITH_DOCS=no`

## Solution

Rename the CMake option from `DOCUMENTATION` to `WITH_DOCS` to match the Makefile convention and maintain consistency across the build system.

### Changes

1. Renamed `option(DOCUMENTATION ...)` to `option(WITH_DOCS ...)`
2. Updated all references: `if (DOCUMENTATION)` → `if (WITH_DOCS)`
3. Maintains consistency with other CMake options (`WITH_CLIENTS`, `WITH_BROKER`, `WITH_APPS`, `WITH_PLUGINS`)

### Usage

Before:
```bash
cmake -DDOCUMENTATION=OFF ..
```

After:
```bash
cmake -DWITH_DOCS=OFF ..
```

## Backward Compatibility

This is a **breaking change** for users who explicitly set `-DDOCUMENTATION=OFF` in their CMake commands. However:
- The option was undocumented in README (which only mentions `WITH_DOCS`)
- It aligns with the established `WITH_*` naming convention
- Makes the build system more intuitive and consistent

## Testing

- Verified the diff shows correct renaming
- Option maintains the same default value (`ON`)
- No functional changes to the build process