### PR TITLE
Fix bind_interface support guard

### DIFF
--- a/config.h
+++ b/config.h
@@ -16,6 +16,10 @@
 #  define HAVE_NETINET_IN_H
 #endif
 
+#if !defined(WIN32) && !defined(_AIX)
+#  define HAVE_BIND_INTERFACE
+#endif
+
 #define OPENSSL_LOAD_CONF
 
 /* ============================================================

--- a/src/conf.c
+++ b/src/conf.c
@@ -1291,7 +1291,7 @@ static int config__read_file_core(struct mosquitto__config *config, bool reload,
 						return MOSQ_ERR_INVAL;
 					}
 				}else if(!strcmp(token, "bind_interface")){
-#ifdef SO_BINDTODEVICE
+#ifdef HAVE_BIND_INTERFACE
 					if(reload){
 						continue;        /* Rebinding listeners not valid during reloading. */
 					}

--- a/src/net.c
+++ b/src/net.c
@@ -20,9 +20,6 @@ Contributors:
 
 #ifndef WIN32
 #  include <arpa/inet.h>
-#  ifndef _AIX
-#    include <ifaddrs.h>
-#  endif
 #  include <netdb.h>
 #  include <netinet/tcp.h>
 #  include <strings.h>
@@ -43,6 +40,10 @@ Contributors:
 
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
+#endif
+
+#ifdef HAVE_BIND_INTERFACE
+#  include <ifaddrs.h>
 #endif
 
 #if defined(WITH_UNIX_SOCKETS) || defined(WITH_TLS)
@@ -718,15 +719,14 @@ int net__tls_load_verify(struct mosquitto__listener *listener)
 }
 
 
-#if !defined(WIN32) && !defined(_AIX)
+#ifdef HAVE_BIND_INTERFACE
 
 
 static int net__bind_interface(struct mosquitto__listener *listener, struct addrinfo *rp)
 {
 	/*
 	 * This binds the listener sock to a network interface.
-	 * The use of SO_BINDTODEVICE requires root access, which we don't have, so instead
-	 * use getifaddrs to find the interface addresses, and use IP of the
+	 * Use getifaddrs to find the interface addresses, then use the IP of the
 	 * matching interface in the later bind().
 	 */
 	struct ifaddrs *ifaddr;
@@ -874,7 +874,7 @@ static int net__socket_listen_tcp(struct mosquitto__listener *listener)
 			return 1;
 		}
 
-#if !defined(WIN32) && !defined(_AIX)
+#ifdef HAVE_BIND_INTERFACE
 		if(listener->bind_interface){
 			/* It might be possible that an interface does not support all relevant sa_families.
 			 * We should successfully find at least one. */


### PR DESCRIPTION
The bind_interface parser guard still checked SO_BINDTODEVICE, but the runtime implementation no longer uses SO_BINDTODEVICE. It uses getifaddrs() on non-Windows/non-AIX platforms instead.

This caused bind_interface to be rejected at config parse time on platforms where the runtime implementation is available, including macOS.

Add a HAVE_BIND_INTERFACE guard and use it consistently for parsing, the ifaddrs include, the bind helper, and the call site. This fixes test/broker/16-config-huge.py on macOS.

Assisted-by: OpenAI Codex (GPT-5)

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
Tested with:
- `cmake --build build`
- `env PATH="$PWD/build/test-venv/bin:$PATH" ctest --test-dir build --output-on-failure --parallel 1`