### PR TITLE
mosquitto_ctrl: Fix file descriptor leak in dynsec_init()

### DIFF
--- a/apps/mosquitto_ctrl/dynsec.c
+++ b/apps/mosquitto_ctrl/dynsec.c
@@ -744,6 +744,7 @@ static int dynsec_init(int argc, char *argv[])
 		fclose(fptr);
 	}else{
 		free(json_str);
+		fclose(fptr);
 		fprintf(stderr, "dynsec init: Unable to open '%s' for writing.\n", filename);
 		return -1;
 	}


### PR DESCRIPTION
Close the file descriptor returned by `open()` when `fdopen()`
fails in `dynsec_init()`. Without this, the descriptor remains
open until process exit.

https://github.com/eclipse-mosquitto/mosquitto/issues/3678

## Checklist
* [x]  Commits signed off (`Signed-off-by`, DCO), email matches Eclipse account
* [x]  ECA signed
* [x]  Based on and targeting `fix`
* [x] Run `make test` with my changes locally
