### PR TITLE
buildtest.py: Use ccache

### DIFF
--- a/.github/workflows/build-variants.yml
+++ b/.github/workflows/build-variants.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
+          ccache \
           docbook-xsl \
           libargon2-dev \
           libc-ares-dev \

--- a/buildtest.py
+++ b/buildtest.py
@@ -36,11 +36,15 @@ import os
 import random
 import subprocess
 
+env = os.environ.copy()
+env['CC'] = "ccache gcc"
+env['CXX'] = "ccache g++"
+
 def run_test(msg, opts):
     subprocess.run(["make", "clean"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     print("%s: %s" % (msg, str(opts)))
     args = ["make", "test-compile", "-j%d" % (os.cpu_count())] + opts
-    proc = subprocess.run(args, stdout=subprocess.DEVNULL)
+    proc = subprocess.run(args, stdout=subprocess.DEVNULL, env=env)
     if proc.returncode != 0:
         raise RuntimeError("BUILD FAILED: %s" % (' '.join(args)))
 


### PR DESCRIPTION
Reduces the time to run `./buildtest.py` on my 8-core laptop from 25 minutes to 7 minutes.

```
 # Before, without ccache
$ time ./buildtest.py
[...]
./buildtest.py  5844.08s user 755.75s system 434% cpu 25:17.99 total

 # After, with ccache, empty cache.
$ time ./buildtest.py
[...]
./buildtest.py  1620.97s user 472.66s system 482% cpu 7:13.54 total
```

The `ccache -s` status after building once from an empty cache shows just how much duplicated work is performed: 83.00% cache hits!

```
$ ccache -s
Cacheable calls:    12538 / 22769 (55.07%)
  Hits:             10407 / 12538 (83.00%)
    Direct:          9093 / 10407 (87.37%)
    Preprocessed:    1314 / 10407 (12.63%)
  Misses:            2131 / 12538 (17.00%)
Uncacheable calls:  10231 / 22769 (44.93%)
Local storage:
  Cache size (GiB):   0.1 /   5.0 ( 1.97%)
  Hits:             10407 / 12538 (83.00%)
  Misses:            2131 / 12538 (17.00%)
```

---

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] ~If you are contributing a new feature, is your work based off the develop branch?~
- [ ] ~If you are contributing a bugfix, is your work based off the fixes branch?~
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
