### PR TITLE
sys_tree: fix int64_t format specifier warning

### DIFF
--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -210,7 +210,7 @@ static int drop_privileges(struct mosquitto__config *config)
 					}
 				}
 			}
-			if(initgroups(config->user, pwd->pw_gid) == -1){
+			if(initgroups(config->user, (int)pwd->pw_gid) == -1){
 				err = strerror(errno);
 				log__printf(NULL, MOSQ_LOG_ERR, "Error setting groups whilst dropping privileges: %s.", err);
 				return MOSQ_ERR_ERRNO;

--- a/src/sys_tree.c
+++ b/src/sys_tree.c
@@ -24,7 +24,6 @@ Contributors:
 #include <stdio.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <inttypes.h>
 
 #include "mosquitto_broker_internal.h"
 #include "sys_tree.h"
@@ -282,7 +281,7 @@ void sys_tree__update(bool force)
 					(!metrics[i].is_max && metrics[i].next != metrics[i].current)){
 
 				metrics[i].current = metrics[i].next;
-				len = (uint32_t)snprintf(buf, BUFLEN, "%lu", metrics[i].current);
+				len = (uint32_t)snprintf(buf, BUFLEN, "%" PRId64, metrics[i].current);
 				if(metrics[i].topic){
 					db__messages_easy_queue(NULL, metrics[i].topic, SYS_TREE_QOS, len, buf, 1, MSG_EXPIRY_INFINITE, NULL);
 				}


### PR DESCRIPTION
 - Cast `gid_t` in i`nitgroups()` call to silence sign conversion warning
- Fix `sys_tree` printf format specifier for int64_t metrics"
- Remove duplicate `<inttypes.h>` include

## Checklist
* [x]  Commits signed off (`Signed-off-by`, DCO), email matches Eclipse account
* [x]  ECA signed
* [x]  Based on and targeting `fix`
* [x] Run `make test` with my changes locally
 
