### PR TITLE
Fix mosquitto_passwd hash types and some doc. details

### DIFF
--- a/apps/mosquitto_passwd/mosquitto_passwd.c
+++ b/apps/mosquitto_passwd/mosquitto_passwd.c
@@ -118,11 +118,11 @@ static void print_usage(void)
 {
 	printf("mosquitto_passwd is a tool for managing password files for mosquitto.\n\n");
 #ifndef WITH_ARGON2
-	printf("Usage: mosquitto_passwd [-H sha512 | -H sha512-pbkdf2] [-c | -D] passwordfile username\n");
-	printf("       mosquitto_passwd [-H sha512 | -H sha512-pbkdf2] [-c] -b passwordfile username password\n");
+	printf("Usage: mosquitto_passwd [-H sha512 | -H sha512-pbkdf2] [-I iterations] [-c | -D] passwordfile username\n");
+	printf("       mosquitto_passwd [-H sha512 | -H sha512-pbkdf2] [-I iterations] [-c] -b passwordfile username password\n");
 #else
-	printf("Usage: mosquitto_passwd [-H argon2id | -H sha512-pbkdf2] [-c | -D] passwordfile username\n");
-	printf("       mosquitto_passwd [-H argon2id | -H sha512-pbkdf2] [-c] -b passwordfile username password\n");
+	printf("Usage: mosquitto_passwd [-H argon2id | -H sha512-pbkdf2] [-I iterations] [-c | -D] passwordfile username\n");
+	printf("       mosquitto_passwd [-H argon2id | -H sha512-pbkdf2] [-I iterations] [-c] -b passwordfile username password\n");
 #endif
 	printf("       mosquitto_passwd -U passwordfile\n");
 	printf(" -b : run in batch mode to allow passing passwords on the command line.\n");
@@ -135,6 +135,7 @@ static void print_usage(void)
 	printf("      Mosquitto 2.x and earlier defaulted to sha512-pbkdf2.\n"); // FIXME - substitute last version with pbkdf2 default
 #endif
 	printf("      Mosquitto 1.6 and earlier defaulted to sha512.\n");
+	printf(" -I : specify the number of iterations for sha512-pbkdf2 algorithm. Defaults to 1000.\n");
 	printf(" -U : update a plain text password file to use hashed passwords.\n");
 	printf("\nSee https://mosquitto.org/ for more information.\n\n");
 }

--- a/man/mosquitto_passwd.1.xml
+++ b/man/mosquitto_passwd.1.xml
@@ -21,6 +21,9 @@
 				<arg choice='plain'><option>-H</option> <replaceable>hash</replaceable></arg>
 			</group>
 			<group>
+				<arg choice='plain'><option>-I</option> <replaceable>iterations</replaceable></arg>
+			</group>
+			<group>
 				<arg choice='plain'><option>-c</option></arg>
 				<arg choice='plain'><option>-D</option></arg>
 			</group>
@@ -31,6 +34,9 @@
 			<command>mosquitto_passwd</command>
 			<group>
 				<arg choice='plain'><option>-H</option> <replaceable>hash</replaceable></arg>
+			</group>
+			<group>
+				<arg choice='plain'><option>-I</option> <replaceable>iterations</replaceable></arg>
 			</group>
 			<arg choice='plain'><option>-b</option></arg>
 			<arg choice='plain'><replaceable>passwordfile</replaceable></arg>
@@ -106,6 +112,16 @@
 						<replaceable>sha512</replaceable> option is provided for
 						creating password files for use with Mosquitto 1.6
 						and earlier.
+					</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term><option>-I</option></term>
+				<listitem>
+					<para>
+						Specify the number of iterations to use for
+						generating <replaceable>sha512-pbkdf2</replaceable>
+						hashes. Defaults to 1000.
 					</para>
 				</listitem>
 			</varlistentry>


### PR DESCRIPTION
* use WITH_ARGON2 define to only set argon2id as default and accept
  argon2id type if enabled (currently only possible on build cmd line)
* additionally use WITH_ARGON2 to produce corresponding inline help
* in doc. remove argon2id and indicate correct sha512-pbkdf2 default

* in doc. and inline help correct -c overwrite wording about effect of file
  existence and elaborate about expectations if not given

* in doc. and inline help document -I option for sha512-pbkdf2 iterations

(observations triggered by discussion in #2915)
(based on develop as instructed fixes branch does not carry changes since
~2.0, however develop is also missing changes since 2.1.0, ie. two tagged
releases, let me know if there is a better approach)

-----

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?