### PR TITLE
Fix properties list binding and double-close in persist-sqlite migrat…

### DIFF
--- a/plugins/persist-sqlite/migrate_to_persist_sqlite.py
+++ b/plugins/persist-sqlite/migrate_to_persist_sqlite.py
@@ -46,10 +46,12 @@ class SQLite3Persistence:
     def __close_db(self):
         if self.__cursor is not None:
             self.__cursor.close()
+            self.__cursor = None
 
         if self.__conn is not None:
             self.__conn.commit()
             self.__conn.close()
+            self.__conn = None
 
     def __on_error(self):
         self.__close_db()
@@ -249,7 +251,7 @@ class SQLite3Persistence:
                     base_msg["source-port"],
                     base_msg["qos"],
                     base_msg["retain"],
-                    base_msg["properties"] if "properties" in base_msg else None,
+                    json.dumps(base_msg["properties"]) if "properties" in base_msg else None,
                 ),
             )
 


### PR DESCRIPTION
…ion script

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----

Fixes #3698

## Problem

`migrate_to_persist_sqlite.py` crashes during migration with:
```
Error during SQLite3 DB creation. Reason: Error binding parameter 12: type 'list' is not supported
```
followed by a second, confusing exception during cleanup:
```
sqlite3.ProgrammingError: Cannot operate on a closed database.
```

## Root cause

**Primary bug:** In `__add_base_msgs`, `base_msg["properties"]` is passed directly into the sqlite3 parameter tuple, but the `properties` column is declared as `STRING` in the schema. Since `mosquitto_db_dump --json` produces `properties` as a parsed JSON array (via the broker's own `mosquitto_properties_to_json`), Python's `sqlite3` module can't bind a `list` type directly, causing the crash.

**Secondary bug:** `__close_db()` closes the cursor and connection but never clears the references afterward. When the primary error triggers `__on_error()`, `__close_db()` runs once and closes everything. Then `sys.exit(1)` triggers garbage collection, `__del__` calls `__close_db()` a second time, and since `self.__cursor` was never set back to `None`, it tries to close an already-closed cursor, throwing the second exception seen in the original report.

## Fix

1. Serialize `properties` with `json.dumps()` before binding, matching the STRING schema.
2. Set `self.__cursor` and `self.__conn` to `None` after closing in `__close_db()`, so a second cleanup call is a safe no-op instead of operating on a closed database.

## Verification

Traced the JSON shape through both ends of the actual data contract in the C plugin:

- **Write side** (`apps/db_dump/json.c`): `mosquitto_db_dump --json` serializes `properties` via the core `mosquitto_properties_to_json()` function.
- **Read side** (`plugins/persist-sqlite/restore.c`): `json_to_properties()` deserializes that same column using `mosquitto_string_to_property_info()`, expecting an array of `{"identifier": ..., "value": ...}` objects (plus `"name"` for string-pair properties).

Both ends use the same canonical property serialization from the core library, so re-serializing the already-correctly-shaped data with `json.dumps()` round-trips cleanly through `json_to_properties()` on restore.

## Testing

- Reproduced the exact original traceback (both errors) using a standalone script that feeds a synthetic snapshot dump with a properties list into `SQLite3Persistence`.
- Applied the fix and confirmed the same script completes with no errors.
- Queried the resulting `mosquitto.sqlite3` directly and confirmed the `properties` column contains valid JSON that round-trips back to the original structure via `json.loads()`.
- Ran the full test suite via `ctest`. 7 failures observed, all pre-existing and unrelated to this change (which only modifies a standalone Python script, not compiled code):
  - 5 `broker-22-http-api-*` failures: HTTP API support not available locally (`libmicrohttpd` not installed)
  - 1 `broker-01-connect-575314` failure: missing local Python dependency (`psutil`), unrelated to Mosquitto
  - 1 `broker-09-plugin-evt-tick` failure on the first run, passed cleanly on rerun (one-time flake)

## Note

While investigating, I noticed an unrelated bug in the same file: `payloadlen` in `__add_base_msgs` is computed as `len(payload) if "username" in base_msg else 0`, which checks the wrong key (should check `"payload"`, matching how `payload` itself is computed two lines above). Filing this separately rather than folding it into this PR, since it's a distinct issue.
