### PR TITLE
Fix makefile build with WITH_SQLITE disabled

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -3,8 +3,11 @@ DIRS= \
 		dynamic-security \
 		examples \
 		password-file \
-		persist-sqlite \
 		sparkplug-aware
+
+ifeq ($(WITH_SQLITE),yes)
+DIRS+=persist-sqlite
+endif
 
 .PHONY : all binary check clean reallyclean test test-compile install uninstall
 

--- a/plugins/persist-sqlite/Makefile
+++ b/plugins/persist-sqlite/Makefile
@@ -23,11 +23,7 @@ OBJS = \
 OBJS_EXTERNAL = \
 	json_help.o
 
-ifeq ($(WITH_SQLITE),yes)
 ALL_DEPS:= binary
-else
-ALL_DEPS:=
-endif
 
 all : ${ALL_DEPS}
 


### PR DESCRIPTION
When using WITH_SQLITE=no, the build system correctly avoids to compile the plugin, but the install step fails because it tries to install it even if it has not been compiled.

This commit fixes this behaviour by totally omitting the plugin if WITH_SQLITE=no is specified, so no compilation and no installation is performed.

I followed the same build approach that is used with the option `WITH_PERSISTENCE` in `apps/Makefile`

I contributed the fix to `master` branch directly instead of `fixes` because the bug is not present there.

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
