### PR TITLE
Add mosquitto_connect_bind_v5_async()

### DIFF
--- a/include/mosquitto/libmosquitto_connect.h
+++ b/include/mosquitto/libmosquitto_connect.h
@@ -107,7 +107,7 @@ libmosq_EXPORT int mosquitto_connect_bind(struct mosquitto *mosq, const char *ho
  * over a particular interface.
  *
  * Use e.g. <mosquitto_property_add_string> and similar to create a list of
- * properties, then attach them to this publish. Properties need freeing with
+ * properties, then attach them to this connect. Properties need freeing with
  * <mosquitto_property_free_all>.
  *
  * If the mosquitto instance `mosq` is using MQTT v5, the `properties` argument
@@ -145,9 +145,69 @@ libmosq_EXPORT int mosquitto_connect_bind(struct mosquitto *mosq, const char *ho
  *	MOSQ_ERR_PROTOCOL - if any property is invalid for use with CONNECT.
  *
  * See Also:
- * 	<mosquitto_connect>, <mosquitto_connect_async>, <mosquitto_connect_bind_async>
+ * 	<mosquitto_connect>, <mosquitto_connect_async>, <mosquitto_connect_bind_async>,
+ * 	<mosquitto_connect_bind_v5_async>
  */
 libmosq_EXPORT int mosquitto_connect_bind_v5(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address, const mosquitto_property *properties);
+
+/*
+ * Function: mosquitto_connect_bind_v5_async
+ *
+ * Connect to an MQTT broker. This is a non-blocking call. If you use
+ * <mosquitto_connect_async> your client must use the threaded interface
+ * <mosquitto_loop_start>. If you need to use <mosquitto_loop>, you must use
+ * <mosquitto_connect> to connect the client.
+ *
+ * May be called before or after <mosquitto_loop_start>.
+ *
+ * This extends the functionality of
+ * <mosquitto_connect_async> by adding the bind_address parameter and MQTT v5
+ * properties. Use this function if you need to restrict network communication
+ * over a particular interface.
+ *
+ * Use e.g. <mosquitto_property_add_string> and similar to create a list of
+ * properties, then attach them to this connect. Properties need freeing with
+ * <mosquitto_property_free_all>.
+ *
+ * If the mosquitto instance `mosq` is using MQTT v5, the `properties` argument
+ * will be applied to the CONNECT message. For MQTT v3.1.1 and below, the
+ * `properties` argument will be ignored.
+ *
+ * Set your client to use MQTT v5 immediately after it is created:
+ *
+ * mosquitto_int_option(mosq, MOSQ_OPT_PROTOCOL_VERSION, MQTT_PROTOCOL_V5);
+ *
+ * Parameters:
+ * 	mosq -         a valid mosquitto instance.
+ * 	host -         the hostname or ip address of the broker to connect to.
+ * 	port -         the network port to connect to. Usually 1883.
+ * 	keepalive -    the number of seconds after which the client should send a PING
+ *                 message to the broker if no other messages have been exchanged
+ *                 in that time.
+ *  bind_address - the hostname or ip address of the local network interface to
+ *                 bind to. If you do not want to bind to a specific interface,
+ *                 set this to NULL.
+ *  properties - the MQTT 5 properties for the connect (not for the Will).
+ *
+ * Returns:
+ * 	MOSQ_ERR_SUCCESS - on success.
+ * 	MOSQ_ERR_INVAL -   if the input parameters were invalid, which could be any of:
+ * 	                   * mosq == NULL
+ * 	                   * host == NULL
+ * 	                   * port < 0
+ * 	                   * keepalive < 5 (keepalive == 0 is allowed, for an infinite keepalive)
+ * 	MOSQ_ERR_ERRNO -   if a system call returned an error. The variable errno
+ *                     contains the error code, even on Windows.
+ *                     Use strerror_r() where available or FormatMessage() on
+ *                     Windows.
+ *	MOSQ_ERR_DUPLICATE_PROPERTY - if a property is duplicated where it is forbidden.
+ *	MOSQ_ERR_PROTOCOL - if any property is invalid for use with CONNECT.
+ *
+ * See Also:
+ * 	<mosquitto_connect>, <mosquitto_connect_async>, <mosquitto_connect_bind_async>,
+ * 	<mosquitto_connect_bind_v5>
+ */
+libmosq_EXPORT int mosquitto_connect_bind_v5_async(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address, const mosquitto_property *properties);
 
 /*
  * Function: mosquitto_connect_async
@@ -340,7 +400,7 @@ libmosq_EXPORT int mosquitto_disconnect(struct mosquitto *mosq);
  * Disconnect from the broker, with attached MQTT properties.
  *
  * Use e.g. <mosquitto_property_add_string> and similar to create a list of
- * properties, then attach them to this publish. Properties need freeing with
+ * properties, then attach them to this disconnect. Properties need freeing with
  * <mosquitto_property_free_all>.
  *
  * If the mosquitto instance `mosq` is using MQTT v5, the `properties` argument

--- a/include/mosquitto/libmosquitto_subscribe.h
+++ b/include/mosquitto/libmosquitto_subscribe.h
@@ -63,7 +63,7 @@ libmosq_EXPORT int mosquitto_subscribe(struct mosquitto *mosq, int *mid, const c
  * Subscribe to a topic, with attached MQTT properties.
  *
  * Use e.g. <mosquitto_property_add_string> and similar to create a list of
- * properties, then attach them to this publish. Properties need freeing with
+ * properties, then attach them to this subscribe. Properties need freeing with
  * <mosquitto_property_free_all>.
  *
  * If the mosquitto instance `mosq` is using MQTT v5, the `properties` argument

--- a/include/mosquitto/libmosquitto_unsubscribe.h
+++ b/include/mosquitto/libmosquitto_unsubscribe.h
@@ -62,7 +62,7 @@ libmosq_EXPORT int mosquitto_unsubscribe(struct mosquitto *mosq, int *mid, const
  * <mosquitto_unsubscribe_v5> instead.
  *
  * Use e.g. <mosquitto_property_add_string> and similar to create a list of
- * properties, then attach them to this publish. Properties need freeing with
+ * properties, then attach them to this unsubscribe. Properties need freeing with
  * <mosquitto_property_free_all>.
  *
  * If the mosquitto instance `mosq` is using MQTT v5, the `properties` argument

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -44,6 +44,7 @@ static char alphanum[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01
 
 static int mosquitto__reconnect(struct mosquitto *mosq, bool blocking);
 static int mosquitto__connect_init(struct mosquitto *mosq, const char *host, int port, int keepalive);
+static int mosquitto__connect(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address, const mosquitto_property *properties, bool blocking);
 
 
 static int mosquitto__connect_init(struct mosquitto *mosq, const char *host, int port, int keepalive)
@@ -102,17 +103,41 @@ static int mosquitto__connect_init(struct mosquitto *mosq, const char *host, int
 
 int mosquitto_connect(struct mosquitto *mosq, const char *host, int port, int keepalive)
 {
-	return mosquitto_connect_bind(mosq, host, port, keepalive, NULL);
+	return mosquitto__connect(mosq, host, port, keepalive, NULL, NULL, true);
 }
 
 
 int mosquitto_connect_bind(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address)
 {
-	return mosquitto_connect_bind_v5(mosq, host, port, keepalive, bind_address, NULL);
+	return mosquitto__connect(mosq, host, port, keepalive, bind_address, NULL, true);
 }
 
 
 int mosquitto_connect_bind_v5(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address, const mosquitto_property *properties)
+{
+	return mosquitto__connect(mosq, host, port, keepalive, bind_address, properties, true);
+}
+
+
+int mosquitto_connect_bind_v5_async(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address, const mosquitto_property *properties)
+{
+	return mosquitto__connect(mosq, host, port, keepalive, bind_address, properties, false);
+}
+
+
+int mosquitto_connect_async(struct mosquitto *mosq, const char *host, int port, int keepalive)
+{
+	return mosquitto__connect(mosq, host, port, keepalive, NULL, NULL, false);
+}
+
+
+int mosquitto_connect_bind_async(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address)
+{
+	return mosquitto__connect(mosq, host, port, keepalive, bind_address, NULL, false);
+}
+
+
+int mosquitto__connect(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address, const mosquitto_property *properties, bool blocking)
 {
 	int rc;
 
@@ -144,33 +169,7 @@ int mosquitto_connect_bind_v5(struct mosquitto *mosq, const char *host, int port
 
 	mosquitto__set_state(mosq, mosq_cs_new);
 
-	return mosquitto__reconnect(mosq, true);
-}
-
-
-int mosquitto_connect_async(struct mosquitto *mosq, const char *host, int port, int keepalive)
-{
-	return mosquitto_connect_bind_async(mosq, host, port, keepalive, NULL);
-}
-
-
-int mosquitto_connect_bind_async(struct mosquitto *mosq, const char *host, int port, int keepalive, const char *bind_address)
-{
-	int rc;
-
-	if(bind_address){
-		rc = mosquitto_string_option(mosq, MOSQ_OPT_BIND_ADDRESS, bind_address);
-		if(rc){
-			return rc;
-		}
-	}
-
-	rc = mosquitto__connect_init(mosq, host, port, keepalive);
-	if(rc){
-		return rc;
-	}
-
-	return mosquitto__reconnect(mosq, false);
+	return mosquitto__reconnect(mosq, blocking);
 }
 
 

--- a/lib/linker.version
+++ b/lib/linker.version
@@ -144,6 +144,7 @@ MOSQ_1.7 {
 
 MOSQ_2.1 {
 	global:
+		mosquitto_connect_bind_v5_async;
 		mosquitto_ext_auth_callback_set;
 		mosquitto_ext_auth_continue;
 		mosquitto_pre_connect_callback_set;


### PR DESCRIPTION
Fills the gap where so far no async connect accepts MQTT v5 properties.

Fixes #2644.