### PR TITLE
Fix OpenSSL config loading race condition for TLS engines

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -14,6 +14,9 @@ Broker:
   mosquitto 1.5 or earlier is loaded. Closes #3439.
 - Limit auto_id_prefix to 50 characters. Closes #3440.
 
+Windows:
+- Installer will not overwrite an existing mosquitto.conf
+
 
 2.0.22 - 2025-07-11
 ===================

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -15,6 +15,8 @@ Broker:
 - Limit auto_id_prefix to 50 characters. Closes #3440.
 - Fix max_connections not being honoured on websockets listeners. Closes #3455.
 - Fix outgoing maximum-packet-size limit check. Closes #3503.
+- Fix creation of log and runtime directories in systemd unit files.
+ Closes #3344.
 
 Windows:
 - Installer will not overwrite an existing mosquitto.conf

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,4 @@
-2.0.23 - 2026-01-14
+2.0.23 - 2026-xx-xx
 ===================
 
 Broker:
@@ -13,6 +13,7 @@ Broker:
 - Fix potential crash on startup if a malicious/corrupt persistence file from
   mosquitto 1.5 or earlier is loaded. Closes #3439.
 - Limit auto_id_prefix to 50 characters. Closes #3440.
+- Fix max_connections not being honoured on websockets listeners. Closes #3455.
 
 Windows:
 - Installer will not overwrite an existing mosquitto.conf

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -17,6 +17,8 @@ Broker:
 - Fix outgoing maximum-packet-size limit check. Closes #3503.
 - Fix creation of log and runtime directories in systemd unit files.
  Closes #3344.
+- Fix will messages being incorrectly delayed if a client set
+  session-expiry-interval=0 when using will-delay-interval>0. Closes #3505.
 
 Windows:
 - Installer will not overwrite an existing mosquitto.conf

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -14,6 +14,7 @@ Broker:
   mosquitto 1.5 or earlier is loaded. Closes #3439.
 - Limit auto_id_prefix to 50 characters. Closes #3440.
 - Fix max_connections not being honoured on websockets listeners. Closes #3455.
+- Fix outgoing maximum-packet-size limit check. Closes #3503.
 
 Windows:
 - Installer will not overwrite an existing mosquitto.conf

--- a/installer/mosquitto.nsi
+++ b/installer/mosquitto.nsi
@@ -57,7 +57,6 @@ Section "Files" SecInstall
 	File "..\build\plugins\dynamic-security\Release\mosquitto_dynamic_security.dll"
 	File "..\aclfile.example"
 	File "..\ChangeLog.txt"
-	File "..\mosquitto.conf"
 	File "..\NOTICE.md"
 	File "..\pwfile.example"
 	File "..\README.md"
@@ -66,6 +65,10 @@ Section "Files" SecInstall
 	File "..\SECURITY.md"
 	File "..\edl-v10"
 	File "..\epl-v20"
+
+	SetOverwrite off
+	File "..\mosquitto.conf"
+	SetOverwrite on
 
 	File "..\build\vcpkg_installed\x86-windows\bin\cjson.dll"
 	File "..\build\vcpkg_installed\x86-windows\bin\libcrypto-3.dll"

--- a/installer/mosquitto64.nsi
+++ b/installer/mosquitto64.nsi
@@ -58,7 +58,6 @@ Section "Files" SecInstall
 	File "..\build64\plugins\dynamic-security\Release\mosquitto_dynamic_security.dll"
 	File "..\aclfile.example"
 	File "..\ChangeLog.txt"
-	File "..\mosquitto.conf"
 	File "..\NOTICE.md"
 	File "..\pwfile.example"
 	File "..\README.md"
@@ -67,6 +66,10 @@ Section "Files" SecInstall
 	File "..\SECURITY.md"
 	File "..\edl-v10"
 	File "..\epl-v20"
+
+	SetOverwrite off
+	File "..\mosquitto.conf"
+	SetOverwrite on
 
 	File "..\build64\vcpkg_installed\x64-windows-release\bin\cjson.dll"
 	File "..\build64\vcpkg_installed\x64-windows-release\bin\libcrypto-3-x64.dll"

--- a/lib/options.c
+++ b/lib/options.c
@@ -295,7 +295,7 @@ int mosquitto_string_option(struct mosquitto *mosq, enum mosq_opt_t option, cons
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 				/* The "Dynamic" OpenSSL engine is not initialized by default but
 				   is required by ENGINE_by_id() to find dynamically loadable engines */
-				OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_DYNAMIC, NULL);
+				OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_ENGINE_DYNAMIC, NULL);
 #endif
 				eng = ENGINE_by_id(value);
 				if(!eng){

--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -215,7 +215,7 @@ int packet__check_oversize(struct mosquitto *mosq, uint32_t remaining_length)
 
 	if(mosq->maximum_packet_size == 0) return MOSQ_ERR_SUCCESS;
 
-	len = remaining_length + packet__varint_bytes(remaining_length);
+	len = 1 + remaining_length + packet__varint_bytes(remaining_length);
 	if(len > mosq->maximum_packet_size){
 		return MOSQ_ERR_OVERSIZE_PACKET;
 	}else{

--- a/service/systemd/mosquitto.service.notify
+++ b/service/systemd/mosquitto.service.notify
@@ -5,15 +5,15 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+User=mosquitto
 Type=notify
+WatchdogSec=3min
 NotifyAccess=main
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
-ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /var/log/mosquitto
-ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /run/mosquitto
+RuntimeDirectory=mosquitto
+LogsDirectory=mosquitto
 
 [Install]
 WantedBy=multi-user.target

--- a/service/systemd/mosquitto.service.simple
+++ b/service/systemd/mosquitto.service.simple
@@ -5,13 +5,12 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+User=mosquitto
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
-ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /var/log/mosquitto
-ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto
-ExecStartPre=/bin/chown mosquitto:mosquitto /run/mosquitto
+RuntimeDirectory=mosquitto
+LogsDirectory=mosquitto
 
 [Install]
 WantedBy=multi-user.target

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -222,7 +222,7 @@ endif (WIN32)
 
 if (WITH_WEBSOCKETS)
 	if (STATIC_WEBSOCKETS)
-		set (MOSQ_LIBS ${MOSQ_LIBS} websockets_static)
+		set (MOSQ_LIBS ${MOSQ_LIBS} websockets)
 		if (WIN32)
 			set (MOSQ_LIBS ${MOSQ_LIBS} iphlpapi)
 			link_directories(${mosquitto_SOURCE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,7 +193,7 @@ if(WITH_ADNS)
 		endif()
 	endif()
 	cmake_pop_check_state()
-endif (HAVE_GETADDRINFO_A AND WITH_ADNS)
+endif()
 
 
 if (UNIX)

--- a/src/context.c
+++ b/src/context.c
@@ -185,7 +185,7 @@ void context__cleanup(struct mosquitto *context, bool force_free)
 void context__send_will(struct mosquitto *ctxt)
 {
 	if(ctxt->state != mosq_cs_disconnecting && ctxt->will){
-		if(ctxt->will_delay_interval > 0){
+		if(ctxt->session_expiry_interval > 0 && ctxt->will_delay_interval > 0){
 			will_delay__add(ctxt);
 			return;
 		}
@@ -218,10 +218,10 @@ void context__disconnect(struct mosquitto *context)
 	if(mosquitto__get_state(context) == mosq_cs_disconnected){
 		return;
 	}
+	context__send_will(context);
 
 	plugin__handle_disconnect(context, -1);
 
-	context__send_will(context);
 	net__socket_close(context);
 #ifdef WITH_BRIDGE
 	if(context->bridge == NULL)

--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -195,6 +195,7 @@ int connect__on_authorised(struct mosquitto *context, void *auth_data_out, uint1
 				|| (context->clean_start == true)
 				){
 
+			found_context->session_expiry_interval = 0;
 			context__send_will(found_context);
 		}
 

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -170,10 +170,12 @@ static int callback_mqtt(
 				u->mosq = NULL;
 				return -1;
 			}
+			mosq->listener->client_count++;
 			if(mosq->listener->max_connections > 0 && mosq->listener->client_count > mosq->listener->max_connections){
 				if(db.config->connection_messages == true){
 					log__printf(NULL, MOSQ_LOG_NOTICE, "Client connection from %s denied: max_connections exceeded.", mosq->address);
 				}
+				mosq->listener->client_count--;
 				mosquitto__free(mosq->address);
 				mosquitto__free(mosq);
 				u->mosq = NULL;
@@ -194,6 +196,7 @@ static int callback_mqtt(
 					HASH_DELETE(hh_sock, db.contexts_by_sock, mosq);
 					mosq->sock = INVALID_SOCKET;
 					mux__delete(mosq);
+					mosq->listener->client_count--;
 				}
 				mosq->wsi = NULL;
 #ifdef WITH_TLS

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -196,7 +196,6 @@ static int callback_mqtt(
 					HASH_DELETE(hh_sock, db.contexts_by_sock, mosq);
 					mosq->sock = INVALID_SOCKET;
 					mux__delete(mosq);
-					mosq->listener->client_count--;
 				}
 				mosq->wsi = NULL;
 #ifdef WITH_TLS

--- a/test/broker/07-will-delay-reconnect.py
+++ b/test/broker/07-will-delay-reconnect.py
@@ -15,12 +15,13 @@ def do_test():
     connect1_packet = mosq_test.gen_connect("will-qos0-test", keepalive=keepalive, proto_ver=5)
     connack1_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
 
-    props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_WILL_DELAY_INTERVAL, 3)
-    connect2a_packet = mosq_test.gen_connect("will-helper", keepalive=keepalive, proto_ver=5, will_topic="will/test", will_payload=b"will delay", will_properties=props, clean_session=False)
+    props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_SESSION_EXPIRY_INTERVAL, 60)
+    will_props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_WILL_DELAY_INTERVAL, 3)
+    connect2a_packet = mosq_test.gen_connect("will-delay-reconnect-helper", proto_ver=5, will_topic="will/test", will_payload=b"will delay", will_properties=will_props, clean_session=False, properties=props)
     connack2a_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
 
-    connect2b_packet = mosq_test.gen_connect("will-helper", keepalive=keepalive, proto_ver=5, clean_session=True)
-    connack2b_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
+    connect2b_packet = mosq_test.gen_connect("will-delay-reconnect-helper", proto_ver=5, clean_session=False)
+    connack2b_packet = mosq_test.gen_connack(rc=0, flags=1, proto_ver=5)
 
     subscribe_packet = mosq_test.gen_subscribe(mid, "will/test", 0, proto_ver=5)
     suback_packet = mosq_test.gen_suback(mid, 0, proto_ver=5)

--- a/test/broker/07-will-delay-recover.py
+++ b/test/broker/07-will-delay-recover.py
@@ -26,6 +26,8 @@ def do_test(clean_session):
     subscribe_packet = mosq_test.gen_subscribe(mid, "will/test", 0, proto_ver=5)
     suback_packet = mosq_test.gen_suback(mid, 0, proto_ver=5)
 
+    will_packet = mosq_test.gen_publish(topic="will/test", payload="will delay", qos=0, proto_ver=5)
+
     port = mosq_test.get_port()
     broker = mosq_test.start_broker(filename=os.path.basename(__file__), port=port)
 
@@ -41,8 +43,13 @@ def do_test(clean_session):
         time.sleep(3)
 
         # The client2 has reconnected within the will delay interval, which has now
-        # passed. We should not have received the will at this point.
-        mosq_test.do_ping(sock1)
+        # passed.
+        if clean_session:
+            # The old session has ended, so we should receive the will
+            mosq_test.expect_packet(sock1, "will", will_packet)
+        else:
+            # We should not have received the will at this point.
+            mosq_test.do_ping(sock1)
         rc = 0
 
         sock1.close()

--- a/test/broker/07-will-delay-session-expiry-0.py
+++ b/test/broker/07-will-delay-session-expiry-0.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Test whether a client that connects with a will delay that is longer than
+# their session expiry interval has their will published.
+# MQTT 5
+# https://github.com/eclipse/mosquitto/issues/1401
+
+from mosq_test_helper import *
+
+def do_test(start_broker):
+    rc = 1
+
+    mid = 1
+    connect1_packet = mosq_test.gen_connect("will-session-exp", proto_ver=5)
+    connack1_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
+
+    will_props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_WILL_DELAY_INTERVAL, 60)
+    connect_props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_SESSION_EXPIRY_INTERVAL, 0)
+
+    connect2_packet = mosq_test.gen_connect("will-session-exp-helper", proto_ver=5, properties=connect_props, will_topic="will/session-expiry/test", will_payload=b"will delay", will_qos=2, will_properties=will_props)
+    connack2_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
+
+    subscribe_packet = mosq_test.gen_subscribe(mid, "will/session-expiry/test", 0, proto_ver=5)
+    suback_packet = mosq_test.gen_suback(mid, 0, proto_ver=5)
+
+    publish_packet = mosq_test.gen_publish("will/session-expiry/test", qos=0, payload="will delay", proto_ver=5)
+
+    port = mosq_test.get_port()
+    if start_broker:
+        broker = mosq_test.start_broker(filename=os.path.basename(__file__), port=port)
+
+    try:
+        sock1 = mosq_test.do_client_connect(connect1_packet, connack1_packet, timeout=5, port=port, connack_error="connack1")
+        mosq_test.do_send_receive(sock1, subscribe_packet, suback_packet, "suback")
+
+        sock2 = mosq_test.do_client_connect(connect2_packet, connack2_packet, timeout=5, port=port, connack_error="connack2")
+        time.sleep(1)
+        sock2.close()
+
+        # Will should be sent immediately due to session-expiry-interval=0. If not, the read will timeout
+        mosq_test.expect_packet(sock1, "publish", publish_packet)
+        rc = 0
+
+        sock1.close()
+    except mosq_test.TestError:
+        pass
+    finally:
+        if start_broker:
+            broker.terminate()
+            broker.wait()
+            (stdo, stde) = broker.communicate()
+            if rc:
+                print(stde.decode('utf-8'))
+                exit(rc)
+        else:
+            return rc
+
+
+def all_tests(start_broker=False):
+    return do_test(start_broker)
+
+if __name__ == '__main__':
+    all_tests(True)

--- a/test/broker/07-will-delay.py
+++ b/test/broker/07-will-delay.py
@@ -13,8 +13,9 @@ def do_test(clean_session):
     connect1_packet = mosq_test.gen_connect("will-qos0-test", keepalive=keepalive, proto_ver=5)
     connack1_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
 
-    props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_WILL_DELAY_INTERVAL, 3)
-    connect2_packet = mosq_test.gen_connect("will-helper", keepalive=keepalive, proto_ver=5, will_topic="will/test", will_payload=b"will delay", will_qos=2, will_properties=props, clean_session=clean_session)
+    props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_SESSION_EXPIRY_INTERVAL, 60)
+    will_props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_WILL_DELAY_INTERVAL, 3)
+    connect2_packet = mosq_test.gen_connect("will-helper", proto_ver=5, properties=props, will_topic="will/test", will_payload=b"will delay", will_qos=2, will_properties=will_props, clean_session=clean_session)
     connack2_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
 
     subscribe_packet = mosq_test.gen_subscribe(mid, "will/test", 0, proto_ver=5)

--- a/test/broker/12-prop-maximum-packet-size-publish-qos1.py
+++ b/test/broker/12-prop-maximum-packet-size-publish-qos1.py
@@ -17,11 +17,11 @@ subscribe_packet = mosq_test.gen_subscribe(mid, "test/topic", 1, proto_ver=5)
 suback_packet = mosq_test.gen_suback(mid, 1, proto_ver=5)
 
 mid=1
-publish1_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=1, payload="12345678901234567890", proto_ver=5)
+publish1_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=1, payload="1234", proto_ver=5)
 puback1_packet = mosq_test.gen_puback(mid, proto_ver=5)
 
 mid=2
-publish2_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=1, payload="7890", proto_ver=5)
+publish2_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=1, payload="789", proto_ver=5)
 puback2_packet = mosq_test.gen_puback(mid, proto_ver=5)
 
 port = mosq_test.get_port()

--- a/test/broker/12-prop-maximum-packet-size-publish-qos2.py
+++ b/test/broker/12-prop-maximum-packet-size-publish-qos2.py
@@ -17,13 +17,13 @@ subscribe_packet = mosq_test.gen_subscribe(mid, "test/topic", 2, proto_ver=5)
 suback_packet = mosq_test.gen_suback(mid, 2, proto_ver=5)
 
 mid=1
-publish1_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=2, payload="12345678901234567890", proto_ver=5)
+publish1_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=2, payload="1234", proto_ver=5)
 pubrec1_packet = mosq_test.gen_pubrec(mid, proto_ver=5)
 pubrel1_packet = mosq_test.gen_pubrel(mid, proto_ver=5)
 pubcomp1_packet = mosq_test.gen_pubcomp(mid, proto_ver=5)
 
 mid=2
-publish2_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=2, payload="7890", proto_ver=5)
+publish2_packet = mosq_test.gen_publish(topic="test/topic", mid=mid, qos=2, payload="789", proto_ver=5)
 pubrec2_packet = mosq_test.gen_pubrec(mid, proto_ver=5)
 pubrel2_packet = mosq_test.gen_pubrel(mid, proto_ver=5)
 pubcomp2_packet = mosq_test.gen_pubcomp(mid, proto_ver=5)

--- a/test/broker/Makefile
+++ b/test/broker/Makefile
@@ -132,6 +132,7 @@ msg_sequence_test:
 	./07-will-delay-invalid-573191.py
 	./07-will-delay-reconnect.py
 	./07-will-delay-recover.py
+	./07-will-delay-session-expiry-0.py
 	./07-will-delay-session-expiry.py
 	./07-will-delay-session-expiry2.py
 	./07-will-delay.py

--- a/test/broker/test.py
+++ b/test/broker/test.py
@@ -108,6 +108,7 @@ tests = [
     (1, './07-will-delay-invalid-573191.py'),
     (1, './07-will-delay-reconnect.py'),
     (1, './07-will-delay-recover.py'),
+    (1, './07-will-delay-session-expiry-0.py'),
     (1, './07-will-delay-session-expiry.py'),
     (1, './07-will-delay-session-expiry2.py'),
     (1, './07-will-delay.py'),

--- a/test/lib/11-prop-oversize-packet.py
+++ b/test/lib/11-prop-oversize-packet.py
@@ -14,8 +14,8 @@ connect_packet = mosq_test.gen_connect("publish-qos0-test", keepalive=keepalive,
 props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MAXIMUM_PACKET_SIZE, 30)
 connack_packet = mosq_test.gen_connack(rc=0, proto_ver=5, properties=props)
 
-bad_publish_packet = mosq_test.gen_publish("pub/test", qos=0, payload="0123456789012345678", proto_ver=5)
-publish_packet = mosq_test.gen_publish("pub/test", qos=0, payload="012345678901234567", proto_ver=5)
+bad_publish_packet = mosq_test.gen_publish("pub/test", qos=0, payload="123456789012345678", proto_ver=5)
+publish_packet = mosq_test.gen_publish("pub/test", qos=0, payload="12345678901234567", proto_ver=5)
 
 disconnect_packet = mosq_test.gen_disconnect()
 

--- a/test/lib/c/11-prop-oversize-packet.c
+++ b/test/lib/c/11-prop-oversize-packet.c
@@ -24,12 +24,12 @@ void on_connect(struct mosquitto *mosq, void *obj, int rc)
 			exit(1);
 		}
 
-		rc = mosquitto_publish(mosq, &sent_mid, "pub/test", strlen("0123456789012345678"), "0123456789012345678", 0, false);
+		rc = mosquitto_publish(mosq, &sent_mid, "pub/test", strlen("123456789012345678"), "123456789012345678", 0, false);
 		if(rc != MOSQ_ERR_OVERSIZE_PACKET){
 			printf("Fail on publish 1\n");
 			exit(1);
 		}
-		rc = mosquitto_publish(mosq, &sent_mid, "pub/test", strlen("012345678901234567"), "012345678901234567", 0, false);
+		rc = mosquitto_publish(mosq, &sent_mid, "pub/test", strlen("12345678901234567"), "12345678901234567", 0, false);
 		if(rc != MOSQ_ERR_SUCCESS){
 			printf("Fail on publish 2\n");
 			exit(1);


### PR DESCRIPTION
When setting MOSQ_OPT_TLS_ENGINE, mosquitto_string_option() initializes the OpenSSL singleton via OPENSSL_init_crypto but omits the OPENSSL_INIT_LOAD_CONFIG flag.

If an engine is set before mosquitto_connect_async() (which calls net__init_tls()), OpenSSL locks its initialization state without reading openssl.cnf. This causes engines like pkcs11 to fail to resolve their MODULE_PATH, resulting in dlopen failures for hardware TrustZone/HSM modules.

Example error log (Found under release/v2.0)
```
Unable to load module (null)
PKCS11_get_private_key returned NULL
[libmosq] level=8 Error: Unable to load engine private key file "<pkcs#11-uri>".
[libmosq] level=8 OpenSSL Error[0]: error:41000401:libp11::Unable to load PKCS#11 module
[libmosq] level=8 OpenSSL Error[1]: error:40000067:pkcs11 engine::invalid parameter
[libmosq] level=8 OpenSSL Error[2]: error:13000080:engine routines::failed loading private key
```

Adding OPENSSL_INIT_LOAD_CONFIG to the engine initialization ensures the configuration is parsed and the engine can locate its dynamic backend.