### PR TITLE
Fix MOSQ_EVT_DISCONNECT being called before MOSQ_EVT_ACL_CHECK

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,11 @@
+2.1.3 - 2026-02-xx
+==================
+
+Broker:
+- Fix MOSQ_EVT_DISCONNECT being called before MOSQ_EVT_ACL_CHECK for the will
+  of that client. Closes #3487.
+
+
 2.1.2 - 2026-02-09
 ==================
 

--- a/src/context.c
+++ b/src/context.c
@@ -269,13 +269,14 @@ void context__disconnect(struct mosquitto *context, int reason)
 		}
 	}
 
+	context__send_will(context);
+
 	if(context->session_expiry_interval == MQTT_SESSION_EXPIRY_IMMEDIATE){
 		plugin__handle_disconnect(context, reason);
 	}else{
 		plugin__handle_client_offline(context, reason);
 	}
 
-	context__send_will(context);
 	net__socket_close(context);
 #ifdef WITH_BRIDGE
 	if(context->bridge == NULL)


### PR DESCRIPTION
This occurs for the will of that client.

Closes #3487. Thanks to ChrisBFX.

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
