### PR TITLE
Dynamic Bridge Credentials via Plugin API #3676

### DIFF
--- a/include/mosquitto/broker.h
+++ b/include/mosquitto/broker.h
@@ -745,6 +745,25 @@ mosq_EXPORT int mosquitto_set_username(struct mosquitto *client, const char *use
  */
 mosq_EXPORT int mosquitto_set_clientid(struct mosquitto *client, const char *clientid);
 
+/* Function: mosquitto_bridge_set_remote_credentials
+ *
+ * Set the remote username/password for a bridge client.
+ *
+ * This updates the bridge credentials used for future bridge CONNECT packets.
+ * Both values are replaced atomically. Either value may be set to NULL to
+ * clear it.
+ *
+ * This function is only valid for bridge clients and will return
+ * MOSQ_ERR_INVAL for non-bridge clients.
+ *
+ * Returns:
+ *   MOSQ_ERR_SUCCESS - on success
+ *   MOSQ_ERR_INVAL - if client is NULL, not a bridge client, or username is not valid UTF-8
+ *   MOSQ_ERR_NOMEM - on out of memory
+ *   MOSQ_ERR_NOT_SUPPORTED - if broker was built without bridge support
+ */
+mosq_EXPORT int mosquitto_bridge_set_remote_credentials(struct mosquitto *client, const char *remote_username, const char *remote_password);
+
 
 /* =========================================================================
  *

--- a/src/linker-aix.syms
+++ b/src/linker-aix.syms
@@ -64,6 +64,7 @@ mosquitto_property_read_varint
 mosquitto_pub_topic_check2
 mosquitto_pub_topic_check
 mosquitto_realloc
+mosquitto_bridge_set_remote_credentials
 mosquitto_set_clientid
 mosquitto_set_username
 mosquitto_strdup

--- a/src/linker-macosx.syms
+++ b/src/linker-macosx.syms
@@ -65,6 +65,7 @@ _mosquitto_property_read_varint
 _mosquitto_pub_topic_check
 _mosquitto_pub_topic_check2
 _mosquitto_realloc
+_mosquitto_bridge_set_remote_credentials
 _mosquitto_set_clientid
 _mosquitto_set_username
 _mosquitto_strdup

--- a/src/linker.syms
+++ b/src/linker.syms
@@ -66,6 +66,7 @@
 	mosquitto_pub_topic_check2;
 	mosquitto_pub_topic_check;
 	mosquitto_realloc;
+	mosquitto_bridge_set_remote_credentials;
 	mosquitto_set_clientid;
 	mosquitto_set_username;
 	mosquitto_strdup;

--- a/src/plugin_public.c
+++ b/src/plugin_public.c
@@ -386,6 +386,62 @@ BROKER_EXPORT int mosquitto_set_clientid(struct mosquitto *client, const char *c
 }
 
 
+BROKER_EXPORT int mosquitto_bridge_set_remote_credentials(struct mosquitto *client, const char *remote_username, const char *remote_password)
+{
+#ifdef WITH_BRIDGE
+	char *new_username;
+	char *new_password;
+	char *old_username;
+	char *old_password;
+
+	if(!client || !client->bridge){
+		return MOSQ_ERR_INVAL;
+	}
+
+	if(remote_username){
+		if(mosquitto_validate_utf8(remote_username, (int)strlen(remote_username))){
+			return MOSQ_ERR_MALFORMED_UTF8;
+		}
+		new_username = mosquitto_strdup(remote_username);
+		if(!new_username){
+			return MOSQ_ERR_NOMEM;
+		}
+	}else{
+		new_username = NULL;
+	}
+
+	if(remote_password){
+		new_password = mosquitto_strdup(remote_password);
+		if(!new_password){
+			mosquitto_FREE(new_username);
+			return MOSQ_ERR_NOMEM;
+		}
+	}else{
+		new_password = NULL;
+	}
+
+	old_username = client->bridge->remote_username;
+	old_password = client->bridge->remote_password;
+
+	client->bridge->remote_username = new_username;
+	client->bridge->remote_password = new_password;
+	client->username = new_username;
+	client->password = new_password;
+
+	mosquitto_FREE(old_username);
+	mosquitto_FREE(old_password);
+
+	return MOSQ_ERR_SUCCESS;
+#else
+	UNUSED(client);
+	UNUSED(remote_username);
+	UNUSED(remote_password);
+
+	return MOSQ_ERR_NOT_SUPPORTED;
+#endif
+}
+
+
 /* Check to see whether durable clients still have rights to their subscriptions. */
 static void check_subscription_acls(struct mosquitto *context)
 {


### PR DESCRIPTION
Adds a broker plugin API to set or update bridge remote_username and remote_password dynamically with minimal impact.

https://github.com/eclipse-mosquitto/mosquitto/issues/3676