### PR TITLE
Add Multipath TCP (MPTCP) support for listeners, bridges, libmosquitto and clients

### DIFF
--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -889,6 +889,8 @@ int client_config_line_proc(struct mosq_config *cfg, int pub_or_sub, int argc, c
 				goto unknown_option;
 			}
 			cfg->message_rate = true;
+		}else if(!strcmp(argv[i], "--mptcp")){
+			cfg->mptcp = true;
 		}else if(!strcmp(argv[i], "--nodelay")){
 			cfg->tcp_nodelay = true;
 		}else if(!strcmp(argv[i], "--no-tls")){
@@ -1425,9 +1427,7 @@ static int client_tls_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 
 int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 {
-#if defined(WITH_SOCKS)
 	int rc;
-#endif
 
 	mosquitto_int_option(mosq, MOSQ_OPT_PROTOCOL_VERSION, cfg->protocol_version);
 	mosquitto_int_option(mosq, MOSQ_OPT_TRANSPORT, cfg->transport);
@@ -1461,6 +1461,13 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 #endif
 	if(cfg->tcp_nodelay){
 		mosquitto_int_option(mosq, MOSQ_OPT_TCP_NODELAY, 1);
+	}
+	if(cfg->mptcp){
+		rc = mosquitto_int_option(mosq, MOSQ_OPT_MPTCP, 1);
+		if(rc){
+			err_printf(cfg, "Error: MPTCP is not supported on this platform.\n");
+			return rc;
+		}
 	}
 
 	if(cfg->msg_count > 0 && cfg->msg_count < 20){

--- a/client/client_shared.h
+++ b/client/client_shared.h
@@ -141,6 +141,7 @@ struct mosq_config {
 	char *options_file;
 	bool have_topic_alias; /* pub */
 	bool tcp_nodelay;
+	bool mptcp;
 	bool no_tls;
 	bool message_rate; /* sub */
 	bool measure_latency; /* rr */

--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -416,9 +416,9 @@ static void print_usage(void)
 	printf("                     {-f file | -l | -n | -m message}\n");
 	printf("                     [-c] [-k keepalive] [-q qos] [-r] [--repeat N] [--repeat-delay time] [-x session-expiry]\n");
 #ifdef WITH_SRV
-	printf("                     [-A bind_address] [--nodelay] [-S]\n");
+	printf("                     [-A bind_address] [--mptcp] [--nodelay] [-S]\n");
 #else
-	printf("                     [-A bind_address] [--nodelay]\n");
+	printf("                     [-A bind_address] [--mptcp] [--nodelay]\n");
 #endif
 	printf("                     [-i id] [-I id_prefix]\n");
 	printf("                     [-d] [--quiet]\n");
@@ -484,6 +484,7 @@ static void print_usage(void)
 	printf("      seconds after the client disconnects, or use -1, 4294967295, or ∞ for a session\n");
 	printf("      that does not expire. Defaults to -1 if -c is also given, or 0 if -c not given.\n");
 	printf(" --help : display this message.\n");
+	printf(" --mptcp : use Multipath TCP to connect to the broker, if available. Linux only.\n");
 	printf(" --nodelay : disable Nagle's algorithm, to reduce socket sending latency at the possible\n");
 	printf("             expense of more packets being sent.\n");
 	printf(" --quiet : don't print error messages.\n");

--- a/client/rr_client.c
+++ b/client/rr_client.c
@@ -176,9 +176,9 @@ static void print_usage(void)
 	printf("                    [-W timeout_secs]\n");
 #endif
 #ifdef WITH_SRV
-	printf("                    [-A bind_address] [--nodelay] [-S]\n");
+	printf("                    [-A bind_address] [--mptcp] [--nodelay] [-S]\n");
 #else
-	printf("                    [-A bind_address] [--nodelay]\n");
+	printf("                    [-A bind_address] [--mptcp] [--nodelay]\n");
 #endif
 	printf("                    [-i id] [-I id_prefix]\n");
 	printf("                    [-d] [-N] [--quiet] [-v]\n");
@@ -240,6 +240,7 @@ static void print_usage(void)
 	printf("      seconds after the client disconnects, or use -1, 4294967295, or ∞ for a session\n");
 	printf("      that does not expire. Defaults to -1 if -c is also given, or 0 if -c not given.\n");
 	printf(" --help : display this message.\n");
+	printf(" --mptcp : use Multipath TCP to connect to the broker, if available. Linux only.\n");
 	printf(" --nodelay : disable Nagle's algorithm, to reduce socket sending latency at the possible\n");
 	printf("             expense of more packets being sent.\n");
 	printf(" --pretty : print formatted output rather than minimised output when using the\n");

--- a/client/sub_client.c
+++ b/client/sub_client.c
@@ -244,9 +244,9 @@ static void print_usage(void)
 	printf("                     [-W timeout_secs]\n");
 #endif
 #ifdef WITH_SRV
-	printf("                     [-A bind_address] [--nodelay] [-S]\n");
+	printf("                     [-A bind_address] [--mptcp] [--nodelay] [-S]\n");
 #else
-	printf("                     [-A bind_address] [--nodelay]\n");
+	printf("                     [-A bind_address] [--mptcp] [--nodelay]\n");
 #endif
 	printf("                     [-i id] [-I id_prefix]\n");
 	printf("                     [-d] [-N] [--quiet] [-v] [-w|--watch]\n");
@@ -316,6 +316,7 @@ static void print_usage(void)
 	printf("      seconds after the client disconnects, or use -1, 4294967295, or ∞ for a session\n");
 	printf("      that does not expire. Defaults to -1 if -c is also given, or 0 if -c not given.\n");
 	printf(" --help : display this message.\n");
+	printf(" --mptcp : use Multipath TCP to connect to the broker, if available. Linux only.\n");
 	printf(" --nodelay : disable Nagle's algorithm, to reduce socket sending latency at the possible\n");
 	printf("             expense of more packets being sent.\n");
 	printf(" --pretty : print formatted output rather than minimised output when using the\n");

--- a/include/mosquitto/libmosquitto.h
+++ b/include/mosquitto/libmosquitto.h
@@ -91,6 +91,7 @@ enum mosq_opt_t {
 	MOSQ_OPT_TRANSPORT = 15,
 	MOSQ_OPT_HTTP_PATH = 16,
 	MOSQ_OPT_HTTP_HEADER_SIZE = 17,
+	MOSQ_OPT_MPTCP = 18,
 };
 
 /* Struct: mosquitto_message

--- a/include/mosquitto/libmosquitto_options.h
+++ b/include/mosquitto/libmosquitto_options.h
@@ -90,6 +90,14 @@ libmosq_EXPORT int mosquitto_opts_set(struct mosquitto *mosq, enum mosq_opt_t op
  *	          packets being sent.
  *	          Defaults to 0, which means Nagle remains enabled.
  *
+ *	MOSQ_OPT_MPTCP - Set to 1 to use Multipath TCP (MPTCP) instead of plain
+ *	          TCP when connecting to the broker. This is currently only
+ *	          supported on Linux, with kernel 5.6 or later. If the running
+ *	          kernel does not support MPTCP, the connection will fall back
+ *	          to plain TCP. On other platforms this option returns
+ *	          MOSQ_ERR_NOT_SUPPORTED. Must be set before the client
+ *	          connects. Defaults to 0, which means plain TCP is used.
+ *
  *	MOSQ_OPT_PROTOCOL_VERSION - Value must be set to either MQTT_PROTOCOL_V31,
  *	          MQTT_PROTOCOL_V311, or MQTT_PROTOCOL_V5. Must be set before the
  *	          client connects.  Defaults to MQTT_PROTOCOL_V311.

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -452,6 +452,7 @@ struct mosquitto {
 	uint8_t max_qos;
 	uint8_t retain_available;
 	bool tcp_nodelay;
+	bool mptcp;
 #if defined(WITH_WEBSOCKETS) && WITH_WEBSOCKETS == WS_IS_BUILTIN
 	char *http_request;
 #endif

--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -367,7 +367,7 @@ int net__try_connect_step2(struct mosquitto *mosq, uint16_t port, mosq_sock_t *s
 	ainfo = mosq->adns->ar_result;
 
 	for(rp = ainfo; rp != NULL; rp = rp->ai_next){
-		*sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		*sock = net__socket_stream(rp->ai_family, rp->ai_socktype, rp->ai_protocol, mosq->mptcp);
 		if(*sock == INVALID_SOCKET){
 			continue;
 		}
@@ -421,7 +421,31 @@ int net__try_connect_step2(struct mosquitto *mosq, uint16_t port, mosq_sock_t *s
 #endif
 
 
-static int net__try_connect_tcp(const char *host, uint16_t port, mosq_sock_t *sock, const char *bind_address, bool blocking)
+/* Create a stream socket, optionally attempting to use MPTCP instead of
+ * plain TCP. If MPTCP is requested but not supported by the running kernel,
+ * fall back to creating a plain TCP socket. */
+mosq_sock_t net__socket_stream(int domain, int type, int protocol, bool use_mptcp)
+{
+#if defined(__linux__)
+	if(use_mptcp){
+		mosq_sock_t sock;
+
+		sock = socket(domain, type, IPPROTO_MPTCP);
+		if(sock != INVALID_SOCKET
+				|| (errno != EINVAL && errno != EPROTONOSUPPORT && errno != ENOPROTOOPT)){
+
+			return sock;
+		}
+		/* MPTCP is not available, fall through to plain TCP. */
+	}
+#else
+	UNUSED(use_mptcp);
+#endif
+	return socket(domain, type, protocol);
+}
+
+
+static int net__try_connect_tcp(const char *host, uint16_t port, mosq_sock_t *sock, const char *bind_address, bool blocking, bool use_mptcp)
 {
 	struct addrinfo hints;
 	struct addrinfo *ainfo, *rp;
@@ -452,7 +476,7 @@ static int net__try_connect_tcp(const char *host, uint16_t port, mosq_sock_t *so
 	}
 
 	for(rp = ainfo; rp != NULL; rp = rp->ai_next){
-		*sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		*sock = net__socket_stream(rp->ai_family, rp->ai_socktype, rp->ai_protocol, use_mptcp);
 		if(*sock == INVALID_SOCKET){
 			continue;
 		}
@@ -556,16 +580,18 @@ static int net__try_connect_unix(const char *host, mosq_sock_t *sock)
 #endif
 
 
-int net__try_connect(const char *host, uint16_t port, mosq_sock_t *sock, const char *bind_address, bool blocking)
+int net__try_connect(const char *host, uint16_t port, mosq_sock_t *sock, const char *bind_address, bool blocking, bool use_mptcp)
 {
 	if(port == 0){
 #ifdef WITH_UNIX_SOCKETS
+		UNUSED(use_mptcp);
 		return net__try_connect_unix(host, sock);
 #else
+		UNUSED(use_mptcp);
 		return MOSQ_ERR_NOT_SUPPORTED;
 #endif
 	}else{
-		return net__try_connect_tcp(host, port, sock, bind_address, blocking);
+		return net__try_connect_tcp(host, port, sock, bind_address, blocking, use_mptcp);
 	}
 }
 
@@ -969,7 +995,7 @@ int net__socket_connect(struct mosquitto *mosq, const char *host, uint16_t port,
 		return MOSQ_ERR_INVAL;
 	}
 
-	rc = net__try_connect(host, port, &mosq->sock, bind_address, blocking);
+	rc = net__try_connect(host, port, &mosq->sock, bind_address, blocking, mosq->mptcp);
 	if(rc > 0){
 		return rc;
 	}

--- a/lib/net_mosq.h
+++ b/lib/net_mosq.h
@@ -19,6 +19,7 @@ Contributors:
 #define NET_MOSQ_H
 
 #ifndef WIN32
+#  include <netinet/in.h>
 #  include <sys/socket.h>
 #  include <unistd.h>
 #else
@@ -27,6 +28,13 @@ Contributors:
 typedef SSIZE_T ssize_t;
 #    define _SSIZE_T_DEFINED
 #  endif
+#endif
+
+#if defined(__linux__) && !defined(IPPROTO_MPTCP)
+/* Multipath TCP is supported by Linux 5.6 and later. The protocol number is
+ * part of the kernel ABI, so it is safe to define it here for the case where
+ * we are building against older headers. */
+#  define IPPROTO_MPTCP 262
 #endif
 
 #include "mosquitto_internal.h"
@@ -72,7 +80,8 @@ void net__init_tls(void);
 int net__socket_connect(struct mosquitto *mosq, const char *host, uint16_t port, const char *bind_address, bool blocking);
 int net__socket_close(struct mosquitto *mosq);
 int net__socket_shutdown(struct mosquitto *mosq);
-int net__try_connect(const char *host, uint16_t port, mosq_sock_t *sock, const char *bind_address, bool blocking);
+int net__try_connect(const char *host, uint16_t port, mosq_sock_t *sock, const char *bind_address, bool blocking, bool use_mptcp);
+mosq_sock_t net__socket_stream(int domain, int type, int protocol, bool use_mptcp);
 int net__try_connect_step1(struct mosquitto *mosq, const char *host);
 int net__try_connect_step2(struct mosquitto *mosq, uint16_t port, mosq_sock_t *sock);
 int net__socket_connect_step3(struct mosquitto *mosq, const char *host);

--- a/lib/options.c
+++ b/lib/options.c
@@ -569,6 +569,14 @@ int mosquitto_int_option(struct mosquitto *mosq, enum mosq_opt_t option, int val
 			mosq->tcp_nodelay = (bool)value;
 			break;
 
+		case MOSQ_OPT_MPTCP:
+#if defined(__linux__)
+			mosq->mptcp = (bool)value;
+#else
+			return MOSQ_ERR_NOT_SUPPORTED;
+#endif
+			break;
+
 		case MOSQ_OPT_TRANSPORT:
 #if defined(WITH_WEBSOCKETS) && WITH_WEBSOCKETS == WS_IS_BUILTIN
 			if(value == mosq_t_tcp || value == mosq_t_ws){

--- a/man/common/option-mptcp.xml
+++ b/man/common/option-mptcp.xml
@@ -1,0 +1,14 @@
+<varlistentry>
+	<term><option>--mptcp</option></term>
+	<listitem>
+		<para>
+			Use Multipath TCP (MPTCP) instead of plain TCP for the connection
+			to the broker. MPTCP allows the connection to make use of multiple
+			network paths simultaneously, which can improve throughput and
+			resilience to network failures, provided the broker also accepts
+			MPTCP connections. This option is only available on Linux, with
+			kernel 5.6 or later. If the running kernel does not support MPTCP,
+			the connection falls back to plain TCP.
+		</para>
+	</listitem>
+</varlistentry>

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -2149,6 +2149,22 @@ openssl dhparam -out dhparam.pem 2048</programlisting>
 				</listitem>
 			</varlistentry>
 			<varlistentry>
+				<term><option>bridge_mptcp</option> [ true | false ]</term>
+				<listitem>
+					<para>Set <option>bridge_mptcp</option> to true to make the
+						bridge connect to the remote broker using Multipath TCP
+						(MPTCP) instead of plain TCP. MPTCP allows the
+						connection to make use of multiple network paths
+						simultaneously, which can improve throughput and
+						resilience to network failures, provided the remote
+						broker also accepts MPTCP connections.</para>
+					<para>This option is only available on Linux, with kernel
+						5.6 or later. If the running kernel does not support
+						MPTCP, the connection falls back to plain TCP.</para>
+					<para>Defaults to false.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
 				<term><option>bridge_outgoing_retain</option> [ true | false ]</term>
 				<listitem>
 					<para>Some MQTT brokers do not allow retained messages. MQTT v5 gives

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -1604,6 +1604,26 @@ accept_protocol_versions 3, 4</programlisting>
 					</listitem>
 				</varlistentry>
 				<varlistentry>
+					<term><option>mptcp</option> [ true | false ]</term>
+					<listitem>
+						<para>Set <option>mptcp</option> to true to make the
+							listener accept connections using Multipath TCP
+							(MPTCP) as well as plain TCP. MPTCP allows a
+							connection to make use of multiple network paths
+							simultaneously, which can improve throughput and
+							resilience to network failures for clients that
+							also use MPTCP. Clients connecting with plain TCP
+							are unaffected and continue to work as normal.
+							</para>
+						<para>This option is only available on Linux, with
+							kernel 5.6 or later. If the running kernel does
+							not support MPTCP, the listener will fall back to
+							plain TCP and a warning will be logged.</para>
+						<para>Defaults to false.</para>
+						<para>Not reloaded on reload signal.</para>
+					</listitem>
+				</varlistentry>
+				<varlistentry>
 					<term><option>port</option> <replaceable>port number</replaceable></term>
 					<listitem>
 						<para>This option is deprecated and will be removed in a

--- a/man/mosquitto_pub.1.xml
+++ b/man/mosquitto_pub.1.xml
@@ -53,6 +53,7 @@
 			</group>
 			<sbr/>
 			<arg><option>-A</option> <replaceable>bind-address</replaceable></arg>
+			<arg><option>--mptcp</option></arg>
 			<arg><option>--nodelay</option></arg>
 			<arg><option>-S</option></arg>
 			<arg><option>--ws</option></arg>
@@ -188,6 +189,7 @@
 			</varlistentry>
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-payload-message.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-payload-null.xml" />
+			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-mptcp.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-nodelay.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-no-tls.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-port.xml" />

--- a/man/mosquitto_rr.1.xml
+++ b/man/mosquitto_rr.1.xml
@@ -56,6 +56,7 @@
 			</group>
 			<sbr/>
 			<arg><option>-A</option> <replaceable>bind-address</replaceable></arg>
+			<arg><option>--mptcp</option></arg>
 			<arg><option>--nodelay</option></arg>
 			<arg><option>-S</option></arg>
 			<arg><option>--ws</option></arg>
@@ -226,6 +227,7 @@
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-payload-message.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-format-no-eol.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-payload-null.xml" />
+			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-mptcp.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-nodelay.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-no-tls.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-port.xml" />

--- a/man/mosquitto_sub.1.xml
+++ b/man/mosquitto_sub.1.xml
@@ -57,6 +57,7 @@
 			</group>
 			<sbr/>
 			<arg><option>-A</option> <replaceable>bind-address</replaceable></arg>
+			<arg><option>--mptcp</option></arg>
 			<arg><option>--nodelay</option></arg>
 			<arg><option>-S</option></arg>
 			<arg><option>--ws</option></arg>
@@ -237,6 +238,7 @@
 				</listitem>
 			</varlistentry>
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-format-no-eol.xml" />
+			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-mptcp.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-nodelay.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-no-tls.xml" />
 			<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/option-port.xml" />

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -297,6 +297,15 @@
 # happens internally to the broker; the client will not see the prefix.
 #mount_point
 
+# Set mptcp to true to make the listener accept connections using Multipath
+# TCP (MPTCP) as well as plain TCP. MPTCP allows a connection to make use of
+# multiple network paths simultaneously, which can improve throughput and
+# resilience to network failures for clients that also use MPTCP. Clients
+# connecting with plain TCP are unaffected.
+# This option is only available on Linux, with kernel 5.6 or later. If the
+# running kernel does not support MPTCP, the listener falls back to plain TCP.
+#mptcp false
+
 # Choose the protocol to use when listening.
 # This can be either mqtt, websockets, or http_api.
 #

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -968,6 +968,16 @@
 # properly.
 #try_private true
 
+# Set bridge_mptcp to true to make the bridge connect to the remote broker
+# using Multipath TCP (MPTCP) instead of plain TCP. MPTCP allows the
+# connection to make use of multiple network paths simultaneously, which can
+# improve throughput and resilience to network failures, provided the remote
+# broker also accepts MPTCP connections.
+# This option is only available on Linux, with kernel 5.6 or later. If the
+# running kernel does not support MPTCP, the connection falls back to plain
+# TCP.
+#bridge_mptcp false
+
 # Some MQTT brokers do not allow retained messages. MQTT v5 gives a mechanism
 # for brokers to tell clients that they do not support retained messages, but
 # this is not possible for MQTT v3.1.1 or v3.1. If you need to bridge to a

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -91,6 +91,7 @@ static struct mosquitto *bridge__new(struct mosquitto__bridge *bridge)
 		context__add_to_by_id(new_context);
 	}
 	new_context->transport = mosq_t_tcp;
+	new_context->mptcp = bridge->mptcp;
 	new_context->bridge = bridge;
 	new_context->is_bridge = true;
 

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -1043,7 +1043,8 @@ void bridge_check(void)
 					rc = net__try_connect(context->bridge->addresses[0].address,
 							context->bridge->addresses[0].port,
 							&context->bridge->primary_retry_sock,
-							context->bridge->bind_address, false);
+							context->bridge->bind_address, false,
+							context->mptcp);
 
 					if(rc == 0){
 						COMPAT_CLOSE(context->bridge->primary_retry_sock);

--- a/src/conf.c
+++ b/src/conf.c
@@ -2299,6 +2299,20 @@ static int config__read_file_core(struct mosquitto__config *config, bool reload,
 								cur_listener->mount_point);
 						return MOSQ_ERR_INVAL;
 					}
+				}else if(!strcmp(token, "mptcp")){
+					if(reload){
+						continue;        /* Listeners are not recreated on reload. */
+					}
+					REQUIRE_LISTENER_OR_DEFAULT_LISTENER(token);
+					if(conf__parse_bool(&token, "mptcp", &cur_listener->mptcp, &saveptr)){
+						return MOSQ_ERR_INVAL;
+					}
+#if !defined(__linux__)
+					if(cur_listener->mptcp){
+						log__printf(NULL, MOSQ_LOG_WARNING, "Warning: MPTCP support is only available on Linux, 'mptcp' option ignored.");
+						cur_listener->mptcp = false;
+					}
+#endif
 				}else if(!strcmp(token, "notifications")){
 #ifdef WITH_BRIDGE
 					REQUIRE_BRIDGE(token);

--- a/src/conf.c
+++ b/src/conf.c
@@ -1435,6 +1435,21 @@ static int config__read_file_core(struct mosquitto__config *config, bool reload,
 #else
 					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge support not available.");
 #endif
+				}else if(!strcmp(token, "bridge_mptcp")){
+#if defined(WITH_BRIDGE)
+					REQUIRE_BRIDGE(token);
+					if(conf__parse_bool(&token, "bridge_mptcp", &cur_bridge->mptcp, &saveptr)){
+						return MOSQ_ERR_INVAL;
+					}
+#  if !defined(__linux__)
+					if(cur_bridge->mptcp){
+						log__printf(NULL, MOSQ_LOG_WARNING, "Warning: MPTCP support is only available on Linux, 'bridge_mptcp' option ignored.");
+						cur_bridge->mptcp = false;
+					}
+#  endif
+#else
+					log__printf(NULL, MOSQ_LOG_WARNING, "Warning: Bridge support not available.");
+#endif
 				}else if(!strcmp(token, "bridge_outgoing_retain")){
 #if defined(WITH_BRIDGE)
 					REQUIRE_BRIDGE(token);

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -555,6 +555,7 @@ struct mosquitto__bridge {
 	time_t primary_retry;
 	mosq_sock_t primary_retry_sock;
 	bool round_robin;
+	bool mptcp;
 	bool try_private;
 	bool try_private_accepted;
 	bool clean_start;

--- a/src/mosquitto_broker_internal.h
+++ b/src/mosquitto_broker_internal.h
@@ -238,6 +238,7 @@ struct mosquitto__listener {
 	int client_count;
 	enum mosquitto_protocol protocol;
 	int socket_domain;
+	bool mptcp;
 	bool use_username_as_clientid;
 	uint8_t max_qos;
 	uint16_t max_topic_alias;

--- a/src/net.c
+++ b/src/net.c
@@ -843,11 +843,23 @@ static int net__socket_listen_tcp(struct mosquitto__listener *listener)
 			continue;
 		}
 
-		sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		sock = net__socket_stream(rp->ai_family, rp->ai_socktype, rp->ai_protocol, listener->mptcp);
 		if(sock == INVALID_SOCKET){
 			net__print_error(MOSQ_LOG_WARNING, "Warning: %s");
 			continue;
 		}
+#if defined(__linux__) && defined(SO_PROTOCOL)
+		if(listener->mptcp){
+			int protocol = 0;
+			socklen_t protocol_len = sizeof(protocol);
+
+			if(getsockopt(sock, SOL_SOCKET, SO_PROTOCOL, &protocol, &protocol_len)
+					|| protocol != IPPROTO_MPTCP){
+
+				log__printf(NULL, MOSQ_LOG_WARNING, "Warning: MPTCP is not supported by the kernel, falling back to TCP.");
+			}
+		}
+#endif
 		listener->sock_count++;
 		listener->socks = mosquitto_realloc(listener->socks, sizeof(mosq_sock_t)*(size_t)listener->sock_count);
 		if(!listener->socks){


### PR DESCRIPTION
# Add Multipath TCP (MPTCP) support

---

## Summary

This PR adds opt-in Multipath TCP (RFC 8684) support across mosquitto, in four
logical commits:

| Commit | Area | Change |
|---|---|---|
| 1 | lib | New `MOSQ_OPT_MPTCP` for `mosquitto_int_option()`; shared `net__socket_stream()` helper |
| 2 | broker | New per-listener config option `mptcp true\|false` |
| 3 | clients | New `--mptcp` flag for `mosquitto_pub`, `mosquitto_sub`, `mosquitto_rr` |
| 4 | broker | New bridge config option `bridge_mptcp true\|false` |

MPTCP lets a single connection use several network paths at once (e.g. WiFi +
cellular, or two NICs), giving seamless failover between paths and potential
throughput aggregation without any change to the MQTT layer. This is
particularly useful for MQTT deployments on mobile/vehicular/IIoT clients with
redundant uplinks, and for broker-to-broker bridges over unreliable WANs.

Everything is **opt-in and off by default**. No behaviour changes unless the
new options are explicitly enabled. No new build dependencies.

## Usage

Broker listener:
```
listener 1883
mptcp true
```

Bridge:
```
connection mybridge
address remote.example.com:1883
bridge_mptcp true
```

libmosquitto:
```c
mosquitto_int_option(mosq, MOSQ_OPT_MPTCP, 1);
```

Clients:
```
mosquitto_sub --mptcp -h remote.example.com -t 'topic/#'
```

## Platform support and fallback semantics

- **Linux-only**, kernel 5.6+ (and `net.mptcp.enabled=1`). All code paths are
  guarded with `#if defined(__linux__)`, so Windows/macOS/BSD builds are
  byte-for-byte unaffected at the socket layer.
- On non-Linux platforms: `MOSQ_OPT_MPTCP` returns `MOSQ_ERR_NOT_SUPPORTED`;
  the `mptcp`/`bridge_mptcp` config options are accepted but ignored with a
  logged warning; the client `--mptcp` flag produces an error.
- On Linux kernels without MPTCP (or with it disabled): socket creation with
  `IPPROTO_MPTCP` fails with `EINVAL`/`EPROTONOSUPPORT`/`ENOPROTOOPT` and we
  **fall back to plain TCP**. The broker detects the fallback (see design
  notes) and logs a warning; the library falls back silently.
- An `mptcp true` listener remains fully compatible with plain-TCP clients:
  an MPTCP listening socket accepts both MPTCP and regular TCP connections,
  so enabling the option cannot lock out existing clients.

## Design notes

**Why substitute the protocol at `socket()` time instead of in `getaddrinfo()`
hints.** Passing `IPPROTO_MPTCP` via `ai_protocol` is rejected by many libc
versions (getaddrinfo validates the protocol against its own tables). The
established pattern — the same one used by curl and iperf3 — is to resolve
addresses normally and substitute `IPPROTO_MPTCP` when creating the socket,
falling back to the resolved `ai_protocol` if the kernel refuses. That is what
the new `net__socket_stream(domain, type, protocol, use_mptcp)` helper in
`lib/net_mosq.c` does; it is the single place holding the fallback-errno
logic, and is shared by the client connect path (both the synchronous path and
the `WITH_ADNS` async path in `net__try_connect_step2()`) and the broker's
listener setup.

**Fallback vs. hard failure.** A hard failure on kernels without MPTCP would
make `--mptcp`/`mptcp true` undeployable in mixed fleets and would break
brokers on kernel downgrades. Silent fallback alone would mask
misconfiguration on the broker side, so the compromise is: clients fall back
silently (documented), while the broker verifies the created listener socket
with `getsockopt(SOL_SOCKET, SO_PROTOCOL)` and logs
`Warning: MPTCP is not supported by the kernel, falling back to TCP.` if the
socket is not actually MPTCP. The check costs one getsockopt per listener at
startup, only when `mptcp true` is set.

**`IPPROTO_MPTCP` availability at build time.** glibc only exposes
`IPPROTO_MPTCP` from 2.32. Since the value (262) is part of the kernel ABI and
cannot change, `net_mosq.h` defines it when missing, guarded by
`#if defined(__linux__) && !defined(IPPROTO_MPTCP)`. `<netinet/in.h>` is
included first so the `#ifndef` test is evaluated against the system
definition and never conflicts with it. This keeps the feature buildable on
older distros whose kernels do support MPTCP.

**Internal API change.** `net__try_connect()` gains a trailing
`bool use_mptcp` parameter. This is an internal symbol (not exported in
`linker.version`), so there is no ABI impact on libmosquitto. Its only two
callers are updated: `net__socket_connect()` passes `mosq->mptcp`, and the
bridge round-robin primary-retry probe in `src/bridge.c` passes
`context->mptcp`. Choosing a parameter over a global keeps the function usable
from both broker and lib contexts.

**Bridge wiring.** `bridge_mptcp` is stored on `struct mosquitto__bridge` and
copied onto the bridge's connection context in `bridge__new()`
(`new_context->mptcp = bridge->mptcp`). Because the broker's bridge contexts
reuse the lib's `struct mosquitto` and connect through `net__socket_connect()`,
both the normal connect path and the primary-retry path use MPTCP
consistently with no bridge-specific socket code.

**Public option numbering/ABI.** `MOSQ_OPT_MPTCP = 18` extends
`enum mosq_opt_t` at the end; existing values are untouched. The `mptcp` flag
is a new `bool` in `struct mosquitto` (internal, not part of the public ABI),
placed alongside `tcp_nodelay`. Old applications running against the new
library see no behavioural difference.

**Interaction with existing socket options.** `TCP_NODELAY`,
`SO_KEEPALIVE`/`TCP_KEEPIDLE` etc. are supported by the kernel's MPTCP socket
option layer on recent kernels; on older kernels where a particular option is
not yet supported on MPTCP sockets, the existing code paths already only log
a warning on `setsockopt()` failure, so behaviour degrades gracefully.

**Reload semantics.** Like `socket_domain`, the listener `mptcp` option is
skipped on config reload, because listener sockets are not recreated on
`SIGHUP`. `bridge_mptcp` follows normal bridge option handling (bridges are
recreated on reload).

**Scope deliberately excluded.** No MPTCP-specific tuning is exposed (path
manager, subflow limits, `MPTCP_INFO`): these are administered system-wide via
`ip mptcp` / sysctls and would bloat the config surface. WebSockets listeners
are unaffected in this PR (the option applies to the TCP socket under any
listener type on the broker side, since it is applied at `socket()` creation
for the listener). TLS works unchanged on top of MPTCP since it is purely
above the transport.

## Documentation

- `man/mosquitto.conf.5.xml`: `mptcp` (listener section) and `bridge_mptcp`
  (bridge section) entries.
- `man/common/option-mptcp.xml` + references from `mosquitto_pub.1.xml`,
  `mosquitto_sub.1.xml`, `mosquitto_rr.1.xml`.
- `include/mosquitto/libmosquitto_options.h`: `MOSQ_OPT_MPTCP` API docs.
- `mosquitto.conf`: commented examples for `mptcp` and `bridge_mptcp`.
- Client `--help` output updated.

ChangeLog.txt intentionally not modified to avoid conflicts — happy to add
entries if preferred.

## Testing performed

On Linux 6.18 (`net.mptcp.enabled=1`), Makefile build with
`-Wall -Wextra -Wconversion`, clean:

1. **Listener**: broker with `mptcp true` — `ss -Mln` shows the listening
   socket as MPTCP.
2. **Client end-to-end**: `mosquitto_sub --mptcp` + `mosquitto_pub --mptcp` —
   `strace` confirms `socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP)`, `ss -Mn`
   shows the established connection as MPTCP on both ends, message delivered.
3. **Interop**: plain-TCP `mosquitto_pub` against the `mptcp true` listener —
   works unchanged.
4. **Kernel fallback**: with `net.mptcp.enabled=0`, client `--mptcp` falls
   back (`strace`: `IPPROTO_MPTCP` → `ENOPROTOOPT` → `IPPROTO_TCP`, publish
   succeeds); broker logs the fallback warning and serves TCP.
5. **Bridge**: two brokers, B with `mptcp true` listener, A with
   `bridge_mptcp true` — `ss -Mn` shows the bridge connection as MPTCP;
   messages flow across the bridge.
6. **Config validation**: `mptcp notabool` → proper
   `Error: Invalid 'mptcp' value` at startup; options on non-listener/bridge
   context rejected by the existing `REQUIRE_*` macros.

## Checklist

- [x] Commits signed off (`Signed-off-by`, DCO), email matches Eclipse account
- [x] ECA signed
- [x] Based on and targeting `develop`
- [x] Four small, self-contained commits
- [x] Linux-only code guarded; other platforms unaffected
- [x] Man pages, header docs, example config updated
