### PR TITLE
Should no longer required to have cmake pinning

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,11 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: pin cmake to 3.x series
-        uses: jwlawson/actions-setup-cmake@09fd9b0fb3b239b4b68d9256cd65adf8d6b91da0
-        with:
-          cmake-version: '3.31.6'
-
       - name: Python test dependencies
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
