### PR TITLE
Fix MQTT receive maximum exceeded handling

### DIFF
--- a/lib/handle_publish.c
+++ b/lib/handle_publish.c
@@ -128,7 +128,7 @@ int handle__publish(struct mosquitto *mosq)
 			if(mosq->msgs_in.inflight_quota == 0){
 				message__cleanup(&message);
 				send__disconnect(mosq, MQTT_RC_RECEIVE_MAXIMUM_EXCEEDED, NULL );
-				return MOSQ_ERR_PROTOCOL;
+				return MOSQ_ERR_RECEIVE_MAXIMUM_EXCEEDED;
 			}
 		}
 

--- a/lib/handle_publish.c
+++ b/lib/handle_publish.c
@@ -127,7 +127,7 @@ int handle__publish(struct mosquitto *mosq)
 		if(mosq->protocol == mosq_p_mqtt5){
 			if(mosq->msgs_in.inflight_quota == 0){
 				message__cleanup(&message);
-				/* FIXME - should send a DISCONNECT here */
+				send__disconnect(mosq, MQTT_RC_RECEIVE_MAXIMUM_EXCEEDED, NULL );
 				return MOSQ_ERR_PROTOCOL;
 			}
 		}

--- a/src/handle_publish.c
+++ b/src/handle_publish.c
@@ -109,14 +109,8 @@ int handle__accepted_publish(struct mosquitto *context, struct mosquitto__base_m
 	if(!cmsg_stored){
 		if(base_msg->data.qos > 0 && context->msgs_in.inflight_quota == 0){
 			log__printf(NULL, MOSQ_LOG_WARNING, "Client %s has exceeded its receive-maximum quota. This behaviour must be fixed on the client.", context->id);
-#if 0
-			/* Badly behaving clients like on the esp32 fall foul of this
-			 * check, so report it for now but don't disconnect, to give chance
-			 * for the bad behaviour to be fixed. */
-			/* Client isn't allowed any more incoming messages, so fail early */
 			db__msg_store_free(base_msg);
 			return MOSQ_ERR_RECEIVE_MAXIMUM_EXCEEDED;
-#endif
 		}
 
 		if(base_msg->data.qos == 0

--- a/test/broker/CMakeLists.txt
+++ b/test/broker/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 set(EXCLUDE_LIST
     01-connect-uname-password-success-no-tls
     03-publish-qos1-queued-bytes
-    03-publish-qos2-max-inflight-exceeded
     09-extended-auth-single2
     # Not a test
     06-bridge-clean-session-core
@@ -81,6 +80,7 @@ add_python_test(PY_TEST_NAMES ${PREFIX} 1 "03-publish-qos1-max-inflight-expire.p
 add_python_test(PY_TEST_NAMES ${PREFIX} 1 "03-publish-qos1-max-inflight.py")
 add_python_test(PY_TEST_NAMES ${PREFIX} 1 "03-publish-qos1-no-subscribers-v5.py")
 add_python_test(PY_TEST_NAMES ${PREFIX} 1 "03-publish-qos1-retain-disabled.py")
+add_python_test(PY_TEST_NAMES ${PREFIX} 1 "03-publish-qos2-max-inflight-exceeded.py")
 add_python_test(PY_TEST_NAMES ${PREFIX} 1 "03-publish-qos2-max-inflight.py")
 add_python_test(PY_TEST_NAMES ${PREFIX} 1 "03-publish-qos2-reuse-mid.py")
 add_python_test(PY_TEST_NAMES ${PREFIX} 2 "04-retain-check-source-persist-diff-port.py")

--- a/test/broker/Makefile
+++ b/test/broker/Makefile
@@ -81,7 +81,7 @@ msg_sequence_test:
 	./03-publish-qos1-max-inflight-expire.py
 	./03-publish-qos1-no-subscribers-v5.py
 	./03-publish-qos1-retain-disabled.py
-	#./03-publish-qos2-max-inflight-exceeded.py
+	./03-publish-qos2-max-inflight-exceeded.py
 	./03-publish-qos2-max-inflight.py
 	./03-publish-qos2-reuse-mid.py
 

--- a/test/broker/test.py
+++ b/test/broker/test.py
@@ -62,7 +62,7 @@ tests = [
     (1, './03-publish-qos1-max-inflight.py'),
     (1, './03-publish-qos1-no-subscribers-v5.py'),
     (1, './03-publish-qos1-retain-disabled.py'),
-    #(1, './03-publish-qos2-max-inflight-exceeded.py'),
+    (1, './03-publish-qos2-max-inflight-exceeded.py'),
     (1, './03-publish-qos2-max-inflight.py'),
     (1, './03-publish-qos2-reuse-mid.py'),
 


### PR DESCRIPTION
Send a DISCONNECT packet with reason code
MQTT_RC_RECEIVE_MAXIMUM_EXCEEDED when a client exceeds its
receive maximum quota instead of returning a protocol error.


## Checklist
* [x]  Commits signed off (`Signed-off-by`, DCO), email matches Eclipse account
* [x]  ECA signed
* [x]  Based on and targeting `fix`
* [x] Run `make test` with my changes locally
