### PR TITLE
Fix typo in '-L' option description

### DIFF
--- a/www/pages/documentation/dynamic-security.md
+++ b/www/pages/documentation/dynamic-security.md
@@ -522,7 +522,7 @@ they would be provided on the command line. For example:
 * `--key path-to-client.key` : Define the path to a file containing a PEM
   encoded private key for this client, if required by the server. See also
   `--cert`.
-* `-L url` : Specify specify user, password, hostname, port and topic at once
+* `-L url` : Specify user, password, hostname, port and topic at once
   as a URL. The URL must be in the form:
   `mqtt(s)://[username[:password]@]host[:port]`. If the scheme is mqtt:// then
   the port defaults to 1883. If the scheme is mqtts:// then the port defaults


### PR DESCRIPTION
Corrected a typo in the description of the '-L' option.

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
