### PR TITLE
ci: add riscv64 native build workflow

### DIFF
--- a/.github/workflows/alt-arch-riscv64.yml
+++ b/.github/workflows/alt-arch-riscv64.yml
@@ -1,0 +1,45 @@
+name: Alt Arch Riscv64
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Mosquitto (riscv64)
+    runs-on: ubuntu-24.04-riscv
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libssl-dev libcjson-dev \
+            libsqlite3-dev libargon2-dev libreadline-dev docbook-xsl xsltproc \
+            pkg-config
+
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_TESTS=OFF
+
+      - name: Build
+        run: |
+          cd build
+          time make -j$(nproc)
+
+      - name: Verify
+        run: |
+          ./build/src/mosquitto --version
+          ./build/client/mosquitto_pub --help 2>&1 | head -3
+          ./build/client/mosquitto_sub --help 2>&1 | head -3
+          file ./build/src/mosquitto


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] Have you successfully run `make test` with your changes locally?

-----

## What does this PR do?

Adds a non-blocking CI job that builds Mosquitto on native riscv64 hardware using RISE Project GitHub Actions runners (`ubuntu-24.04-riscv`). The job uses `continue-on-error: true` so it does not block existing CI.

## Evidence

Validated on RISE native riscv64 runner:
- Build time: 1m38s
- CI run: https://github.com/gounthar/mosquitto/actions/runs/23343365285/job/67902292909
- All binaries build and run: mosquitto (2.1.2), mosquitto_pub, mosquitto_sub

Also validated on BananaPi F3 (SpacemiT K1, rv64gc, 8 cores @ 1.6 GHz):
- Build time: 1m30s wall, 9m CPU

No source changes needed. The workflow installs build dependencies and runs the standard cmake build.

## Related

- Closes #3545
- Related to #3224 (riscv64 snap)