### PR TITLE
Support OpenSSL v3 store providers

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -58,6 +58,9 @@ Contributors:
 #include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/ui.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/store.h>
+#endif
 #include <tls_mosq.h>
 #endif
 
@@ -861,6 +864,52 @@ static int net__init_ssl_ctx(struct mosquitto *mosq)
 					}
 #endif
 				}else{
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+					EVP_PKEY *pkey = NULL;
+					OSSL_STORE_CTX *ctx = NULL;
+					UI_METHOD *ui_method = net__get_ui_method();
+					ctx = OSSL_STORE_open(mosq->tls_keyfile, ui_method, NULL, NULL, NULL);
+					if(!ctx){
+						log__printf(mosq, MOSQ_LOG_ERR, "Error: unable to load a store context based on URI \"%s\".", mosq->tls_keyfile);
+						net__print_ssl_error(mosq, "while trying to load the private key");
+						return MOSQ_ERR_TLS;
+					}
+					while(!pkey && !OSSL_STORE_eof(ctx)){
+						int read_failed = 0;
+						OSSL_STORE_INFO *info = OSSL_STORE_load(ctx);
+						// That may be a successful fail, let's ignore it
+						if(info == NULL)
+							continue;
+						switch (OSSL_STORE_INFO_get_type(info)) {
+							case OSSL_STORE_INFO_PKEY:
+								pkey = OSSL_STORE_INFO_get1_PKEY(info);
+								if(pkey == NULL){
+									read_failed = 1;
+								}
+								break;
+							default:
+								break;
+						}
+						OSSL_STORE_INFO_free(info);
+						if(read_failed){
+							log__printf(mosq, MOSQ_LOG_ERR, "Error: read failed on openssl store for URI \"%s\".", mosq->tls_keyfile);
+							net__print_ssl_error(mosq, "while trying to load the private key");
+							break;
+						}
+					}
+					OSSL_STORE_close(ctx);
+					if(!pkey){
+						log__printf(mosq, MOSQ_LOG_ERR, "Error: could not find a private key matching URI \"%s\".", mosq->tls_keyfile);
+						return MOSQ_ERR_TLS;
+					}
+					if(SSL_CTX_use_PrivateKey(mosq->ssl_ctx, pkey) <= 0){
+						log__printf(mosq, MOSQ_LOG_ERR, "Error: Unable to use private key from URI \"%s\".", mosq->tls_keyfile);
+						net__print_ssl_error(mosq, "while trying to use the private key");
+						EVP_PKEY_free(pkey);
+						return MOSQ_ERR_TLS;
+					}
+					EVP_PKEY_free(pkey);
+#else
 					ret = SSL_CTX_use_PrivateKey_file(mosq->ssl_ctx, mosq->tls_keyfile, SSL_FILETYPE_PEM);
 					if(ret != 1){
 #ifdef WITH_BROKER
@@ -874,6 +923,7 @@ static int net__init_ssl_ctx(struct mosquitto *mosq)
 						net__print_ssl_error(mosq, "while trying to use the private key file");
 						return MOSQ_ERR_TLS;
 					}
+#endif
 				}
 				ret = SSL_CTX_check_private_key(mosq->ssl_ctx);
 				if(ret != 1){

--- a/lib/options.c
+++ b/lib/options.c
@@ -166,6 +166,7 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 
 	mosquitto_FREE(mosq->tls_certfile);
 	if(certfile){
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 		fptr = mosquitto_fopen(certfile, "rt", false);
 		if(fptr){
 			fclose(fptr);
@@ -174,6 +175,7 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 			mosquitto_FREE(mosq->tls_capath);
 			return MOSQ_ERR_INVAL;
 		}
+#endif
 		mosq->tls_certfile = mosquitto_strdup(certfile);
 		if(!mosq->tls_certfile){
 			return MOSQ_ERR_NOMEM;
@@ -182,6 +184,7 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 
 	mosquitto_FREE(mosq->tls_keyfile);
 	if(keyfile){
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 		if(mosq->tls_keyform == mosq_k_pem){
 			fptr = mosquitto_fopen(keyfile, "rt", false);
 			if(fptr){
@@ -198,6 +201,7 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 				return MOSQ_ERR_INVAL;
 			}
 		}
+#endif
 		mosq->tls_keyfile = mosquitto_strdup(keyfile);
 		if(!mosq->tls_keyfile){
 			return MOSQ_ERR_NOMEM;


### PR DESCRIPTION
OpenSSL3 introduced the providers mechanic, and obsoleted the engine mechanics. The OpenSSL applications now leverage the store provider mechanics to remove the key type selection: the key type is inferred from the key URI.

This change adds support for the OpenSSL store mechanics when available to load private keys, and makes it the default behavior according to OpenSSL guidelines.

Close https://github.com/eclipse-mosquitto/mosquitto/issues/3115

-----
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
