### PR TITLE
Do not include microhttpd.h if WITH_HTTP_API is disabled

### DIFF
--- a/src/http_api.c
+++ b/src/http_api.c
@@ -18,6 +18,8 @@ Contributors:
 
 #include "config.h"
 
+#ifdef WITH_HTTP_API
+
 #include <assert.h>
 #include <errno.h>
 #include <microhttpd.h>
@@ -31,8 +33,6 @@ Contributors:
 #include "mosquitto_broker_internal.h"
 #include "mosquitto/mqtt_protocol.h"
 #include "sys_tree.h"
-
-#ifdef WITH_HTTP_API
 
 #ifndef HTTP_API_DIR
 #  define HTTP_API_DIR ""


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

Just move the ifdef higher up so we don't needlessly include microhttpd.h.
Only relevant for the Makefile build.
