### PR TITLE
Fix basic auth denial for proxy-protocol cert clients

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -1248,7 +1248,8 @@ int handle__connect(struct mosquitto *context)
 		}
 	}else{
 #ifdef WITH_TLS
-		if(context->listener->ssl_ctx && (context->listener->use_identity_as_username || context->listener->use_subject_as_username)){
+		if((context->listener->ssl_ctx || context->listener->enable_proxy_protocol > 0)
+				&& (context->listener->use_identity_as_username || context->listener->use_subject_as_username)){
 			/* Authentication assumed to be cleared */
 		}else
 #endif


### PR DESCRIPTION
## Problem

When a listener uses PROXY protocol v2 with `use_identity_as_username true`,
clients authenticated via mTLS at the proxy are incorrectly denied by
`mosquitto_basic_auth()`.

With direct TLS, `handle_connect.c` skips `mosquitto_basic_auth()` when
`ssl_ctx` is set and `use_identity_as_username` is enabled — authentication
is "assumed to be cleared." However, with proxy protocol, `ssl_ctx` is NULL
(TLS was terminated externally), so the bypass does not trigger. The client
falls through to `mosquitto_basic_auth()`, all plugins defer (no password),
and the `allow_anonymous` fallback rejects it because `username != NULL`.

### Code path (before fix)

```
handle_connect.c:1251
  → ssl_ctx is NULL (proxy protocol, no direct TLS)
  → condition FAILS: ssl_ctx && (use_identity_as_username || ...)
  → falls through to mosquitto_basic_auth()

plugin_basic_auth.c:101
  → all plugins defer (no password to check)
  → anonymous fallback: username == NULL? NO (it's the cert CN)
  → DENIED
```

## Fix

Extend the auth bypass condition to also recognize proxy protocol listeners:

```c
if((context->listener->ssl_ctx || context->listener->enable_proxy_protocol > 0)
        && (context->listener->use_identity_as_username || context->listener->use_subject_as_username)){
    /* Authentication assumed to be cleared */
}
```

When `enable_proxy_protocol > 0` and `use_identity_as_username` is set, the
client was authenticated externally via certificate — same as direct TLS.

## Testing

Tested with:

- Proxy protocol v2 listener + `use_identity_as_username true`
- mTLS cert clients connecting through an external TLS-terminating proxy
- Confirmed: cert clients connect successfully (CONNACK 0)
- Confirmed: passwordless clients on non-proxy listeners are still denied


It seems the fixes branch doesn't contain Mosquitto 2.1 with PROXY protocol support yet. Therefore, I'm submitting this to "master".

- [x] Have you signed the Eclipse Contributor Agreement, using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?