### PR TITLE
Add OCI labels to all docker images

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,10 @@
+2.1.1 - xxxx-xx-xx
+==================
+
+# Broker
+- Fix PUID/PGID checking for docker
+
+
 2.1.0 - 2026-01-29
 ==================
 

--- a/docker/2.1-alpine/Dockerfile
+++ b/docker/2.1-alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.22
 
-ENV VERSION=2.1.0 \
-    DOWNLOAD_SHA256=ceccf14f43b8ce21312d0dbf247025b8166536e9afba326f8b7c8b1d201fa6d9 \
+ENV VERSION=2.1.0.1 \
+    DOWNLOAD_SHA256=cd0dd9d2b824746f9bc7dfc0a26a62854f64de72c1838023a12471f66b25dd7c \
     GPG_KEYS=A0D6EEA1DCAE49A635A3B2F0779B22DFB3E717B7
 
 LABEL \
@@ -75,6 +75,7 @@ RUN set -x && \
     install -s -m755 /build/mosq/plugins/persist-sqlite/mosquitto_persist_sqlite.so /usr/lib/mosquitto_persist_sqlite.so && \
     install -s -m755 /build/mosq/plugins/sparkplug-aware/mosquitto_sparkplug_aware.so /usr/lib/mosquitto_sparkplug_aware.so && \
     install -m644 /build/mosq/docker/2.1-alpine/mosquitto.conf /mosquitto/config/mosquitto.conf && \
+    install -m644 /build/mosq/docker/2.1-ubuntu/mosquitto.conf /mosquitto-no-auth.conf && \
     install -d /usr/share/mosquitto && \
     cp -r /build/mosq/dashboard/src /usr/share/mosquitto/dashboard && \
     install -Dm644 /build/mosq/epl-v20 /usr/share/licenses/mosquitto/epl-v20 && \

--- a/docker/2.1-alpine/docker-entrypoint.sh
+++ b/docker/2.1-alpine/docker-entrypoint.sh
@@ -4,10 +4,10 @@ set -e
 # Set permissions
 user="$(id -u)"
 if [ "$PUID" = "" ]; then
-	PUID="mosquitto"
+	PUID="1883"
 fi
 if [ "$PGID" = "" ]; then
-	PGID="mosquitto"
+	PGID="1883"
 fi
 if [ "$user" = '0' ]; then
 	[ -d "/mosquitto/data" ] && chown -R ${PUID}:${PGID} /mosquitto/data || true

--- a/docker/2.1-ubuntu/Dockerfile
+++ b/docker/2.1-ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
-ENV VERSION=2.1.0 \
-    DOWNLOAD_SHA256=ceccf14f43b8ce21312d0dbf247025b8166536e9afba326f8b7c8b1d201fa6d9 \
+ENV VERSION=2.1.0.1 \
+    DOWNLOAD_SHA256=cd0dd9d2b824746f9bc7dfc0a26a62854f64de72c1838023a12471f66b25dd7c \
     GPG_KEYS=A0D6EEA1DCAE49A635A3B2F0779B22DFB3E717B7
 
 LABEL \
@@ -75,6 +75,7 @@ RUN set -x && \
     install -s -m755 /build/mosq/plugins/persist-sqlite/mosquitto_persist_sqlite.so /usr/lib/mosquitto_persist_sqlite.so && \
     install -s -m755 /build/mosq/plugins/sparkplug-aware/mosquitto_sparkplug_aware.so /usr/lib/mosquitto_sparkplug_aware.so && \
     install -m644 /build/mosq/docker/2.1-ubuntu/mosquitto.conf /mosquitto/config/mosquitto.conf && \
+    install -m644 /build/mosq/docker/2.1-ubuntu/mosquitto.conf /mosquitto-no-auth.conf && \
     install -d /usr/share/mosquitto && \
     cp -r /build/mosq/dashboard/src /usr/share/mosquitto/dashboard && \
     install -Dm644 /build/mosq/epl-v20 /usr/share/licenses/mosquitto/epl-v20 && \

--- a/docker/2.1-ubuntu/docker-entrypoint.sh
+++ b/docker/2.1-ubuntu/docker-entrypoint.sh
@@ -4,10 +4,10 @@ set -e
 # Set permissions
 user="$(id -u)"
 if [ "$PUID" = "" ]; then
-	PUID="mosquitto"
+	PUID="1883"
 fi
 if [ "$PGID" = "" ]; then
-	PGID="mosquitto"
+	PGID="1883"
 fi
 if [ "$user" = '0' ]; then
 	[ -d "/mosquitto/data" ] && chown -R ${PUID}:${PGID} /mosquitto/data || true

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -101,7 +101,10 @@ static int set_umask(void)
 static int check_uid(const char *s, const char *name)
 {
 	char *endptr = NULL;
-	long id = strtol(s, &endptr, 10);
+	long id;
+
+	errno = 0;
+	id = strtol(s, &endptr, 10);
 	if(errno || endptr == s || *endptr != '\0'){
 		log__printf(NULL, MOSQ_LOG_ERR, "Error: %s not a valid ID '%s'", name, s);
 		return -1;


### PR DESCRIPTION
Extend PR #3182 to add OCI metadata to (hopefully) all docker images.

I added the VERSION arg to the local build, even though I'm not 100% sure it is necessary, but for the sake of consistency.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
