### PR TITLE
Fix missing error code in persist read error paths

### DIFF
--- a/src/persist_read_v5.c
+++ b/src/persist_read_v5.c
@@ -120,6 +120,7 @@ int persist__chunk_client_msg_read_v56(FILE *db_fptr, struct P_client_msg *chunk
 
 	length -= (uint32_t)(sizeof(struct PF_client_msg) + chunk->F.id_len);
 	if(length > MQTT_MAX_PAYLOAD){
+		rc = MOSQ_ERR_INVAL;
 		goto error;
 	}
 
@@ -133,6 +134,7 @@ int persist__chunk_client_msg_read_v56(FILE *db_fptr, struct P_client_msg *chunk
 		prop_packet.payload = mosquitto_malloc(length);
 		if(!prop_packet.payload){
 			errno = ENOMEM;
+			rc = MOSQ_ERR_NOMEM;
 			goto error;
 		}
 
@@ -186,6 +188,7 @@ int persist__chunk_base_msg_read_v56(FILE *db_fptr, struct P_base_msg *chunk, ui
 
 	length -= (uint32_t)(sizeof(struct PF_base_msg) + chunk->F.payloadlen + chunk->F.source_id_len + chunk->F.source_username_len + chunk->F.topic_len);
 	if(length > MQTT_MAX_PAYLOAD){
+		rc = MOSQ_ERR_INVAL;
 		goto error;
 	}
 


### PR DESCRIPTION
In persist__chunk_client_msg_read_v56() and persist__chunk_base_msg_read_v56(), three error paths jump to the error cleanup label without setting rc, causing the functions to return success (0) on malformed input.

A crafted persistence file with a length underflow silently loads a corrupt message with NULL topic and payload pointers, leading to a NULL pointer dereference (SEGV) on the next persistence save.

Confirmed with AddressSanitizer: SEGV in strncmp called from persist__client_messages_save during broker shutdown.

Set rc to the appropriate error code before each goto.

- [x] Have you signed the Eclipse Contributor Agreement, using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address?
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?